### PR TITLE
DRT-5128 - Ema desk and queues page fix

### DIFF
--- a/client/src/main/scala/drt/client/components/TerminalDesksAndQueues.scala
+++ b/client/src/main/scala/drt/client/components/TerminalDesksAndQueues.scala
@@ -43,7 +43,7 @@ object TerminalDesksAndQueuesRow {
 
   val component = ScalaComponent.builder[Props]("TerminalDesksAndQueuesRow")
     .render_P((props) => {
-      val crunchMinutesByQueue = props.queueMinutes.map(qm => Tuple2(qm.queueName, qm)).toMap
+      val crunchMinutesByQueue = props.queueMinutes.filter(qm=> props.airportConfig.queues(props.terminalName).contains(qm.queueName)).map(qm => Tuple2(qm.queueName, qm)).toMap
       val queueTds = crunchMinutesByQueue.flatMap {
         case (qn, cm) =>
           val paxLoadTd = <.td(^.className := queueColour(qn), s"${Math.round(cm.paxLoad)}")


### PR DESCRIPTION
Ema desk and queues page fix.

The forecast data was in preprod before we renamed the queue from eeaDesk to desks.

This fix will filter out the data that's not required before we show the page.