### PR TITLE
DRT-5177- Play Controllers with akka

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -16,6 +16,7 @@ contact-email = ${?CONTACT_EMAIL}
 play.http.context = "/v2/"${portcode}"/live"
 
 play.server.netty.maxHeaderSize = 32768
+play.akka.actor-system = ${portcode}"-drt-actor-system"
 
 persistenceBaseDir = "/tmp"
 persistenceBaseDir = ${?PERSISTENCE_BASE_DIR}

--- a/server/src/main/scala/Filters.scala
+++ b/server/src/main/scala/Filters.scala
@@ -1,8 +1,9 @@
-import com.google.inject.Inject
+import javax.inject.{Singleton, Inject}
 import controllers.NoCacheFilter
 import play.api.Environment
 import play.api.http.HttpFilters
 
+@Singleton
 class Filters @Inject()(
                          env: Environment,
                          noCache: NoCacheFilter) extends HttpFilters {

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -12,7 +12,7 @@ import akka.util.{ByteString, Timeout}
 import boopickle.CompositePickler
 import boopickle.Default._
 import buildinfo.BuildInfo
-import com.google.inject.{Inject, Singleton}
+import javax.inject.{Singleton, Inject}
 import com.typesafe.config.ConfigFactory
 import drt.shared.CrunchApi.{groupCrunchMinutesByX, _}
 import drt.shared.FlightsApi.TerminalName
@@ -149,7 +149,7 @@ trait UserRoleProviderLike {
   def getRoles(config: Configuration, headers: Headers, session: Session): List[String]
 }
 
-
+@Singleton
 class Application @Inject()(implicit val config: Configuration,
                             implicit val mat: Materializer,
                             env: Environment,

--- a/server/src/main/scala/controllers/Test.scala
+++ b/server/src/main/scala/controllers/Test.scala
@@ -35,9 +35,9 @@ class Test @Inject()(implicit val config: Configuration,
 
   val baseTime: SDateLike = SDate.now()
 
-  val liveArrivalsTestActor: Future[ActorRef] = system.actorSelection("akka://application/user/TestActor-LiveArrivals").resolveOne()
-  val apiManifestsTestActor: Future[ActorRef] = system.actorSelection("akka://application/user/TestActor-APIManifests").resolveOne()
-  val mockRolesTestActor: Future[ActorRef] = system.actorSelection("akka://application/user/TestActor-MockRoles").resolveOne()
+  val liveArrivalsTestActor: Future[ActorRef] = system.actorSelection("akka://test-drt-actor-system/user/TestActor-LiveArrivals").resolveOne()
+  val apiManifestsTestActor: Future[ActorRef] = system.actorSelection("akka://test-drt-actor-system/user/TestActor-APIManifests").resolveOne()
+  val mockRolesTestActor: Future[ActorRef] = system.actorSelection("akka://test-drt-actor-system/user/TestActor-MockRoles").resolveOne()
 
   def saveArrival(arrival: Arrival) = {
     liveArrivalsTestActor.map(actor => {
@@ -56,7 +56,7 @@ class Test @Inject()(implicit val config: Configuration,
   }
 
   def resetData() = {
-    system.actorSelection("akka://application/user/TestActor-ResetData").resolveOne().map(actor => {
+    system.actorSelection("akka://test-drt-actor-system/user/TestActor-ResetData").resolveOne().map(actor => {
 
       log.info(s"Sending reset message")
 

--- a/server/src/main/scala/controllers/Test.scala
+++ b/server/src/main/scala/controllers/Test.scala
@@ -3,7 +3,7 @@ package controllers
 import akka.actor.{ActorRef, ActorSystem}
 import akka.stream.Materializer
 import akka.util.Timeout
-import com.google.inject.Inject
+import javax.inject.{Singleton, Inject}
 import drt.chroma.chromafetcher.ChromaFetcher.ChromaLiveFlight
 import drt.chroma.chromafetcher.ChromaParserProtocol._
 import passengersplits.parsing.VoyageManifestParser.FlightPassengerInfoProtocol._
@@ -23,6 +23,7 @@ import test.TestActors.ResetActor
 import test.MockRoles._
 import test.MockRoles.MockRolesProtocol._
 
+@Singleton
 class Test @Inject()(implicit val config: Configuration,
                      implicit val mat: Materializer,
                      env: Environment,


### PR DESCRIPTION
Whilst reading [this](https://www.playframework.com/documentation/2.6.x/ScalaAkka#Creating-and-using-actors) when investigating #DRT-5174 - running akka in a cluster; 
It was noted that some of our Controllers are not Singletons

Play Controllers must be a singleton or else it would need to create actors with a unique names.


> if the controller was not scoped as singleton, this would mean a new actor would be created every time the controller was created, which would ultimate throw an exception because you can’t have two actors in the same system with the same name.
