### PR TITLE
DRT-5041 - Desks & Queues Export should include the Moves number

### DIFF
--- a/server/src/main/scala/services/CSVData.scala
+++ b/server/src/main/scala/services/CSVData.scala
@@ -96,11 +96,11 @@ object CSVData {
     val queueHeadings = relevantQueues.map(queue => Queues.queueDisplayNames.getOrElse(queue, queue))
       .flatMap(qn => List.fill(colHeadings.length)(Queues.exportQueueDisplayNames.getOrElse(qn, qn))).mkString(",")
     val headingsLine1 = "Date,," + queueHeadings +
-      ",Misc,PCP Staff,PCP Staff"
+      ",Misc,Moves,PCP Staff,PCP Staff"
     val headingsLine2 = ",Start," + relevantQueues.flatMap(q => {
       if (q == Queues.EGate) eGatesHeadings else colHeadings
     }).mkString(",") +
-      ",Staff req,Avail,Req"
+      ",Staff req,Staff movements,Avail,Req"
 
     headingsLine1 + lineEnding + headingsLine2
   }
@@ -157,7 +157,7 @@ object CSVData {
 
           val staffMinute = staffMinutesByMinute.getOrElse(minute, StaffMinute.empty)
 
-          val staffData: Seq[String] = List(staffMinute.fixedPoints.toString, staffMinute.available.toString)
+          val staffData: Seq[String] = List(staffMinute.fixedPoints.toString, staffMinute.movements.toString, staffMinute.available.toString)
           val reqForMinute = crunchMilliMinutes
             .toList
             .find { case (minuteMilli, _) => minuteMilli == minute }


### PR DESCRIPTION
Added a Moves column after Misc
There is a second heading also - at this moment in time I've chosen to call it `Staff movements`

As in the image below;
<img width="295" alt="screen shot 2018-07-13 at 09 38 59" src="https://user-images.githubusercontent.com/369407/42681988-2a9e00e0-8681-11e8-89ed-58b2af78c68f.png">
