### PR TITLE
DRT-5166 - Export Desks CSV should include the last date time in the range

### DIFF
--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -605,7 +605,7 @@ class Application @Inject()(implicit val config: Configuration,
   }
 
   def isInRangeOnDay(startDateTime: SDateLike, endDateTime: SDateLike)(minute: SDateLike): Boolean =
-    startDateTime.millisSinceEpoch <= minute.millisSinceEpoch && minute.millisSinceEpoch < endDateTime.millisSinceEpoch
+    startDateTime.millisSinceEpoch <= minute.millisSinceEpoch && minute.millisSinceEpoch <= endDateTime.millisSinceEpoch
 
 
   def flightsForCSVExportWithinRange(

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -1,0 +1,5 @@
+# Config file in HOCON format.  See following for more information:
+# https://www.playframework.com/documentation/latest/Configuration
+
+portcode = "test"
+

--- a/server/src/test/scala/controllers/ApplicationSpec.scala
+++ b/server/src/test/scala/controllers/ApplicationSpec.scala
@@ -1,0 +1,34 @@
+package controllers
+
+import akka.actor.ActorSystem
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
+import org.joda.time.DateTime
+import org.specs2.matcher.Scope
+import org.specs2.mutable.SpecificationLike
+import play.api.Environment
+import services.SDate
+
+import scala.concurrent.ExecutionContext.global
+
+class ApplicationSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.empty())) with SpecificationLike {
+
+  trait Context extends Scope {
+    implicit val mat: Materializer = ActorMaterializer()
+    implicit val config = play.api.Configuration.from(Map("portCode" -> "test", "dq.s3.bucket" -> "bucket"))
+
+    val application = new Application()(config = config, mat = mat, env = Environment.simple(), system = system, ec = global)
+  }
+
+  "Application" should {
+    "isInRangeOnDay should be True of the last date-time in a given date range" in new Context {
+      val anHourAgo: DateTime = DateTime.now.minusHours(1)
+      val now: DateTime = DateTime.now
+      val startDateTime = SDate(anHourAgo)
+      val endDateTime = SDate(now)
+      application.isInRangeOnDay(startDateTime, endDateTime)(endDateTime) must beTrue
+    }
+  }
+
+}


### PR DESCRIPTION
The Export Desks CSV which misses the last time in a given date/time range.

e.g. a CVS file generated from 13:00 to 17:00 will omit the last time at 17:00

The CSV will now include the last time from a given date range.