### PR TITLE
Birmingham Forecast Scheduled Time is off by one hour from UTC.

### DIFF
--- a/server/src/main/scala/drt/server/feeds/bhx/BHXArrivals.scala
+++ b/server/src/main/scala/drt/server/feeds/bhx/BHXArrivals.scala
@@ -21,6 +21,11 @@ sealed trait BHXArrivals {
     }
   }
 
+  def convertToUTCPlusOneHour(feedDate: XMLGregorianCalendar): String = {
+    val utcDatePlusOneHour = new DateTime(feedDate.toGregorianCalendar.getTimeInMillis, DateTimeZone.UTC).plusHours(1)
+    utcDatePlusOneHour.toString(ISODateTimeFormat.dateTime)
+  }
+
 }
 
 trait BHXLiveArrivals extends BHXArrivals {
@@ -55,7 +60,7 @@ trait BHXForecastArrivals extends BHXArrivals {
 
   def toForecastArrival(flightRecord: ScheduledFlightRecord) : Arrival =
     new Arrival(Operator = "",
-      Status = "Scheduled",
+      Status = "Port Forecast",
       EstDT = "",
       ActDT = "",
       EstChoxDT = "",
@@ -73,8 +78,8 @@ trait BHXForecastArrivals extends BHXArrivals {
       rawICAO = flightRecord.getFlightNumber,
       rawIATA = flightRecord.getFlightNumber,
       Origin = flightRecord.getOrigin,
-      SchDT= convertToUTC(flightRecord.getScheduledTime).getOrElse(""),
-      Scheduled = convertToUTC(flightRecord.getScheduledTime).map(SDate(_).millisSinceEpoch).getOrElse(0),
+      SchDT= convertToUTCPlusOneHour(flightRecord.getScheduledTime),
+      Scheduled = SDate(convertToUTCPlusOneHour(flightRecord.getScheduledTime)).millisSinceEpoch,
       PcpTime = 0,
       None)
 }

--- a/server/src/test/scala/feeds/BHXFeedSpec.scala
+++ b/server/src/test/scala/feeds/BHXFeedSpec.scala
@@ -125,7 +125,7 @@ class BHXFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.p
       arrivals.size mustEqual 1
       arrivals.head mustEqual new Arrival(
         Operator = "",
-        Status = "Scheduled",
+        Status = "Port Forecast",
         EstDT = "",
         ActDT = "",
         EstChoxDT = "",
@@ -143,8 +143,8 @@ class BHXFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.p
         rawICAO = "AF1164",
         rawIATA = "AF1164",
         Origin = "CPH",
-        SchDT = "2012-06-02T06:46:53.123Z",
-        Scheduled = 1338619613123L,
+        SchDT = "2012-06-02T07:46:53.123Z", // BHX Forecast is incorrect. It should be 2012-06-02T06:46:53.123Z
+        Scheduled = 1338623213123L, // BHX Forecast is incorrect. This should be 1338619613123L
         PcpTime = 0,
         LastKnownPax = None)
     }


### PR DESCRIPTION
I feel very sorry for creating this PR. Feel free to not merge this, I think we should get Birmingham to fix their forecast times.

If we assume their giving us local times the scheduled time is behind by two hours.

The Flight Forecast app assumes it is UTC as we do - the trouble is that it's behind by one hour.

This PR is created to correct date times that seem to be one hour behind UTC for the forecast scheduled time. It would be better to call the people who create this feed and tell them to correct it.