### PR TITLE
DRT-5165 - Improve LGW's live feed statuses

### DIFF
--- a/server/src/main/scala/drt/server/feeds/lgw/ResponseToArrivals.scala
+++ b/server/src/main/scala/drt/server/feeds/lgw/ResponseToArrivals.scala
@@ -81,7 +81,33 @@ case class ResponseToArrivals(data: Array[Byte], locationOption: Option[String] 
   }
 
   def parseStatus(n: Node): String = {
-    ((n \ "FlightLeg").head \ "LegData").head \ "OperationalStatus" text
+    val aidxCodeOrIdahoCode = ((n \ "FlightLeg").head \ "LegData").head \ "OperationalStatus" text
+
+    aidxCodeOrIdahoCode match {
+      case "DV" => "Diverted"
+      case "DX" | "CX" => "Cancelled"
+      case "EST" | "ES" => "Estimated"
+      case "EXP" | "EX" => "Expected"
+      case "FRB" | "FB" => "First Bag Delivered"
+      case "LAN" | "LD" => "Landed"
+      case "LSB" | "LB" => "Last Bag Delivered"
+      case "NIT" | "NI" => "Next Information Time"
+      case "ONB" | "OC" => "On Chocks"
+      case "OVS" | "OV" => "Overshoot"
+      case "REM" | "**" => "Deleted / Removed Flight Record"
+      case "SCT" | "SH" => "Scheduled"
+      case "TEN" | "FS" => "Final Approach"
+      case "THM" | "ZN" => "Zoning"
+      case "UNK" | "??" => "Unknown"
+      case "FCT" | "LC" => "Last Call (Departure Only)"
+      case "BST" | "BD" => "Boarding (Departure Only)"
+      case "GCL" | "GC" => "Gate Closed (Departure Only)"
+      case "GOP" | "GO" => "Gate Opened (Departure Only)"
+      case "RST" | "RS" => "Return to Stand (Departure Only)"
+      case "OFB" | "TX" => "Taxied (Departure Only)"
+      case "TKO" | "AB" => "Airborne (Departure Only)"
+      case unknownCode => unknownCode
+     }
   }
 
   def parseOrigin(n: Node): String = {

--- a/server/src/test/scala/feeds/LGWFeedSpec.scala
+++ b/server/src/test/scala/feeds/LGWFeedSpec.scala
@@ -91,7 +91,7 @@ class LGWFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.e
     arrivals.size mustEqual 1
     arrivals.head mustEqual new Arrival(
       Operator = None,
-      Status = "LAN",
+      Status = "Landed",
       Estimated = Some(SDate("2018-06-03T19:28:00Z").millisSinceEpoch),
       Actual =  Some(SDate("2018-06-03T19:30:00Z").millisSinceEpoch),
       EstimatedChox =  Some(SDate("2018-06-03T19:37:00Z").millisSinceEpoch),


### PR DESCRIPTION
Currently the LGW feed status has codes such as `LAN`, `FRB` and `LSB` that does not make sense to an English speaking person.

We should show the description of the status codes instead.

The table below are the current, _valid_ status codes they use and what they mean.

AIDX Code | AIDX Code Context | IDAHO Code | Description
-- | -- | -- | --
FCT | 9750 | LC | Last Call (Departure Only)
BST | 9750 | BD | Boarding   (Departure Only)
DV | 2005 | DV | Diverted   (Arrival Only)
DX | 2005 | CX | Cancelled
EST | 2005 | ES | Estimated
EXP | 0000 | EX | Expected
FRB | 0000 | FB | First   Bag Delivered (Arrival Only)
GCL | 9750 | GC | Gate   Closed (Departure Only)
GOP | 0000 | GO | Gate   Opened (Departure Only)
LAN | 9750 | LD | Landed   (Arrival Only)
LSB | 0000 | LB | Last   Bag Delivered (Arrival Only)
NIT | 2005 | NI | Next Information Time
OFB | 9750 | TX | Taxied   (Departure Only)
ONB | 9750 | OC | On   Chocks (Arrival Only)
OVS | 0000 | OV | Overshoot   (Arrival Only)
REM | 0000 | ** | Deleted   / Removed Flight Record
RST | 9750 | RS | Return   to Stand (Departure Only)
SCT | 9750 | SH | Scheduled
TEN | 9750 | FS | Final   Approach (Arrival Only)
THM | 9750 | ZN | Zoning   (Arrival Only)
TKO | 9750 | AB | Airborne   (Departure Only)
UNK | 0000 | ?? | Unknown

