### PR TITLE
[DRT-5099] - Distributed desks evenly when more staff are available.

### DIFF
--- a/server/src/main/scala/services/graphstages/SimulationGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/SimulationGraphStage.scala
@@ -341,6 +341,21 @@ class SimulationGraphStage(name: String = "",
 
     var deploymentCache: Map[Int, Seq[(String, Int)]] = Map()
 
+    @scala.annotation.tailrec
+    def addOneDeskToQueueAtIndex(deployments : List[(String, Int, Int)], index: Int, numberOfQueues: Int, staffAvailable: Int): List[(String, Int, Int)] = {
+      val safeIndex = if (index > numberOfQueues - 1) 0 else index
+      val deployedStaff = deployments.map(_._2).sum
+      val maxStaff = deployments.map(_._3).sum
+      val freeStaff = staffAvailable - deployedStaff
+
+      if (deployedStaff != maxStaff && freeStaff > 0) {
+        val (queue, dr, maxStaff) = deployments(safeIndex)
+        val newDeployments = if (dr < maxStaff) deployments.updated(safeIndex, Tuple3(queue, dr + 1, maxStaff)) else deployments
+        addOneDeskToQueueAtIndex(newDeployments, safeIndex + 1, numberOfQueues, staffAvailable)
+      } else {
+        deployments
+      }
+    }
     def queueRecsToDeployments(round: Double => Int)
                               (queueRecs: Seq[(String, Double)], staffAvailable: Int, minMaxDesks: Map[String, (Int, Int)]): Seq[(String, Int)] = {
       val key = (queueRecs, staffAvailable, minMaxDesks).hashCode()
@@ -352,22 +367,22 @@ class SimulationGraphStage(name: String = "",
 
           val totalStaffRec = queueRecsCorrected.map(_._2).sum
 
-          val deployments = queueRecsCorrected.foldLeft(List[(String, Int)]()) {
+          val deployments = queueRecsCorrected.foldLeft(List[(String, Int, Int)]()) {
             case (agg, (queue, deskRec)) if agg.length < queueRecsCorrected.length - 1 =>
               val ideal = round(staffAvailable * (deskRec.toDouble / totalStaffRec))
               val totalRecommended = agg.map(_._2).sum
-              val dr = deploymentWithinBounds(minMaxDesks.getOrElse(queue, (0, 10))._1, minMaxDesks.getOrElse(queue, (0, 10))._2, ideal, staffAvailable - totalRecommended)
-              agg :+ Tuple2(queue, dr)
+              val maxStaff = minMaxDesks.getOrElse(queue, (0, 10))._2
+              val dr = deploymentWithinBounds(minMaxDesks.getOrElse(queue, (0, 10))._1, maxStaff, ideal, staffAvailable - totalRecommended)
+              agg :+ Tuple3(queue, dr, maxStaff)
             case (agg, (queue, _)) =>
               val totalRecommended = agg.map(_._2).sum
               val ideal = staffAvailable - totalRecommended
-              val dr = deploymentWithinBounds(minMaxDesks.getOrElse(queue, (0, 10))._1, minMaxDesks.getOrElse(queue, (0, 10))._2, ideal, staffAvailable - totalRecommended)
-              agg :+ Tuple2(queue, dr)
+              val maxStaff = minMaxDesks.getOrElse(queue, (0, 10))._2
+              val dr = deploymentWithinBounds(minMaxDesks.getOrElse(queue, (0, 10))._1, maxStaff, ideal, staffAvailable - totalRecommended)
+              agg :+ Tuple3(queue, dr, maxStaff)
           }
-
-          deploymentCache = deploymentCache.updated(key, deployments)
-
-          deployments
+          val newDeployments = addOneDeskToQueueAtIndex(deployments, index=0, queueRecsCorrected.length, staffAvailable)
+          newDeployments.map(tuple3 => Tuple2(tuple3._1, tuple3._2))
       }
     }
 


### PR DESCRIPTION
Jira: https://jira.digital.homeoffice.gov.uk/browse/DRT-5099

When there are extra staff on duty in a time period, distribute them evenly amongst the queues.
