### PR TITLE
Gatwick changes

### DIFF
--- a/server/src/main/scala/drt/server/feeds/lgw/AzureSamlAssertion.scala
+++ b/server/src/main/scala/drt/server/feeds/lgw/AzureSamlAssertion.scala
@@ -1,0 +1,79 @@
+package drt.server.feeds.lgw
+
+import java.util.UUID
+import org.joda.time.DateTime
+import org.opensaml.DefaultBootstrap
+import org.opensaml.saml2.core.Assertion
+import org.opensaml.saml2.core.impl._
+import org.opensaml.xml.Configuration
+import org.opensaml.xml.security.SecurityHelper
+import org.opensaml.xml.signature.Signer
+import org.opensaml.xml.signature.impl.SignatureBuilder
+import org.opensaml.xml.util.XMLHelper
+
+case class AzureSamlAssertion(namespace: String, issuer: String, nameId: String) {
+
+  def initialiseOpenSAMLLibraryWithDefaultConfiguration(): Unit = DefaultBootstrap.bootstrap()
+
+  initialiseOpenSAMLLibraryWithDefaultConfiguration()
+
+  def asString(privateKey: Array[Byte], certificate: Array[Byte]): String = {
+    val assertion = createAzureSamlAssertion(privateKey, certificate)
+
+    def marshalledAndSignedMessage = {
+      Configuration.getMarshallerFactory.getMarshaller(assertion).marshall(assertion)
+      Signer.signObject(assertion.getSignature)
+
+      val marshaller = new ResponseMarshaller
+      marshaller.marshall(assertion)
+    }
+
+    XMLHelper.nodeToString(marshalledAndSignedMessage)
+  }
+
+  def createAzureSamlAssertion(privateKey: Array[Byte], certificate: Array[Byte]): Assertion = {
+    val builder: AssertionBuilder = new AssertionBuilder()
+    val assertion = builder.buildObject()
+    assertion.setID("_" + UUID.randomUUID().toString)
+    assertion.setIssueInstant(new DateTime())
+
+    val nameIdObj = new NameIDBuilder().buildObject
+    nameIdObj.setValue(nameId)
+
+    val subject = new SubjectBuilder().buildObject
+    subject.setNameID(nameIdObj)
+    assertion.setSubject(subject)
+
+    val subjectConfirmation = new SubjectConfirmationBuilder().buildObject
+    subjectConfirmation.setMethod("urn:oasis:names:tc:SAML:2.0:cm:bearer")
+    subject.getSubjectConfirmations.add(subjectConfirmation)
+
+    val audience = new AudienceBuilder().buildObject
+    audience.setAudienceURI("https://" + namespace + "-sb.accesscontrol.windows.net")
+
+    val audienceRestriction = new AudienceRestrictionBuilder().buildObject
+    audienceRestriction.getAudiences.add(audience)
+
+    val conditions = new ConditionsBuilder().buildObject
+    conditions.getConditions.add(audienceRestriction)
+    assertion.setConditions(conditions)
+
+    val issuerObj = new IssuerBuilder().buildObject
+    issuerObj.setValue(issuer)
+    assertion.setIssuer(issuerObj)
+
+    signAssertion(assertion, privateKey, certificate)
+
+    assertion
+  }
+
+  def signAssertion(assertion: Assertion, privateKey: Array[Byte], certificate: Array[Byte]) {
+    val signature = new SignatureBuilder().buildObject
+    val signingCredential = CredentialsFactory.getSigningCredential(privateKey, certificate)
+    signature.setSigningCredential(signingCredential)
+    val secConfig = Configuration.getGlobalSecurityConfiguration
+    SecurityHelper.prepareSignatureParams(signature, signingCredential, secConfig, null)
+    assertion.setSignature(signature)
+  }
+
+}

--- a/server/src/main/scala/drt/server/feeds/lgw/LGWFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/lgw/LGWFeed.scala
@@ -1,43 +1,28 @@
 package drt.server.feeds.lgw
 
-import java.io.{ByteArrayInputStream, FileInputStream}
+import java.io.FileInputStream
 import java.nio.file.{FileSystems, Path}
-import java.util.UUID
 import akka.NotUsed
 import akka.actor.{ActorSystem, Cancellable}
 import akka.stream.scaladsl.Source
-import akka.stream.{ActorAttributes, ActorMaterializer, Supervision, ThrottleMode}
+import akka.stream.{ActorAttributes, ActorMaterializer, Supervision}
 import drt.http.ProdSendAndReceive
 import drt.server.feeds.lgw.LGWParserProtocol._
 import drt.shared.Arrival
 import org.apache.commons.io.IOUtils
-import org.joda.time.DateTime
-import org.opensaml.DefaultBootstrap
-import org.opensaml.saml2.core.Assertion
-import org.opensaml.saml2.core.impl._
-import org.opensaml.xml.Configuration
-import org.opensaml.xml.security.SecurityHelper
-import org.opensaml.xml.signature.Signer
-import org.opensaml.xml.signature.impl.SignatureBuilder
-import org.opensaml.xml.util.XMLHelper
 import org.slf4j.{Logger, LoggerFactory}
 import spray.client.pipelining
 import spray.client.pipelining.{Delete, Post, addHeader, _}
-import spray.http.{FormData, HttpRequest, HttpResponse, MediaTypes}
 import spray.http.HttpHeaders.Accept
+import spray.http._
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
-import scala.xml.Node
 
 case class LGWFeed(certPath: String, privateCertPath: String, namespace: String, issuer: String, nameId: String, implicit val system: ActorSystem) extends ProdSendAndReceive {
   val log: Logger = LoggerFactory.getLogger(getClass)
-
-  def initialiseOpenSAMLLibraryWithDefaultConfiguration(): Unit = DefaultBootstrap.bootstrap()
-
-  initialiseOpenSAMLLibraryWithDefaultConfiguration()
 
   val privateCert: Path = FileSystems.getDefault.getPath(privateCertPath)
   val certificateURI: Path = FileSystems.getDefault.getPath(certPath)
@@ -55,7 +40,8 @@ case class LGWFeed(certPath: String, privateCertPath: String, namespace: String,
 
   val privateKey: Array[Byte] = IOUtils.toByteArray(pkInputStream)
   val certificate: Array[Byte] = IOUtils.toByteArray(certInputStream)
-  val assertion: String = createAzureSamlAssertionAsString(privateKey, certificate)
+
+  lazy val assertion: String = AzureSamlAssertion(namespace = namespace, issuer = issuer, nameId = nameId).asString(privateKey, certificate)
 
   val tokenScope = s"http://$namespace.servicebus.windows.net/partners/$issuer/to"
   val tokenPostUri = s"https://$namespace-sb.accesscontrol.windows.net/v2/OAuth2-13"
@@ -87,58 +73,20 @@ case class LGWFeed(certPath: String, privateCertPath: String, namespace: String,
   }
 
   def requestArrivals(token: GatwickAzureToken): Future[List[Arrival]] = {
-    val restApiTimeoutInSeconds = 30
+    val restApiTimeoutInSeconds = 25
     val serviceBusUri = s"https://$namespace.servicebus.windows.net/partners/$issuer/to/messages/head?timeout=$restApiTimeoutInSeconds"
     val wrapHeader = "WRAP access_token=\"" + token.access_token + "\""
 
     val toArrivals: HttpResponse => List[(Arrival, Option[String])] = { r =>
-      val locationOption: Option[String] = r.headers.find(h => h.name == "Location").map(_.value)
-      log.debug(s"LGW response status code is ${r.status.intValue}")
-      val is = new ByteArrayInputStream(r.entity.data.toByteArray)
-      val xmlTry = Try(scala.xml.XML.load(is)).recoverWith {
-        case e: Throwable => log.error(s"Cannot load Gatwick XML from the response ${r.status}", e); null
+
+      r.status match {
+        case StatusCodes.OK | StatusCodes.Created =>
+          val locationOption: Option[String] = r.headers.find(h => h.name == "Location").map(_.value)
+          ResponseToArrivals(r.entity.data.toByteArray, locationOption).getArrivals
+        case status =>
+          log.info(s"LGW response status is $status")
+          List.empty[(Arrival, Option[String])]
       }
-      IOUtils.closeQuietly(is)
-      val xmlSeq = xmlTry.map(scala.xml.Utility.trimProper(_)).get
-      lazy val result = xmlSeq map nodeToArrival
-
-      def nodeToArrival = (n: Node) => {
-
-        val terminal = (n \\ "AirportResources" \ "Resource").find(n => (n \ "@DepartureOrArrival" text).equals("Arrival")).map(n => n \\ "AircraftTerminal" text).getOrElse("")
-        val mappedTerminal = terminal match {
-          case "1" => "S"
-          case "2" => "N"
-          case _ => ""
-        }
-        val arrival = new Arrival(
-          Operator = (n \ "AirlineIATA") text,
-          Status = parseStatus(n),
-          EstDT = parseDateTime(n, "TDN", "EST").getOrElse(""),
-          ActDT = parseDateTime(n, "TDN", "ACT").getOrElse(""),
-          EstChoxDT = parseDateTime(n, "ONB", "EST").getOrElse(""),
-          ActChoxDT = parseDateTime(n, "ONB", "ACT").getOrElse(""),
-          Gate = (n \\ "PassengerGate").headOption.map(n => n text).getOrElse(""),
-          Stand = (n \\ "ArrivalStand").headOption.map(n => n text).getOrElse(""),
-          MaxPax = (n \\ "SeatCapacity").headOption.map(n => (n text).toInt).getOrElse(0),
-          ActPax = parsePaxCount(n, "70A").getOrElse(0),
-          TranPax = parsePaxCount(n, "TIP").getOrElse(0),
-          RunwayID = parseRunwayId(n).getOrElse(""),
-          BaggageReclaimId = Try(n \\ "FIDSBagggeHallActive" text).getOrElse(""),
-          FlightID = 0,
-          AirportID = "LGW",
-          Terminal = mappedTerminal,
-          rawICAO = (n \\ "AirlineICAO" text) + parseFlightNumber(n),
-          rawIATA = (n \\ "AirlineIATA" text) + parseFlightNumber(n),
-          Origin = parseOrigin(n),
-          SchDT = (((n \ "FlightLeg").head \ "LegData").head \\ "OperationTime").find(n => (n \ "@OperationQualifier" text).equals("ONB") && (n \ "@TimeType" text).equals("SCT")).map(n => n text).getOrElse(""),
-          Scheduled = (((n \ "FlightLeg").head \ "LegData").head \\ "OperationTime").find(n => (n \ "@OperationQualifier" text).equals("ONB") && (n \ "@TimeType" text).equals("SCT")).map(n => services.SDate.parseString(n text).millisSinceEpoch).getOrElse(0),
-          PcpTime = 0,
-          LastKnownPax = None)
-        log.info(s"parsed arrival: $arrival")
-        (arrival, locationOption)
-      }
-
-      result.toList
     }
 
     val processDeleteIfApplicable: List[(Arrival, Option[String])] => List[Arrival] = { arrivalsAndLocationList =>
@@ -164,6 +112,8 @@ case class LGWFeed(certPath: String, privateCertPath: String, namespace: String,
         ~> processDeleteIfApplicable
       )
 
+    println(wrapHeader)
+    println(serviceBusUri)
     resultPipeline(Post(serviceBusUri))
       .recoverWith {
         case t: Throwable =>
@@ -172,89 +122,6 @@ case class LGWFeed(certPath: String, privateCertPath: String, namespace: String,
       }
   }
 
-  private def parseFlightNumber(n: Node) = {
-    ((n \ "FlightLeg").head \ "LegIdentifier").head \ "FlightNumber" text
-  }
-
-  def parseStatus(n: Node): String = {
-    ((n \ "FlightLeg").head \ "LegData").head \ "OperationalStatus" text
-  }
-
-  def parseOrigin(n: Node): String = {
-    ((n \ "FlightLeg").head \ "LegIdentifier").head \ "DepartureAirport" text
-  }
-
-  def parseRunwayId(n: Node): Option[String] = {
-    (n \\ "AirportResources" \ "Resource").find(n => (n \ "@DepartureOrArrival" text).equals("Arrival")).map(n => n \\ "Runway" text)
-  }
-
-  def parsePaxCount(n: Node, qualifier: String): Option[Int] = {
-    (n \\ "PaxCount").find(n => (n \ "@Qualifier" text).equals(qualifier) && (n \ "@Class").isEmpty).map(n => (n text).toInt)
-  }
-
-  def parseDateTime(n: Node, operationQualifier: String, timeType: String): Option[String] = {
-    (((n \ "FlightLeg").head \ "LegData").head \\ "OperationTime").find(n => (n \ "@OperationQualifier" text).equals("ONB") && (n \ "@TimeType" text).equals("SCT")).map(n => n text)
-    (((n \ "FlightLeg").head \ "LegData").head \\ "OperationTime").find(n => (n \ "@OperationQualifier" text).equals(operationQualifier) && (n \ "@TimeType" text).equals(timeType)).map(n => n text)
-  }
-
-  def createAzureSamlAssertionAsString(privateKey: Array[Byte], certificate: Array[Byte]): String = {
-    val assertion = createAzureSamlAssertion(privateKey, certificate)
-
-    def marshalledAndSignedMessage = {
-      Configuration.getMarshallerFactory.getMarshaller(assertion).marshall(assertion)
-      Signer.signObject(assertion.getSignature)
-
-      val marshaller = new ResponseMarshaller
-      marshaller.marshall(assertion)
-    }
-
-    XMLHelper.nodeToString(marshalledAndSignedMessage)
-  }
-
-  def createAzureSamlAssertion(privateKey: Array[Byte], certificate: Array[Byte]): Assertion = {
-    val builder: AssertionBuilder = new AssertionBuilder()
-    val assertion = builder.buildObject()
-    assertion.setID("_" + UUID.randomUUID().toString)
-    assertion.setIssueInstant(new DateTime())
-
-    val nameIdObj = new NameIDBuilder().buildObject
-    nameIdObj.setValue(nameId)
-
-    val subject = new SubjectBuilder().buildObject
-    subject.setNameID(nameIdObj)
-    assertion.setSubject(subject)
-
-    val subjectConfirmation = new SubjectConfirmationBuilder().buildObject
-    subjectConfirmation.setMethod("urn:oasis:names:tc:SAML:2.0:cm:bearer")
-    subject.getSubjectConfirmations.add(subjectConfirmation)
-
-    val audience = new AudienceBuilder().buildObject
-    audience.setAudienceURI("https://" + namespace + "-sb.accesscontrol.windows.net")
-
-    val audienceRestriction = new AudienceRestrictionBuilder().buildObject
-    audienceRestriction.getAudiences.add(audience)
-
-    val conditions = new ConditionsBuilder().buildObject
-    conditions.getConditions.add(audienceRestriction)
-    assertion.setConditions(conditions)
-
-    val issuerObj = new IssuerBuilder().buildObject
-    issuerObj.setValue(issuer)
-    assertion.setIssuer(issuerObj)
-
-    signAssertion(assertion, privateKey, certificate)
-
-    assertion
-  }
-
-  def signAssertion(assertion: Assertion, privateKey: Array[Byte], certificate: Array[Byte]) {
-    val signature = new SignatureBuilder().buildObject
-    val signingCredential = CredentialsFactory.getSigningCredential(privateKey, certificate)
-    signature.setSigningCredential(signingCredential)
-    val secConfig = Configuration.getGlobalSecurityConfiguration
-    SecurityHelper.prepareSignatureParams(signature, signingCredential, secConfig, null)
-    assertion.setSignature(signature)
-  }
 }
 
 object LGWFeed {

--- a/server/src/main/scala/drt/server/feeds/lgw/LGWFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/lgw/LGWFeed.scala
@@ -112,8 +112,6 @@ case class LGWFeed(certPath: String, privateCertPath: String, namespace: String,
         ~> processDeleteIfApplicable
       )
 
-    println(wrapHeader)
-    println(serviceBusUri)
     resultPipeline(Post(serviceBusUri))
       .recoverWith {
         case t: Throwable =>

--- a/server/src/main/scala/drt/server/feeds/lgw/ResponseToArrivals.scala
+++ b/server/src/main/scala/drt/server/feeds/lgw/ResponseToArrivals.scala
@@ -1,0 +1,96 @@
+package drt.server.feeds.lgw
+
+import java.io.ByteArrayInputStream
+import drt.shared.Arrival
+import org.apache.commons.io.IOUtils
+import org.slf4j.{Logger, LoggerFactory}
+import scala.util.{Failure, Success, Try}
+import scala.xml.Node
+
+case class ResponseToArrivals(data: Array[Byte], locationOption: Option[String] ) {
+  val log: Logger = LoggerFactory.getLogger(getClass)
+
+  def getArrivals: List[(Arrival, Option[String])] = {
+    val is = new ByteArrayInputStream(data)
+    val xmlTry = Try(scala.xml.XML.load(is)).recoverWith {
+      case e: Throwable => log.error(s"Cannot load Gatwick XML from the response ${data.toString}", e); null
+    }
+    IOUtils.closeQuietly(is)
+    Try {
+      val xmlSeq = xmlTry.map(scala.xml.Utility.trimProper(_)).get
+      lazy val result = xmlSeq map nodeToArrival
+      result.toList
+    } match {
+      case Success(arrivalsAndLocation) => arrivalsAndLocation
+      case Failure(t) =>
+        log.error(s"Failed to get an Arrival from the Gatwick XML. ${t.getMessage}. $xmlTry.")
+        throw t
+    }
+  }
+
+  def nodeToArrival: Node => (Arrival, Option[String]) = (n: Node) => {
+
+    val arrival = new Arrival(
+      Operator = (n \ "AirlineIATA") text,
+      Status = parseStatus(n),
+      EstDT = parseDateTime(n, "TDN", "EST").getOrElse(""),
+      ActDT = parseDateTime(n, "TDN", "ACT").getOrElse(""),
+      EstChoxDT = parseDateTime(n, "ONB", "EST").getOrElse(""),
+      ActChoxDT = parseDateTime(n, "ONB", "ACT").getOrElse(""),
+      Gate = (n \\ "PassengerGate").headOption.map(n => n text).getOrElse(""),
+      Stand = (n \\ "ArrivalStand").headOption.map(n => n text).getOrElse(""),
+      MaxPax = (n \\ "SeatCapacity").headOption.map(n => (n text).toInt).getOrElse(0),
+      ActPax = parsePaxCount(n, "70A").getOrElse(0),
+      TranPax = parsePaxCount(n, "TIP").getOrElse(0),
+      RunwayID = parseRunwayId(n).getOrElse(""),
+      BaggageReclaimId = Try(n \\ "FIDSBagggeHallActive" text).getOrElse(""),
+      FlightID = 0,
+      AirportID = "LGW",
+      Terminal = parseTerminal(n),
+      rawICAO = (n \\ "AirlineICAO" text) + parseFlightNumber(n),
+      rawIATA = (n \\ "AirlineIATA" text) + parseFlightNumber(n),
+      Origin = parseOrigin(n),
+      SchDT = (((n \ "FlightLeg").head \ "LegData").head \\ "OperationTime").find(n => (n \ "@OperationQualifier" text).equals("ONB") && (n \ "@TimeType" text).equals("SCT")).map(n => n text).getOrElse(""),
+      Scheduled = (((n \ "FlightLeg").head \ "LegData").head \\ "OperationTime").find(n => (n \ "@OperationQualifier" text).equals("ONB") && (n \ "@TimeType" text).equals("SCT")).map(n => services.SDate.parseString(n text).millisSinceEpoch).getOrElse(0),
+      PcpTime = 0,
+      LastKnownPax = None)
+    log.info(s"parsed arrival: $arrival")
+    (arrival, locationOption)
+  }
+
+  private def parseTerminal(n: Node): String = {
+    val terminal = (n \\ "AirportResources" \ "Resource").find(n => (n \ "@DepartureOrArrival" text).equals("Arrival")).map(n => n \\ "AircraftTerminal" text).getOrElse("")
+    val mappedTerminal = terminal match {
+      case "1" => "S"
+      case "2" => "N"
+      case _ => ""
+    }
+    mappedTerminal
+  }
+
+  private def parseFlightNumber(n: Node) = {
+    ((n \ "FlightLeg").head \ "LegIdentifier").head \ "FlightNumber" text
+  }
+
+  def parseStatus(n: Node): String = {
+    ((n \ "FlightLeg").head \ "LegData").head \ "OperationalStatus" text
+  }
+
+  def parseOrigin(n: Node): String = {
+    ((n \ "FlightLeg").head \ "LegIdentifier").head \ "DepartureAirport" text
+  }
+
+  def parseRunwayId(n: Node): Option[String] = {
+    (n \\ "AirportResources" \ "Resource").find(n => (n \ "@DepartureOrArrival" text).equals("Arrival")).map(n => n \\ "Runway" text)
+  }
+
+  def parsePaxCount(n: Node, qualifier: String): Option[Int] = {
+    (n \\ "PaxCount").find(n => (n \ "@Qualifier" text).equals(qualifier) && (n \ "@Class").isEmpty).map(n => (n text).toInt)
+  }
+
+  def parseDateTime(n: Node, operationQualifier: String, timeType: String): Option[String] = {
+    (((n \ "FlightLeg").head \ "LegData").head \\ "OperationTime").find(n => (n \ "@OperationQualifier" text).equals("ONB") && (n \ "@TimeType" text).equals("SCT")).map(n => n text)
+    (((n \ "FlightLeg").head \ "LegData").head \\ "OperationTime").find(n => (n \ "@OperationQualifier" text).equals(operationQualifier) && (n \ "@TimeType" text).equals(timeType)).map(n => n text)
+  }
+
+}

--- a/server/src/test/scala/feeds/LGWFeedSpec.scala
+++ b/server/src/test/scala/feeds/LGWFeedSpec.scala
@@ -8,6 +8,8 @@ import drt.server.feeds.lgw.{GatwickAzureToken, LGWFeed}
 import drt.shared.Arrival
 import org.specs2.mock.Mockito
 import org.specs2.mutable.SpecificationLike
+import org.specs2.specification.Scope
+import spray.http.HttpHeaders.RawHeader
 import spray.http._
 import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -26,7 +28,7 @@ class LGWFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.e
     "When I ask for some arrivals " +
     "Then I should get some arrivals" >> {
 
-    skipped("exploratory test for the LGW live feed")
+  skipped("exploratory test for the LGW live feed")
 
     val certPath = ""
     val privateCertPath = ""
@@ -55,31 +57,37 @@ class LGWFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.e
     arrivals mustNotEqual Seq()
   }.pendingUntilFixed("This is not a test")
 
-  "Can convert an XML into an Arrival" in {
-    val certPath = getClass.getClassLoader.getResource("lgw.xml").getPath
-    val privateCertPath = certPath
+  trait Context extends Scope {
+    val certPath: String = getClass.getClassLoader.getResource("lgw.xml").getPath
+    val privateCertPath: String = certPath
     val azureServiceNamespace = "Gat"
     val issuer = "issuer"
     val nameId = "nameId"
+  }
 
-    val mockResponse = mock[HttpResponse]
-    val xml = Source.fromInputStream(getClass.getClassLoader.getResourceAsStream("lgw.xml")).mkString
-    val body = HttpEntity(MediaTypes.`application/xml`, xml.getBytes)
+  "Can convert an XML into an Arrival" in new Context {
+    val mockResponse: HttpResponse = mock[HttpResponse]
+    val xml: String = Source.fromInputStream(getClass.getClassLoader.getResourceAsStream("lgw.xml")).mkString
+    val body: HttpEntity = HttpEntity(MediaTypes.`application/xml`, xml.getBytes)
     mockResponse.entity returns body
     mockResponse.status returns StatusCode.int2StatusCode(200)
-    mockResponse.headers returns List.empty[HttpHeader]
+    mockResponse.headers returns List(RawHeader("Location", "blah.example.com/delete/messageId"))
+    var deleteCalled = false
 
-    val feed = new LGWFeed(certPath, privateCertPath, azureServiceNamespace, issuer, nameId, system = system) {
-      override def sendAndReceive = (req: HttpRequest) => Promise.successful(mockResponse).future
-
-      override def createAzureSamlAssertionAsString(privateKey: Array[Byte], certificate: Array[Byte]) = "assertion"
+    val feed: LGWFeed = new LGWFeed(certPath, privateCertPath, azureServiceNamespace, issuer, nameId, system = system) {
+      override def sendAndReceive: HttpRequest => Future[HttpResponse] = (req: HttpRequest) => {
+        deleteCalled = req.method.equals(HttpMethods.DELETE)
+        Promise.successful(mockResponse).future
+      }
+      override lazy val assertion = "assertion"
     }
 
-    val futureArrivals = feed.requestArrivals(GatwickAzureToken("type", "access_token", "0", "scope"))
-    val arrivals = Await.result(futureArrivals, Duration(10, TimeUnit.SECONDS))
+    val futureArrivals: Future[List[Arrival]] = feed.requestArrivals(GatwickAzureToken("type", "access_token", "0", "scope"))
+    val arrivals: List[Arrival] = Await.result(futureArrivals, Duration(10, TimeUnit.SECONDS))
 
     arrivals.size mustEqual 1
-    arrivals.head mustEqual new Arrival("",
+    arrivals.head mustEqual new Arrival(
+      Operator = "",
       Status = "LAN",
       EstDT = "2018-03-22T15:50:00Z",
       ActDT = "2018-03-22T15:48:00Z",
@@ -94,7 +102,48 @@ class LGWFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.e
       BaggageReclaimId = "1",
       FlightID = 0,
       AirportID = "LGW",
-      Terminal = "S", "NAX1314", "DY1314", "BGO", "2018-03-22T10:15:00Z", 1521713700000L, 0, None)
+      Terminal = "S", rawICAO = "NAX1314", rawIATA = "DY1314", Origin = "BGO", SchDT = "2018-03-22T10:15:00Z",
+      Scheduled = 1521713700000L, PcpTime = 0, LastKnownPax = None)
 
+    deleteCalled must beTrue
+  }
+
+  "A response of 204 does not return an Arrival" in new Context {
+    val mockResponse: HttpResponse = mock[HttpResponse]
+    mockResponse.headers returns List.empty[HttpHeader]
+    mockResponse.status returns StatusCode.int2StatusCode(204)
+    var deleteCalled = false
+
+    val feed: LGWFeed = new LGWFeed(certPath, privateCertPath, azureServiceNamespace, issuer, nameId, system = system) {
+      override def sendAndReceive: HttpRequest => Future[HttpResponse] = (req: HttpRequest) => {
+        deleteCalled = req.method.equals(HttpMethods.DELETE)
+        Promise.successful(mockResponse).future
+      }
+      override lazy val assertion: String = "assertion"
+    }
+    val futureArrivals: Future[List[Arrival]] = feed.requestArrivals(GatwickAzureToken("type", "access_token", "0", "scope"))
+    val arrivals: List[Arrival] = Await.result(futureArrivals, Duration(10, TimeUnit.SECONDS))
+    arrivals.size mustEqual 0
+    deleteCalled must beFalse
+  }
+
+  "will return an empty Arrival when given dodgy XML" in new Context {
+    val mockResponse: HttpResponse = mock[HttpResponse]
+    val body: HttpEntity = HttpEntity(MediaTypes.`application/xml`, "<ns0:hello><title>This XML is dodgy</title></ns0:hello>".getBytes)
+    mockResponse.entity returns body
+    mockResponse.status returns StatusCode.int2StatusCode(200)
+    mockResponse.headers returns List(RawHeader("Location", "blah.example.com/delete/messageId"))
+    var deleteCalled = false
+    val feed: LGWFeed = new LGWFeed(certPath, privateCertPath, azureServiceNamespace, issuer, nameId, system = system) {
+      override def sendAndReceive: HttpRequest => Future[HttpResponse] = (req: HttpRequest) => {
+        deleteCalled = req.method.equals(HttpMethods.DELETE)
+        Promise.successful(mockResponse).future
+      }
+      override lazy val assertion = "assertion"
+    }
+
+    val futureArrivals: Future[List[Arrival]] = feed.requestArrivals(GatwickAzureToken("type", "access_token", "0", "scope"))
+    val arrivals: List[Arrival] = Await.result(futureArrivals, Duration(10, TimeUnit.SECONDS))
+    arrivals.size mustEqual 0
   }
 }


### PR DESCRIPTION
- Moved all the XML conversion to its own class and hardened it.
- Moved all the crazy opensaml stuff to it's own class.
- They return us not just 200 - but 201 and 204 status code. We need to cater for all these http status codes.
- They timeout in their url is regarding when they time us out to look for the head of arrivals in their message queue. I've shortened it to 25 seconds.
