### PR TITLE
DRT-5159 - Remove errors in logs: `Dying because Connection reset`

### DIFF
--- a/server/src/test/scala/services/inputfeeds/AclFeedSpec.scala
+++ b/server/src/test/scala/services/inputfeeds/AclFeedSpec.scala
@@ -6,10 +6,11 @@ import drt.shared.CrunchApi.PortState
 import drt.shared.FlightsApi.{Flights, TerminalName}
 import drt.shared.PaxTypesAndQueues._
 import drt.shared._
+import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.sftp.SFTPClient
 import server.feeds.{ArrivalsFeedFailure, ArrivalsFeedSuccess}
 import server.feeds.acl.AclFeed
-import server.feeds.acl.AclFeed.{arrivalsFromCsvContent, contentFromFileName, latestFileForPort, sftpClient}
+import server.feeds.acl.AclFeed.{arrivalsFromCsvContent, contentFromFileName, latestFileForPort, sftpClientAndSshClient}
 import services.SDate
 import services.crunch.CrunchTestLike
 
@@ -263,7 +264,7 @@ class AclFeedSpec extends CrunchTestLike {
     val username = ConfigFactory.load.getString("acl.username")
     val path = ConfigFactory.load.getString("acl.keypath")
 
-    val sftp: SFTPClient = sftpClient(ftpServer, username, path)
+    val (sftp: SFTPClient, sshClient: SSHClient) = sftpClientAndSshClient(ftpServer, username, path)
     val latestFile = latestFileForPort(sftp, "MAN")
     println(s"latestFile: $latestFile")
     val aclArrivals: List[Arrival] = arrivalsFromCsvContent(contentFromFileName(sftp, latestFile), regularTerminalMapping)


### PR DESCRIPTION
We see lots of errors in the logs

```
2018-07-11 02:34:17,329 [reader] ERROR n.s.sshj.transport.TransportImpl  - Dying because - Connection reset

2018-07-11 02:34:18,305 [reader] ERROR n.s.sshj.transport.TransportImpl  - Dying because - Connection reset

2018-07-11 03:34:17,372 [reader] ERROR n.s.sshj.transport.TransportImpl  - Dying because - Connection reset
```

They occur every hour which corresponds to when we get ACL data.

After doing a quick google search I saw this [post](https://github.com/hierynomus/sshj/issues/87):

It is my best guess that if we close the ssh connection it is possible that we will not see these error message in the logs.