### PR TITLE
[DRT-5129] - Max content length

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -4,7 +4,7 @@
 application.cdn = ""
 application.cdn = ${?APPLICATION_CDN}
 
-parsers.text.maxLength = 100m
+play.http.parser.maxMemoryBuffer = 100m
 
 portcode = "xxx"
 portcode = ${?PORT_CODE}


### PR DESCRIPTION
Currently we get the following warning in the log files

2018-06-13 14:12:44,386 [main] WARN  application  - application.conf @ file:/usr/share/drt-v2/stn/drt-931/conf/application.conf: 7: parsers.text.maxLength is deprecated, use play.http.parser.maxMemoryBuffer instead

In the application.conf file we should use `play.http.parser.maxMemoryBuffer` instead of `parsers.text.maxLength`.

https://www.playframework.com/documentation/2.4.x/ScalaBodyParsers#Max-content-length