### PR TITLE
[DRT-5136] - upgrade renjin to `0.9.2646`.

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -47,7 +47,7 @@ object Settings {
     val sprayVersion = "1.3.4"
     val levelDb = "0.7"
     val levelDbJni = "1.8"
-    val renjin = "0.8.2195"
+    val renjin = "0.9.2646"
     val awsSdk = "1.11.89"
     val awsCommons = "0.10.0"
     val csvCommons = "1.4"


### PR DESCRIPTION
The Renjin code that gets executed is probably the slowest and most unknown part of the app.

Unfortunately, it's not clear what has changed from the previous version  `0.8.2195`, but there have been lots of subsequent changes going by the version numbers. 

http://docs.renjin.org/en/latest/library/project-setup.html#scala-build-tool-sbt