### PR TITLE
[DRT-5132] - upgrade the scala.js plugin to 0.6.23

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,5 +1,6 @@
 import sbt._
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 /**
   * Application settings. Configure the build for your application here.
@@ -23,14 +24,14 @@ object Settings {
   /** Declare global dependency versions here to avoid mismatches in multi part dependencies */
   object versions {
     val scala = "2.11.8"
-    val scalaDom = "0.9.5"
+    val scalaDom = "0.9.6"
     val scalajsReact = "1.1.1"
     val scalajsReactComponents = "0.8.0"
     val scalaJsScripts = "1.0.0"
-    val scalaCSS = "0.5.3"
+    val scalaCSS = "0.5.5"
     val autowire = "0.2.6"
     val booPickle = "1.2.6"
-    val diode = "1.1.2"
+    val diode = "1.1.3"
     val uTest = "0.4.7"
 
     val akka = "2.4.16"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.6")
 
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0-pre1"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.19")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.23")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-web-scalajs-bundler" % "0.13.0")
 


### PR DESCRIPTION
There is an `0.6.23` update to scala.js, we are currently using `0.6.19`.

https://www.scala-js.org/news/2018/05/22/announcing-scalajs-0.6.23/

Let us upgrade!


 