### PR TITLE
DRT-5163 - LTN Port feed failure

### DIFF
--- a/server/src/main/scala/drt/server/feeds/ltn/LtnLiveFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/ltn/LtnLiveFeed.scala
@@ -70,7 +70,14 @@ case class LtnLiveFeed(endPoint: String, token: String, username: String, passwo
           Future(ArrivalsFeedFailure(throwable.toString))
       }
 
-    Await.result(responseFuture, 30 seconds)
+    Try {
+      Await.result(responseFuture, 30 seconds)
+    } match {
+      case Success(response) => response
+      case Failure(t) =>
+        log.error(s"Failed to retrieve the LTN port feed", t)
+        ArrivalsFeedFailure(t.toString)
+    }
   }
 
   def toArrival(ltnFeedFlight: LtnLiveFlight): Arrival = Arrival(


### PR DESCRIPTION
LTN port feed failed and needed a restart of the app to get it going again.

Here are the logs from the event.

```
 2018-07-10 05:42:48,000 [application-akka.actor.default-dispatcher-88] INFO c.g.ArrivalsGraphStage$$anon$1- - inFlightsLive.in(2102223838) Took 86ms
 2018-07-10 05:43:06,086 [application-akka.actor.default-dispatcher-76] INFO s.g.VoyageManifestsGraphStage - Fetched 0 manifests up to file drt_dq_180710_063210_9458.zip
 2018-07-10 05:43:06,086 [application-akka.actor.default-dispatcher-76] INFO s.g.VoyageManifestsGraphStage - Pushing 0 new manifests
 2018-07-10 05:43:06,086 [application-akka.actor.default-dispatcher-76] INFO s.g.VoyageManifestsGraphStage - Minimum check interval 60000ms not yet reached. Sleeping for 20167ms
 2018-07-10 05:43:06,086 [application-akka.actor.default-dispatcher-86] INFO c.g.ArrivalSplitsGraphStage$$anon$1- - Grabbed 0 manifests
 2018-07-10 05:43:06,086 [application-akka.actor.default-dispatcher-88] INFO actors.VoyageManifestsActor - Received 0 manifests, up to file drt_dq_180710_063210_9458.zip
 2018-07-10 05:43:06,087 [application-akka.actor.default-dispatcher-88] INFO actors.VoyageManifestsActor - No new manifests to persist
 2018-07-10 05:43:06,095 [application-akka.actor.default-dispatcher-86] INFO c.g.ArrivalSplitsGraphStage$$anon$1- - We now have 16530 arrivals
 2018-07-10 05:43:06,256 [application-akka.actor.default-dispatcher-86] INFO c.g.ArrivalSplitsGraphStage$$anon$1- - No updated arrivals with splits to push
 2018-07-10 05:43:06,256 [application-akka.actor.default-dispatcher-86] INFO c.g.ArrivalSplitsGraphStage$$anon$1- - Pulling SplitsIn.in(1053371717)
 2018-07-10 05:43:06,256 [application-akka.actor.default-dispatcher-86] INFO c.g.ArrivalSplitsGraphStage$$anon$1- - inManifests Took 170ms
 2018-07-10 05:43:16,824 [application-akka.actor.default-dispatcher-86] INFO drt.server.feeds.ltn.LtnLiveFeed - Requesting feed
 2018-07-10 05:43:22,100 [application-akka.actor.default-dispatcher-20] INFO services.LiveArrivalsActor - Received unexpected message class akka.actor.Status$Failure
 2018-07-10 05:43:22,173 [application-akka.actor.default-dispatcher-35] WARN f.CrunchStateActor - Received unexpected message Failure(java.util.concurrent.TimeoutException: Futures timed out after [5 seconds])
 2018-07-10 05:43:22,173 [application-akka.actor.default-dispatcher-86] WARN c.CrunchStateActor - Received unexpected message Failure(java.util.concurrent.TimeoutException: Futures timed out after [5 seconds])
```

We need to remedy this so that it doesn't happen again.

What I have done;
* Increased the timeout from 5 seconds to 30 seconds
* Altered log error messages

What I have not done and may need some help with in this PR
* Not allowed Failures to progress up the graph