### PR TITLE
[DRT-5134] - Playframework upgrade to 2.6.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,6 +84,7 @@ lazy val server = (project in file("server"))
   javaOptions in Test += "-Duser.timezone=UTC",
   javaOptions in Runtime += "-Duser.timezone=UTC",
   libraryDependencies ++= Settings.jvmDependencies.value,
+  libraryDependencies += guice,
   dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % "2.8.7",
   dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.7",
   dependencyOverrides += "com.fasterxml.jackson.module" % "jackson-module-scala_2.11" % "2.8.7",

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -1,6 +1,7 @@
 import sbt._
 import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport._
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
+import sbt.Keys.libraryDependencies
 
 /**
   * Application settings. Configure the build for your application here.
@@ -34,8 +35,8 @@ object Settings {
     val diode = "1.1.3"
     val uTest = "0.4.7"
 
-    val akka = "2.4.16"
-    val akkaStreamContrib = "0.2"
+    val akka = "2.5.13"
+    val akkaStreamContrib = "0.9"
 
     val specs2 = "3.7"
     val react = "15.5.4"
@@ -64,6 +65,8 @@ object Settings {
     val pac4jSaml = "2.0.0-RC1"
     val openSaml = "2.6.1"
     val drtBirminghamSchema = "1.0.0"
+    val playJson = "2.6.0"
+    val playIteratees = "2.6.1"
   }
 
   import versions._
@@ -107,6 +110,10 @@ object Settings {
     "com.typesafe.akka" %% "akka-persistence" % akka,
     "com.typesafe.akka" %% "akka-stream-contrib" % akkaStreamContrib,
     "com.typesafe.akka" %% "akka-slf4j" % akka,
+
+    "com.typesafe.play" %% "play-json" % playJson,
+    "com.typesafe.play" %% "play-iteratees" % playIteratees,
+    "com.typesafe.play" %% "play-iteratees-reactive-streams" % playIteratees,
 
     "com.vmunier" %% "play-scalajs-scripts" % playScripts,
     "com.vmunier" %% "scalajs-scripts" % scalaJsScripts,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-less" % "1.1.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.8")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.15")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.0")
 


### PR DESCRIPTION
Play 2.6.15 is released.

https://blog.playframework.com/play-2-6-15-released/

Let's upgrade!

I followed the migration steps - by adding some extra play dependencies.

One test failed -> drt.chroma.DiffingAkkaStreamSpec

I upgraded akka libraries and all the test passed.

