### PR TITLE
Lets increase the idle timeout to 90 seconds.

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -180,5 +180,5 @@ feeds {
 }
 spray.can.client {
   request-timeout = 1 minutes
-  idle-timeout    = 30 seconds
+  idle-timeout    = 90 seconds
 }


### PR DESCRIPTION
The idle-timeout is `The time after which an idle connection will be automatically closed.`
By default it is 60 seconds, but currently we have it set to 30 seconds.
We see the following in the logs;
``` 
Failed to fetch LGW arrivals. Re-requesting token. java.util.concurrent.TimeoutException: Futures timed out after [30 seconds]
```

I am unsure if this is related to the idle-timeout; but this is the only value that is 30 seconds. I have set it to 90 seconds so that it is an increase to the default value and if we still see 30 seconds in the logs we will know that there is another timeout we need to increase.

Let us see if by changing this value if we see more flight arrivals coming through in production.
If all else fails - we need to ask the Gatwick guys why we are missing flights. Perhaps we should ask them anyhow as we have followed everything by their partner integration guide.

