### PR TITLE
DRT-4938 - removes the strange java security exception bug

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -115,7 +115,7 @@ object Settings {
     "io.spray" %% "spray-json" % sprayVersion,
 
     "joda-time" % "joda-time" % jodaTime,
-    "org.opensaml" % "opensaml" % openSaml,
+    "org.opensaml" % "opensaml" % openSaml excludeAll ExclusionRule("org.bouncycastle"),
     "org.pac4j" % "pac4j-saml" % pac4jSaml,
     "org.apache.commons" % "commons-csv" % csvCommons,
     "org.apache.spark" % "spark-mllib_2.11" % sparkMlLib,


### PR DESCRIPTION
We were getting a stack trace:

> Caused by: java.lang.SecurityException: class "org.bouncycastle.math.ec.ECCurve$AbstractFp"'s signer information does not match signer information of other classes in the same package

We had thought it was due the Birmingham PR, but it was actually down to a library introduced by getting the Gatwick feed.

By excluding `org.bouncycastle` in the `opensaml` library we do not get the stack trace.