### PR TITLE
DRT-5096 Allow Key Cloak User Approval from app

### DIFF
--- a/client/src/main/scala/drt/client/SPAMain.scala
+++ b/client/src/main/scala/drt/client/SPAMain.scala
@@ -2,7 +2,7 @@ package drt.client
 
 import diode.Action
 import drt.client.actions.Actions._
-import drt.client.components.{GlobalStyles, Layout, StatusPage, TerminalComponent, TerminalPlanningComponent, TerminalsDashboardPage}
+import drt.client.components.{GlobalStyles, KeyCloakUsersPage, Layout, StatusPage, TerminalComponent, TerminalPlanningComponent, TerminalsDashboardPage}
 import drt.client.logger._
 import drt.client.services.JSDateConversions.SDate
 import drt.client.services._
@@ -11,12 +11,12 @@ import drt.shared.SDateLike
 import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.extra.router._
 import org.scalajs.dom
-import scalacss.ProdDefaults._
 
 import scala.collection.immutable.Seq
 import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
+import scalacss.ProdDefaults._
 
-object SPAMain  {
+object SPAMain {
 
   sealed trait Loc
 
@@ -60,7 +60,10 @@ object SPAMain  {
   }
 
   case class TerminalsDashboardLoc(period: Option[Int]) extends Loc
+
   case object StatusLoc extends Loc
+
+  case object KeyCloakUsersLoc extends Loc
 
   def requestInitialActions(): Unit = {
     val initActions = Seq(
@@ -80,7 +83,7 @@ object SPAMain  {
     .buildConfig { dsl =>
       import dsl._
 
-      val rule = homeRoute(dsl) | dashboardRoute(dsl) | terminalRoute(dsl) | statusRoute(dsl)
+      val rule = homeRoute(dsl) | dashboardRoute(dsl) | terminalRoute(dsl) | statusRoute(dsl) | keyCloakUsersRoute(dsl)
 
       rule.notFound(redirectToPage(TerminalsDashboardLoc(None))(Redirect.Replace))
     }
@@ -95,6 +98,8 @@ object SPAMain  {
             SPACircuit.dispatch(c.loadAction)
           case (_, _: TerminalsDashboardLoc) =>
             SPACircuit.dispatch(SetViewMode(ViewLive()))
+          case (_, KeyCloakUsersLoc) =>
+            SPACircuit.dispatch(GetKeyCloakUsers)
           case _ =>
         }
       )
@@ -110,6 +115,12 @@ object SPAMain  {
     import dsl._
 
     staticRoute("#status", StatusLoc) ~> renderR((router: RouterCtl[Loc]) => StatusPage())
+  }
+
+  def keyCloakUsersRoute(dsl: RouterConfigDsl[Loc]): dsl.Rule = {
+    import dsl._
+
+    staticRoute("#users", KeyCloakUsersLoc) ~> renderR((router: RouterCtl[Loc]) => KeyCloakUsersPage())
   }
 
   def dashboardRoute(dsl: RouterConfigDsl[Loc]): dsl.Rule = {

--- a/client/src/main/scala/drt/client/actions/Actions.scala
+++ b/client/src/main/scala/drt/client/actions/Actions.scala
@@ -6,6 +6,7 @@ import diode.Action
 import drt.client.services.{StaffAssignment, ViewMode}
 import drt.shared.CrunchApi.{CrunchState, CrunchUpdates, ForecastPeriodWithHeadlines}
 import drt.shared.FlightsApi._
+import drt.shared.KeyCloakApi.KeyCloakUser
 import drt.shared._
 
 import scala.concurrent.duration.FiniteDuration
@@ -97,5 +98,11 @@ object Actions {
   case class RetryActionAfter(action: Action, delay: FiniteDuration) extends Action
 
   case class DoNothing() extends Action
+
+  case object GetKeyCloakUsers extends Action
+
+  case class SetKeyCloakUsers(users: List[KeyCloakUser]) extends Action
+
+  case class AddUserToGroup(userId: String, groupName: String) extends Action
 
 }

--- a/client/src/main/scala/drt/client/components/ListKeyCloakUsers.scala
+++ b/client/src/main/scala/drt/client/components/ListKeyCloakUsers.scala
@@ -13,16 +13,15 @@ object ListKeyCloakUsers {
 
   val component = ScalaComponent.builder[Props]("ListKeyCloakUsers")
     .renderP((scope, p) => {
-      def approveUser(userId: String) = (_: ReactEventFromInput) => {
+      def approveUser(userId: String) = (_: ReactEventFromInput) =>
         Callback(SPACircuit.dispatch(AddUserToGroup(userId, "Approved")))
-      }
+
 
       val keyCloakUsers = SPACircuit.connect(m => m.keyCloakUsers)
       keyCloakUsers(usersMP => {
-        val usersPot: Pot[List[KeyCloakUser]]
-        = usersMP()
+        val usersPot: Pot[List[KeyCloakUser]] = usersMP()
         <.div(
-          usersPot.renderReady(users => {
+          usersPot.renderReady(users =>
            <.table(^.className := "key-cloak-users",
              users.map( user => <.tr(
                <.td(user.firstName),
@@ -31,7 +30,7 @@ object ListKeyCloakUsers {
                <.td(<.button("Approve", ^.className := "btn btn-primary", ^.onClick ==> approveUser(user.id)))
              )
            ).toTagMod)
-          })
+          )
         )
       })
     }
@@ -44,10 +43,7 @@ object KeyCloakUsersPage {
   case class Props()
 
   val component = ScalaComponent.builder[Props]("ListKeyCloakUsers")
-    .render_P(p => {
-      <.div(ListKeyCloakUsers())
-    }
-    ).build
+    .render_P(p => <.div(ListKeyCloakUsers())).build
 
   def apply(): VdomElement = component(Props())
 }

--- a/client/src/main/scala/drt/client/components/ListKeyCloakUsers.scala
+++ b/client/src/main/scala/drt/client/components/ListKeyCloakUsers.scala
@@ -1,0 +1,53 @@
+package drt.client.components
+
+import diode.data.Pot
+import drt.client.actions.Actions.AddUserToGroup
+import drt.client.services._
+import drt.shared.KeyCloakApi.KeyCloakUser
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.{Callback, ReactEventFromInput, ScalaComponent}
+
+object ListKeyCloakUsers {
+
+  case class Props()
+
+  val component = ScalaComponent.builder[Props]("ListKeyCloakUsers")
+    .renderP((scope, p) => {
+      def approveUser(userId: String) = (_: ReactEventFromInput) => {
+        Callback(SPACircuit.dispatch(AddUserToGroup(userId, "Approved")))
+      }
+
+      val keyCloakUsers = SPACircuit.connect(m => m.keyCloakUsers)
+      keyCloakUsers(usersMP => {
+        val usersPot: Pot[List[KeyCloakUser]]
+        = usersMP()
+        <.div(
+          usersPot.renderReady(users => {
+           <.table(^.className := "key-cloak-users",
+             users.map( user => <.tr(
+               <.td(user.firstName),
+               <.td(user.lastName),
+               <.td(user.email),
+               <.td(<.button("Approve", ^.className := "btn btn-primary", ^.onClick ==> approveUser(user.id)))
+             )
+           ).toTagMod)
+          })
+        )
+      })
+    }
+    ).build
+
+  def apply(): VdomElement = component(Props())
+}
+object KeyCloakUsersPage {
+
+  case class Props()
+
+  val component = ScalaComponent.builder[Props]("ListKeyCloakUsers")
+    .render_P(p => {
+      <.div(ListKeyCloakUsers())
+    }
+    ).build
+
+  def apply(): VdomElement = component(Props())
+}

--- a/client/src/main/scala/drt/client/components/Navbar.scala
+++ b/client/src/main/scala/drt/client/components/Navbar.scala
@@ -8,11 +8,11 @@ import org.scalajs.dom.html
 
 object Navbar {
   def apply(ctl: RouterCtl[Loc], page: Loc): VdomTagOf[html.Element] = {
-    val airportConfigRCP = SPACircuit.connect(m => (m.airportConfig, m.feedStatuses))
+    val menueModelRCP = SPACircuit.connect(m => (m.airportConfig, m.feedStatuses, m.userRoles))
 
     <.nav(^.className := "navbar navbar-default",
-      airportConfigRCP(airportConfigPotMP => {
-        val (airportConfigPot, feedStatusesPot) = airportConfigPotMP()
+      menueModelRCP(menuModelPotMP => {
+        val (airportConfigPot, feedStatusesPot, userRolesPot) = menuModelPotMP()
         <.div(^.className := "container",
           airportConfigPot.render(airportConfig => {
             val contactLink = airportConfig.contactEmail.map(contactEmail => {
@@ -21,12 +21,15 @@ object Navbar {
 
             <.div(^.className := "navbar-drt",
               <.span(^.className := "navbar-brand", s"DRT ${airportConfig.portCode}"),
-              <.div(^.className := "collapse navbar-collapse", MainMenu(ctl, page, feedStatusesPot.getOrElse(Seq())),
+              userRolesPot.renderReady(roles =>
+
+              <.div(^.className := "collapse navbar-collapse", MainMenu(ctl, page, feedStatusesPot.getOrElse(Seq()), airportConfig, roles),
                 <.ul(^.className := "nav navbar-nav navbar-right",
                   <.li(contactLink),
                   <.li(<.a(Icon.signOut, "Log Out", ^.href := "/oauth/logout?redirect=" + BaseUrl.until_#.value))
                 )
               ))
+            )
           }))
       })
     )

--- a/client/src/main/scala/drt/client/components/Navbar.scala
+++ b/client/src/main/scala/drt/client/components/Navbar.scala
@@ -8,10 +8,10 @@ import org.scalajs.dom.html
 
 object Navbar {
   def apply(ctl: RouterCtl[Loc], page: Loc): VdomTagOf[html.Element] = {
-    val menueModelRCP = SPACircuit.connect(m => (m.airportConfig, m.feedStatuses, m.userRoles))
+    val menuModelRCP = SPACircuit.connect(m => (m.airportConfig, m.feedStatuses, m.userRoles))
 
     <.nav(^.className := "navbar navbar-default",
-      menueModelRCP(menuModelPotMP => {
+      menuModelRCP(menuModelPotMP => {
         val (airportConfigPot, feedStatusesPot, userRolesPot) = menuModelPotMP()
         <.div(^.className := "container",
           airportConfigPot.render(airportConfig => {

--- a/client/src/main/scala/drt/client/components/SnapshotSelector.scala
+++ b/client/src/main/scala/drt/client/components/SnapshotSelector.scala
@@ -44,9 +44,7 @@ object SnapshotSelector {
   }
 
   implicit val stateReuse: Reusability[State] = Reusability.by(_.hashCode())
-  implicit val propsReuse: Reusability[Props] = Reusability.by(p =>
-    (p.loadingState.isLoading)
-  )
+  implicit val propsReuse: Reusability[Props] = Reusability.by(p => p.loadingState.isLoading)
 
   val component = ScalaComponent.builder[Props]("SnapshotSelector")
     .initialStateFromProps(

--- a/client/src/main/scala/drt/client/services/SPACircuit.scala
+++ b/client/src/main/scala/drt/client/services/SPACircuit.scala
@@ -6,6 +6,7 @@ import diode.react.ReactConnector
 import drt.client.services.JSDateConversions.SDate
 import drt.client.services.handlers._
 import drt.shared.CrunchApi._
+import drt.shared.KeyCloakApi.KeyCloakUser
 import drt.shared._
 
 import scala.collection.immutable.Map
@@ -47,6 +48,7 @@ case class RootModel(
                       showActualIfAvailable: Boolean = true,
                       userRoles: Pot[List[String]] = Empty,
                       minuteTicker: Int = 0,
+                      keyCloakUsers: Pot[List[KeyCloakUser]] = Empty,
                       feedStatuses: Pot[Seq[FeedStatuses]] = Empty
                     )
 
@@ -87,6 +89,7 @@ trait DrtCircuit extends Circuit[RootModel] with ReactConnector[RootModel] {
       new LoggedInStatusHandler(zoomRW(identity)((m, v) => m)),
       new NoopHandler(zoomRW(identity)((m, v) => m)),
       new UserRolesHandler(zoomRW(_.userRoles)((m, v) => m.copy(userRoles = v))),
+      new UsersHandler(zoomRW(_.keyCloakUsers)((m, v) => m.copy(keyCloakUsers = v))),
       new MinuteTickerHandler(zoomRW(_.minuteTicker)((m, v) => m.copy(minuteTicker = v))),
       new FeedsStatusHandler(zoomRW(_.feedStatuses)((m, v) => m.copy(feedStatuses = v)))
     )

--- a/client/src/main/scala/drt/client/services/handlers/UsersHandler.scala
+++ b/client/src/main/scala/drt/client/services/handlers/UsersHandler.scala
@@ -18,7 +18,7 @@ class UsersHandler[M](modelRW: ModelRW[M, Pot[List[KeyCloakUser]]]) extends Logg
     case GetKeyCloakUsers =>
       effectOnly(Effect(AjaxClient[Api].getKeyCloakUsers().call().map(SetKeyCloakUsers).recoverWith {
         case _ =>
-          log.error(s"CrunchState request failed. Re-requesting after ${PollDelay.recoveryDelay}")
+          log.error(s"GetKeyCloakUsers request failed. Re-requesting after ${PollDelay.recoveryDelay}")
           Future(RetryActionAfter(GetKeyCloakUsers, PollDelay.recoveryDelay))
       }))
 
@@ -28,7 +28,7 @@ class UsersHandler[M](modelRW: ModelRW[M, Pot[List[KeyCloakUser]]]) extends Logg
     case AddUserToGroup(userId, groupName) =>
       effectOnly(Effect(AjaxClient[Api].addUserToGroup(userId, groupName).call().map(_ => GetKeyCloakUsers).recoverWith {
         case _ =>
-          log.error(s"CrunchState request failed. Re-requesting after ${PollDelay.recoveryDelay}")
+          log.error(s"AddUserToGroup request failed. Re-requesting after ${PollDelay.recoveryDelay}")
           Future(RetryActionAfter(AddUserToGroup(userId, groupName), PollDelay.recoveryDelay))
       }))
   }

--- a/client/src/main/scala/drt/client/services/handlers/UsersHandler.scala
+++ b/client/src/main/scala/drt/client/services/handlers/UsersHandler.scala
@@ -1,0 +1,35 @@
+package drt.client.services.handlers
+
+import autowire._
+import boopickle.Default._
+import diode.data.{Pot, Ready}
+import diode.{ActionResult, Effect, ModelRW}
+import drt.client.actions.Actions._
+import drt.client.logger.log
+import drt.client.services.{AjaxClient, PollDelay}
+import drt.shared.Api
+import drt.shared.KeyCloakApi.KeyCloakUser
+
+import scala.concurrent.Future
+import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+
+class UsersHandler[M](modelRW: ModelRW[M, Pot[List[KeyCloakUser]]]) extends LoggingActionHandler(modelRW) {
+  protected def handle: PartialFunction[Any, ActionResult[M]] = {
+    case GetKeyCloakUsers =>
+      effectOnly(Effect(AjaxClient[Api].getKeyCloakUsers().call().map(SetKeyCloakUsers).recoverWith {
+        case _ =>
+          log.error(s"CrunchState request failed. Re-requesting after ${PollDelay.recoveryDelay}")
+          Future(RetryActionAfter(GetKeyCloakUsers, PollDelay.recoveryDelay))
+      }))
+
+    case SetKeyCloakUsers(users) =>
+      updated(Ready(users))
+
+    case AddUserToGroup(userId, groupName) =>
+      effectOnly(Effect(AjaxClient[Api].addUserToGroup(userId, groupName).call().map(_ => GetKeyCloakUsers).recoverWith {
+        case _ =>
+          log.error(s"CrunchState request failed. Re-requesting after ${PollDelay.recoveryDelay}")
+          Future(RetryActionAfter(AddUserToGroup(userId, groupName), PollDelay.recoveryDelay))
+      }))
+  }
+}

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -1641,3 +1641,7 @@ a i.fa.fa-remove {
 .navbar-nav li.green .fa-bar-chart  {
     color: #008000;
 }
+
+.key-cloak-users td {
+  padding: 10px;
+}

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -37,6 +37,10 @@ persistence {
   }
 }
 
+key-cloak {
+  url: ${?KEY_CLOAK_URL}
+}
+
 akka {
 //  loglevel ="DEBUG"
 

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -14,11 +14,14 @@ import boopickle.Default._
 import buildinfo.BuildInfo
 import com.google.inject.{Inject, Singleton}
 import com.typesafe.config.ConfigFactory
+import drt.http.ProdSendAndReceive
 import drt.shared.CrunchApi.{groupCrunchMinutesByX, _}
 import drt.shared.FlightsApi.TerminalName
+import drt.shared.KeyCloakApi.{KeyCloakGroup, KeyCloakUser}
 import drt.shared.SplitRatiosNs.SplitRatios
 import drt.shared.{AirportConfig, Api, Arrival, _}
 import drt.staff.ImportStaff
+import drt.users.KeyCloakClient
 import org.joda.time.chrono.ISOChronology
 import org.slf4j.{Logger, LoggerFactory}
 import play.api.http.{HeaderNames, HttpEntity}
@@ -34,7 +37,7 @@ import services.shifts.StaffTimeSlots
 import services.workloadcalculator.PaxLoadCalculator
 import services.workloadcalculator.PaxLoadCalculator.PaxTypeAndQueueCount
 import services.{SDate, _}
-import test.{MockRoles, TestDrtSystem}
+import test.TestDrtSystem
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -142,7 +145,7 @@ class NoCacheFilter @Inject()(
 trait UserRoleProviderLike {
   val log = LoggerFactory.getLogger(getClass)
 
-  val availableRoles = List("staff:edit", "drt:team")
+  val availableRoles = List("staff:edit", "drt:team", "manage-users")
 
   def userRolesFromHeader(headers: Headers): List[String] = headers.get("X-Auth-Roles").map(_.split(",").toList).getOrElse(List())
 
@@ -299,6 +302,29 @@ class Application @Inject()(implicit val config: Configuration,
             log.info(s"Shifts: Retrieved shifts from actor for month starting: ${SDate(month).toISOString()}")
             StaffTimeSlots.getShiftsForMonth(shifts, SDate(month, Crunch.europeLondonTimeZone), terminalName)
         }
+      }
+
+      def keyCloakClient = {
+        val token = headers.get("X-Auth-Token").getOrElse(throw new Exception("X-Auth-Token missing from headers, we need this to query the Key Cloak API."))
+        val keyCloakUrl = config.getOptional[String]("key-cloak.url").getOrElse(throw new Exception("Missing key-cloak.url config value, we need this to query the Key Cloak API"))
+        new KeyCloakClient(token, keyCloakUrl, actorSystem) with ProdSendAndReceive
+      }
+
+      def getKeyCloakUsers(): Future[List[KeyCloakUser]] = {
+        log.info(s"Got these roles: ${getUserRoles}")
+        if (getUserRoles.contains("manage-users")) {
+          keyCloakClient.getUsersNotInGroup("Approved")
+        } else throw new Exception("You do not have permission manage users")
+      }
+
+      def addUserToGroup(userId: String, groupName: String): Unit = {
+        if (getUserRoles.contains("manage-users")) {
+          val futureGroupId: Future[Option[KeyCloakGroup]] = keyCloakClient.getGroups().map(_.find(_.name == groupName))
+          futureGroupId.map {
+            case Some(group) => keyCloakClient.addUserToGroup(userId, group.id)
+            case None => log.error(s"Unable to add $userId to $groupName")
+          }
+        } else throw new Exception("You do not have permission manage users")
       }
 
       override def liveCrunchStateActor: AskableActorRef = ctrl.liveCrunchStateActor

--- a/server/src/main/scala/drt/http/SendAndReceive.scala
+++ b/server/src/main/scala/drt/http/SendAndReceive.scala
@@ -13,7 +13,7 @@ trait WithSendAndReceive {
 
 trait ProdSendAndReceive extends WithSendAndReceive {
   implicit val system: ActorSystem
-  import system.dispatcher
+
   override def sendAndReceive: SendReceive = sendReceive(system, system.dispatcher, 60.seconds)
 }
 

--- a/server/src/main/scala/drt/users/KeyCloakClient.scala
+++ b/server/src/main/scala/drt/users/KeyCloakClient.scala
@@ -1,0 +1,106 @@
+package drt.users
+
+import akka.actor.ActorSystem
+import akka.util.Timeout
+import drt.http.WithSendAndReceive
+import drt.shared.KeyCloakApi.{KeyCloakGroup, KeyCloakUser}
+import org.slf4j.LoggerFactory
+import spray.client.pipelining.{Get, addHeaders, unmarshal, _}
+import spray.http.HttpHeaders.{Accept, Authorization}
+import spray.http.{HttpRequest, HttpResponse, MediaTypes, OAuth2BearerToken}
+import spray.httpx.SprayJsonSupport
+import spray.json.{DefaultJsonProtocol, RootJsonFormat}
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.concurrent.Future
+
+abstract case class KeyCloakClient(token: String, keyCloakUrl: String, implicit val system: ActorSystem)
+  extends WithSendAndReceive with KeyCloakUserParserProtocol {
+
+  import system.dispatcher
+
+  def log = LoggerFactory.getLogger(getClass)
+  implicit val timeout: Timeout = Timeout(1 minute)
+
+  val logResponse: HttpResponse => HttpResponse = resp => {
+
+    if (resp.status.isFailure) {
+      log.error(s"Error when reading KeyCloak API ${resp.headers}, ${resp.entity.data.asString}")
+    }
+
+    resp
+  }
+
+  def getUsers(): Future[List[KeyCloakUser]] = {
+    val pipeline: HttpRequest => Future[List[KeyCloakUser]] = (
+      addHeaders(Accept(MediaTypes.`application/json`), Authorization(OAuth2BearerToken(token)))
+        ~> sendAndReceive
+        ~> logResponse
+        ~> unmarshal[List[KeyCloakUser]]
+      )
+
+    pipeline(Get(keyCloakUrl + "/users"))
+  }
+
+  def getGroups(): Future[List[KeyCloakGroup]] = {
+    val pipeline: HttpRequest => Future[List[KeyCloakGroup]] = (
+      addHeaders(Accept(MediaTypes.`application/json`), Authorization(OAuth2BearerToken(token)))
+        ~> sendAndReceive
+        ~> logResponse
+        ~> unmarshal[List[KeyCloakGroup]]
+      )
+
+    pipeline(Get(keyCloakUrl + "/groups"))
+  }
+
+  def getUsersInGroup(groupName: String): Future[List[KeyCloakUser]] = {
+
+    val futureMaybeId: Future[Option[String]] = getGroups().map(gs => gs.find(_.name == groupName).map(_.id))
+
+    val pipeline: HttpRequest => Future[List[KeyCloakUser]] = (
+      addHeaders(Accept(MediaTypes.`application/json`), Authorization(OAuth2BearerToken(token)))
+        ~> sendAndReceive
+        ~> logResponse
+        ~> unmarshal[List[KeyCloakUser]]
+      )
+
+    futureMaybeId.flatMap {
+      case Some(id) => pipeline(Get(keyCloakUrl + s"/groups/$id/members"))
+      case None => Future(List())
+    }
+  }
+
+  def getUsersNotInGroup(groupName: String): Future[List[KeyCloakUser]] = {
+
+    val futureUsersInGroup: Future[List[KeyCloakUser]] = getUsersInGroup(groupName)
+    val futureAllUsers: Future[List[KeyCloakUser]] = getUsers()
+
+    for {
+      usersInGroup <- futureUsersInGroup
+      allUsers <- futureAllUsers
+    } yield allUsers.filterNot(usersInGroup.toSet)
+  }
+
+  def addUserToGroup(userId: String, groupId: String): Future[HttpResponse] = {
+    val pipeline: HttpRequest => Future[HttpResponse] = (
+      addHeaders(Accept(MediaTypes.`application/json`), Authorization(OAuth2BearerToken(token)))
+        ~> sendAndReceive
+        ~> logResponse
+      )
+
+    log.info(s"Adding $userId to $groupId")
+    pipeline(Put(s"$keyCloakUrl/users/$userId/groups/$groupId"))
+  }
+}
+
+
+trait KeyCloakUserParserProtocol extends DefaultJsonProtocol with SprayJsonSupport {
+  implicit val keyCloakUserFormat: RootJsonFormat[KeyCloakUser] = jsonFormat12(KeyCloakUser)
+  implicit val keyCloakGroupFormat: RootJsonFormat[KeyCloakGroup] = jsonFormat4(KeyCloakGroup)
+}
+
+
+object KeyCloakUserParserProtocol extends KeyCloakUserParserProtocol
+
+

--- a/server/src/main/scala/services/ApiService.scala
+++ b/server/src/main/scala/services/ApiService.scala
@@ -6,6 +6,7 @@ import akka.util.Timeout
 import controllers.{FixedPointPersistence, ShiftPersistence, StaffMovementsPersistence}
 import drt.shared.CrunchApi._
 import drt.shared.FlightsApi.TerminalName
+import drt.shared.KeyCloakApi.KeyCloakUser
 import drt.shared._
 import org.slf4j.{Logger, LoggerFactory}
 import play.api.mvc.{Headers, Session}
@@ -99,5 +100,9 @@ abstract class ApiService(val airportConfig: AirportConfig,
   def isLoggedIn(): Boolean
 
   def getFeedStatuses(): Future[Seq[FeedStatuses]]
+
+  def getKeyCloakUsers() : Future[List[KeyCloakUser]]
+
+  def addUserToGroup(userId: String, groupName: String): Unit
 }
 

--- a/server/src/main/scala/test/MockRoles.scala
+++ b/server/src/main/scala/test/MockRoles.scala
@@ -33,11 +33,10 @@ object MockRoles {
 
 case class MockRoles(roles: List[String])
 
-object TestUserRoleProvider  {
-  val log: Logger = LoggerFactory.getLogger(getClass)
+object TestUserRoleProvider extends UserRoleProviderLike {
 
   def getRoles(config: Configuration, headers: Headers, session: Session): List[String] = {
-    log.info(s"Using MockRoles with $session")
-    MockRoles(session)
+    log.info(s"Using MockRoles with $session and $headers")
+    MockRoles(session) ::: userRolesFromHeader(headers)
   }
 }

--- a/server/src/main/scala/test/TestDrtSystem.scala
+++ b/server/src/main/scala/test/TestDrtSystem.scala
@@ -38,10 +38,7 @@ class TestDrtSystem(override val actorSystem: ActorSystem, override val config: 
 
   override def liveArrivalsSource(portCode: String): Source[ArrivalsFeedResponse, Cancellable] = testFeed
 
-  override def getRoles(config: Configuration, headers: Headers, session: Session): List[String] = {
-    log.info(s"Using MockRoles with $session")
-    MockRoles(session)
-  }
+  override def getRoles(config: Configuration, headers: Headers, session: Session): List[String] = TestUserRoleProvider.getRoles(config, headers, session)
 
   override def run(): Unit = {
 

--- a/server/src/test/scala/drt/users/KeyCloakApiSpec.scala
+++ b/server/src/test/scala/drt/users/KeyCloakApiSpec.scala
@@ -1,0 +1,235 @@
+package drt.users
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
+import drt.shared.KeyCloakApi.{KeyCloakGroup, KeyCloakUser}
+import drt.users.KeyCloakUserParserProtocol._
+import org.specs2.mutable.SpecificationLike
+import spray.http.{HttpMethods, _}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+class KeyCloakApiSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.empty())) with SpecificationLike {
+
+  val keyCloakUrl = "https://keycloak"
+
+  val usersJson =
+    """[{
+      |        "id": "id_string1",
+      |        "createdTimestamp": 1516283371483,
+      |        "username": "test1@digital.homeoffice.gov.uk",
+      |        "enabled": true,
+      |        "totp": false,
+      |        "emailVerified": true,
+      |        "firstName": "Man",
+      |        "lastName": "One",
+      |        "email": "test1@digital.homeoffice.gov.uk",
+      |        "disableableCredentialTypes": [
+      |            "password"
+      |        ],
+      |        "requiredActions": [],
+      |        "notBefore": 0,
+      |        "access": {
+      |            "manageGroupMembership": true,
+      |            "view": true,
+      |            "mapRoles": true,
+      |            "impersonate": true,
+      |            "manage": true
+      |        }
+      |    },
+      |    {
+      |        "id": "id_string2",
+      |        "createdTimestamp": 1516967531289,
+      |        "username": "test2@homeoffice.gsi.gov.uk",
+      |        "enabled": true,
+      |        "totp": false,
+      |        "emailVerified": true,
+      |        "firstName": "Man",
+      |        "lastName": "Two",
+      |        "email": "test2@digital.homeoffice.gov.uk",
+      |        "disableableCredentialTypes": [
+      |            "password"
+      |        ],
+      |        "requiredActions": [],
+      |        "notBefore": 0,
+      |        "access": {
+      |            "manageGroupMembership": true,
+      |            "view": true,
+      |            "mapRoles": true,
+      |            "impersonate": true,
+      |            "manage": true
+      |        }
+      |    }]""".stripMargin
+
+  private val user1 = KeyCloakUser(
+    "id_string1",
+    1516283371483L,
+    "test1@digital.homeoffice.gov.uk",
+    true,
+    false,
+    true,
+    "Man",
+    "One",
+    "test1@digital.homeoffice.gov.uk",
+    List("password"),
+    List(),
+    0
+  )
+  private val user2 = KeyCloakUser(
+    "id_string2",
+    1516967531289L,
+    "test2@homeoffice.gsi.gov.uk",
+    true,
+    false,
+    true,
+    "Man",
+    "Two",
+    "test2@digital.homeoffice.gov.uk",
+    List("password"),
+    List(),
+    0
+  )
+  val expectedUsers = List(
+    user1,
+    user2
+  )
+  "When parsing a JSON list of users from key cloak I should get back a list of KeyCloakUsers" >> {
+
+    import spray.json._
+
+    val result = usersJson.parseJson.convertTo[List[KeyCloakUser]]
+    result == expectedUsers
+  }
+
+  "When querying the keycloak API to get a list of all users " +
+    "Given an auth token then I should get back a list of users" >> {
+
+    val token = "testToken"
+    val kc = new KeyCloakClient(token, keyCloakUrl, system) {
+      def sendAndReceive: (HttpRequest) => Future[HttpResponse] = (req: HttpRequest) => {
+
+        Future(HttpResponse().withEntity(HttpEntity(ContentTypes.`application/json`, usersJson)))
+      }
+    }
+
+    val users: List[KeyCloakUser] = Await.result(kc.getUsers, 30 seconds)
+
+    users === expectedUsers
+  }
+
+
+  val groupsJson =
+    """    [{
+      |        "id": "id1",
+      |        "name": "DRT Admin User",
+      |        "path": "/DRT Admin User",
+      |        "subGroups": []
+      |    },
+      |    {
+      |        "id": "id2",
+      |        "name": "LHR",
+      |        "path": "/LHR",
+      |        "subGroups": []
+      |    }]""".stripMargin
+
+  private val lhrGroup = KeyCloakGroup("id2", "LHR", "/LHR", List())
+  val expectedGroups = List(
+    KeyCloakGroup("id1", "DRT Admin User", "/DRT Admin User", List()),
+    lhrGroup
+  )
+
+  "When parsing a JSON list of users from key cloak I should get back a list of KeyCloakUsers" >> {
+    import spray.json._
+
+    val result = usersJson.parseJson.convertTo[List[KeyCloakUser]]
+
+    result == expectedUsers
+  }
+
+  "When querying the keycloak API to get a list of all groups I should get back a list of groups" >> {
+
+    val token = "testToken"
+    val kc = new KeyCloakClient(token, keyCloakUrl, system) {
+      def sendAndReceive: (HttpRequest) => Future[HttpResponse] = (req: HttpRequest) => {
+        Future(HttpResponse().withEntity(HttpEntity(ContentTypes.`application/json`, groupsJson)))
+      }
+    }
+
+    val groups: List[KeyCloakGroup] = Await.result(kc.getGroups, 30 seconds)
+
+    groups === expectedGroups
+  }
+
+  "When querying the keycloak API to get a list of users in LHR then I should get back user2" >> {
+    val token = "testToken"
+    val kc = new KeyCloakClient(token, keyCloakUrl, system) with MockServerForUsersInGroup
+
+    val users: List[KeyCloakUser] = Await.result(kc.getUsersInGroup("LHR"), 30 seconds)
+
+    users === List(user2)
+  }
+
+  "When asking for users not in LHR I should get back user1" >> {
+    val token = "testToken"
+    val kc = new KeyCloakClient(token, keyCloakUrl, system) with MockServerForUsersInGroup
+
+    val users: List[KeyCloakUser] = Await.result(kc.getUsersNotInGroup("LHR"), 30 seconds)
+
+    users === List(user1)
+  }
+
+  "When adding a user to a group the user and group should be posted to the correct keycloak endpoint" >> {
+    val token = "testToken"
+    val kc = new KeyCloakClient(token, keyCloakUrl, system) with MockServerForUsersInGroup
+
+    val res: HttpResponse = Await.result(kc.addUserToGroup(user1.id, lhrGroup.id), 30 seconds)
+
+    res.status === StatusCodes.NoContent
+  }
+
+  val lhrUsers = """
+    | [{
+    |        "id": "id_string2",
+    |        "createdTimestamp": 1516967531289,
+    |        "username": "test2@homeoffice.gsi.gov.uk",
+    |        "enabled": true,
+    |        "totp": false,
+    |        "emailVerified": true,
+    |        "firstName": "Man",
+    |        "lastName": "Two",
+    |        "email": "test2@digital.homeoffice.gov.uk",
+    |        "disableableCredentialTypes": [
+    |            "password"
+    |        ],
+    |        "requiredActions": [],
+    |        "notBefore": 0,
+    |        "access": {
+    |            "manageGroupMembership": true,
+    |            "view": true,
+    |            "mapRoles": true,
+    |            "impersonate": true,
+    |            "manage": true
+    |        }
+    |  }]
+  """.stripMargin
+
+  trait MockServerForUsersInGroup {
+
+    def sendAndReceive: (HttpRequest) => Future[HttpResponse] = (req: HttpRequest) => {
+      req.uri.toString.replace(keyCloakUrl, "") match {
+        case "/groups/id2/members" =>
+          Future(HttpResponse().withEntity(HttpEntity(ContentTypes.`application/json`, lhrUsers)))
+        case "/groups" =>
+          Future(HttpResponse().withEntity(HttpEntity(ContentTypes.`application/json`, groupsJson)))
+        case "/users" =>
+          Future(HttpResponse().withEntity(HttpEntity(ContentTypes.`application/json`, usersJson)))
+        case "/users/id_string1/groups/id2" =>
+          assert(req.method == HttpMethods.PUT)
+          Future(HttpResponse(StatusCodes.NoContent))
+      }
+    }
+  }
+}

--- a/shared/src/main/scala/drt/shared/Api.scala
+++ b/shared/src/main/scala/drt/shared/Api.scala
@@ -2,6 +2,7 @@ package drt.shared
 
 import drt.shared.CrunchApi._
 import drt.shared.FlightsApi.{QueueName, _}
+import drt.shared.KeyCloakApi.KeyCloakUser
 import drt.shared.SplitRatiosNs.SplitSources
 
 import scala.concurrent.Future
@@ -627,6 +628,10 @@ trait Api {
   def isLoggedIn(): Boolean
 
   def getFeedStatuses(): Future[Seq[FeedStatuses]]
+
+  def getKeyCloakUsers(): Future[List[KeyCloakUser]]
+
+  def addUserToGroup(userId: String, groupName: String): Unit
 }
 
 object ApiSplitsToSplitRatio {

--- a/shared/src/main/scala/drt/shared/KeyCloakApi.scala
+++ b/shared/src/main/scala/drt/shared/KeyCloakApi.scala
@@ -1,0 +1,26 @@
+package drt.shared
+
+object KeyCloakApi {
+
+  case class KeyCloakUser(
+                           id: String,
+                           createdTimestamp: Long,
+                           username: String,
+                           enabled: Boolean,
+                           totp: Boolean,
+                           emailVerified: Boolean,
+                           firstName: String,
+                           lastName: String,
+                           email: String,
+                           disableableCredentialTypes: Seq[String],
+                           requiredActions: Seq[String],
+                           notBefore: Int
+                         )
+
+  case class KeyCloakGroup(
+                            id: String,
+                            name: String,
+                            path: String,
+                            subGroups: List[String]
+                          )
+}


### PR DESCRIPTION
 - Connect to Keycloak API to get all users for realm
 - Display users who are not in "Approved" key cloak group
 - add "Approve" action to add key cloak users to the Approved group
 - Only allow users with "manage-users" role to approve user