### PR TITLE
Drt 5178 improve api feed test coverage

### DIFF
--- a/server/src/main/scala/actors/VoyageManifestsActor.scala
+++ b/server/src/main/scala/actors/VoyageManifestsActor.scala
@@ -93,9 +93,9 @@ class VoyageManifestsActor(now: () => SDateLike, expireAfterMillis: Long, snapsh
 
       if (updates.nonEmpty) persistManifests(updates) else log.info(s"No new manifests to persist")
 
-      state = VoyageManifestState(manifests = updatedManifests,latestZipFilename = updatedLZF,feedName = name,maybeFeedStatuses = Option(state.addStatus(newStatus)))
-
       if (updatedLZF != state.latestZipFilename) persistLastSeenFileName(updatedLZF)
+
+      state = VoyageManifestState(manifests = updatedManifests,latestZipFilename = updatedLZF,feedName = name,maybeFeedStatuses = Option(state.addStatus(newStatus)))
 
       snapshotIfRequired(state)
       persistFeedStatus(newStatus)

--- a/server/src/main/scala/drt/server/feeds/api/S3ApiProvider.scala
+++ b/server/src/main/scala/drt/server/feeds/api/S3ApiProvider.scala
@@ -1,0 +1,91 @@
+package drt.server.feeds.api
+
+import java.io.InputStream
+import java.nio.charset.StandardCharsets.UTF_8
+import java.util.zip.ZipInputStream
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Sink, Source, StreamConverters}
+import akka.util.ByteString
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.mfglabs.commons.aws.s3.{AmazonS3AsyncClient, S3StreamBuilder}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.immutable.Seq
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.matching.Regex
+
+case class S3ApiProvider(bucketName: String)(implicit actorSystem: ActorSystem, materializer: Materializer) {
+  val log: Logger = LoggerFactory.getLogger(getClass)
+  val dqRegex: Regex = "(drt_dq_[0-9]{6}_[0-9]{6})(_[0-9]{4}\\.zip)".r
+
+  def manifestsFuture(latestFile: String): Future[Seq[(String, String)]] = {
+    log.info(s"Requesting DQ zip files > ${latestFile.take(20)}")
+    zipFiles(latestFile)
+      .mapAsync(64) { filename =>
+        log.info(s"Fetching $filename")
+        val zipByteStream = S3StreamBuilder(s3Client).getFileAsStream(bucketName, filename)
+        Future(fileNameAndContentFromZip(filename, zipByteStream))
+      }
+      .map {
+        case (zipFileName, maybeManifests) => maybeManifests.map(content => (zipFileName, content))
+      }
+      .mapConcat(identity)
+      .runWith(Sink.seq[(String, String)])
+  }
+
+  def zipFiles(latestFile: String): Source[String, NotUsed] = {
+    filterToFilesNewerThan(filesAsSource, latestFile)
+  }
+
+  def fileNameAndContentFromZip[X](zipFileName: String,
+                                   zippedFileByteStream: Source[ByteString, X]): (String, List[String]) = {
+    val inputStream: InputStream = zippedFileByteStream.runWith(
+      StreamConverters.asInputStream()
+    )
+    val zipInputStream = new ZipInputStream(inputStream)
+
+    val jsonContents = Stream
+      .continually(zipInputStream.getNextEntry)
+      .takeWhile(_ != null)
+      .map { _ =>
+        val buffer = new Array[Byte](4096)
+        val stringBuffer = new ArrayBuffer[Byte]()
+        var len: Int = zipInputStream.read(buffer)
+
+        while (len > 0) {
+          stringBuffer ++= buffer.take(len)
+          len = zipInputStream.read(buffer)
+        }
+        new String(stringBuffer.toArray, UTF_8)
+      }
+
+    (zipFileName, jsonContents.toList)
+  }
+
+  def filterToFilesNewerThan(filesSource: Source[String, NotUsed], latestFile: String): Source[String, NotUsed] = {
+    val filterFrom: String = filterFromFileName(latestFile)
+    filesSource.filter(fn => fn >= filterFrom && fn != latestFile)
+  }
+
+  def filterFromFileName(latestFile: String): String = {
+    latestFile match {
+      case dqRegex(dateTime, _) => dateTime
+      case _ => latestFile
+    }
+  }
+
+  def filesAsSource: Source[String, NotUsed] = {
+    S3StreamBuilder(s3Client)
+      .listFilesAsStream(bucketName)
+      .map {
+        case (filename, _) => filename
+      }
+  }
+
+  def s3Client: AmazonS3AsyncClient = new AmazonS3AsyncClient(new ProfileCredentialsProvider("drt-prod-s3"))
+}

--- a/server/src/main/scala/services/graphstages/VoyageManifestsGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/VoyageManifestsGraphStage.scala
@@ -3,7 +3,7 @@ package services.graphstages
 import akka.actor.ActorSystem
 import akka.stream._
 import akka.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
-import drt.server.feeds.api.S3ApiProvider
+import drt.server.feeds.api.{ApiProviderLike, S3ApiProvider}
 import drt.shared.CrunchApi.MillisSinceEpoch
 import drt.shared.DqEventCodes
 import org.slf4j.{Logger, LoggerFactory}
@@ -33,7 +33,7 @@ case class DqManifests(lastSeenFileName: String, manifests: Set[VoyageManifest])
 }
 
 class VoyageManifestsGraphStage(portCode: String,
-                                provider: S3ApiProvider,
+                                provider: ApiProviderLike,
                                 initialLastSeenFileName: String,
                                 minCheckIntervalMillis: MillisSinceEpoch = 30000)
                                (implicit actorSystem: ActorSystem,
@@ -94,6 +94,7 @@ class VoyageManifestsGraphStage(portCode: String,
         val (latestFileName, fetchedManifests) = if (fetchedFilesAndManifests.nonEmpty) {
           val lastSeen = fetchedFilesAndManifests.map { case (fileName, _) => fileName }.max
           val manifests = fetchedFilesAndManifests.map { case (_, manifest) => jsonStringToManifest(manifest) }.toSet
+          log.info(s"Got ${manifests.size} manifests")
           (lastSeen, manifests)
         }
         else (startingFileName, Set[Option[VoyageManifest]]())

--- a/server/src/main/scala/services/graphstages/VoyageManifestsGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/VoyageManifestsGraphStage.scala
@@ -1,17 +1,9 @@
 package services.graphstages
 
-import java.io.InputStream
-import java.nio.charset.StandardCharsets.UTF_8
-import java.util.zip.ZipInputStream
-
-import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.stream.scaladsl.{Sink, Source, StreamConverters}
-import akka.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
 import akka.stream._
-import akka.util.ByteString
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.mfglabs.commons.aws.s3.{AmazonS3AsyncClient, S3StreamBuilder}
+import akka.stream.stage.{GraphStage, GraphStageLogic, OutHandler}
+import drt.server.feeds.api.S3ApiProvider
 import drt.shared.CrunchApi.MillisSinceEpoch
 import drt.shared.DqEventCodes
 import org.slf4j.{Logger, LoggerFactory}
@@ -20,11 +12,9 @@ import passengersplits.parsing.VoyageManifestParser.VoyageManifest
 import server.feeds.{ManifestsFeedFailure, ManifestsFeedResponse, ManifestsFeedSuccess}
 import services.SDate
 
-import scala.collection.immutable.Seq
-import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
 import scala.util.matching.Regex
 import scala.util.{Failure, Success, Try}
@@ -42,8 +32,8 @@ case class DqManifests(lastSeenFileName: String, manifests: Set[VoyageManifest])
   }
 }
 
-class VoyageManifestsGraphStage(bucketName: String,
-                                portCode: String,
+class VoyageManifestsGraphStage(portCode: String,
+                                provider: S3ApiProvider,
                                 initialLastSeenFileName: String,
                                 minCheckIntervalMillis: MillisSinceEpoch = 30000)
                                (implicit actorSystem: ActorSystem,
@@ -98,15 +88,16 @@ class VoyageManifestsGraphStage(bucketName: String,
 
   def fetchNewManifests(startingFileName: String): ManifestsFeedResponse = {
     log.info(s"Fetching manifests from files newer than $startingFileName")
-    val eventualFileNameAndManifests = manifestsFuture(startingFileName)
+    val eventualFileNameAndManifests = provider
+      .manifestsFuture(startingFileName)
       .map(fetchedFilesAndManifests => {
-        val (latestFileName, fetchedManifests) = if (fetchedFilesAndManifests.isEmpty) {
-          (startingFileName, Set[Option[VoyageManifest]]())
-        } else {
+        val (latestFileName, fetchedManifests) = if (fetchedFilesAndManifests.nonEmpty) {
           val lastSeen = fetchedFilesAndManifests.map { case (fileName, _) => fileName }.max
-          val manifests = fetchedFilesAndManifests.map { case (_, manifest) => manifest }.toSet
+          val manifests = fetchedFilesAndManifests.map { case (_, manifest) => jsonStringToManifest(manifest) }.toSet
           (lastSeen, manifests)
         }
+        else (startingFileName, Set[Option[VoyageManifest]]())
+
         (latestFileName, fetchedManifests)
       })
 
@@ -123,78 +114,17 @@ class VoyageManifestsGraphStage(bucketName: String,
     }
   }
 
-  def manifestsFuture(latestFile: String): Future[Seq[(String, Option[VoyageManifest])]] = {
-    log.info(s"Requesting DQ zip files > ${latestFile.take(20)}")
-    zipFiles(latestFile)
-      .mapAsync(64) { filename =>
-        log.info(s"Fetching $filename")
-        val zipByteStream = S3StreamBuilder(s3Client).getFileAsStream(bucketName, filename)
-        Future(fileNameAndContentFromZip(filename, zipByteStream, portCode, None))
-      }
-      .mapConcat(identity)
-      .runWith(Sink.seq[(String, Option[VoyageManifest])])
-  }
-
-  def zipFiles(latestFile: String): Source[String, NotUsed] = {
-    filterToFilesNewerThan(filesAsSource, latestFile)
-  }
-
-  def fileNameAndContentFromZip[X](zipFileName: String,
-                                   zippedFileByteStream: Source[ByteString, X],
-                                   port: String,
-                                   maybeAirlines: Option[List[String]]): List[(String, Option[VoyageManifest])] = {
-    val inputStream: InputStream = zippedFileByteStream.runWith(
-      StreamConverters.asInputStream()
-    )
-    val zipInputStream = new ZipInputStream(inputStream)
-    val zipFilesAndMaybeManifests = Stream
-      .continually(zipInputStream.getNextEntry)
-      .takeWhile(_ != null)
-      .map { _ =>
-        val buffer = new Array[Byte](4096)
-        val stringBuffer = new ArrayBuffer[Byte]()
-        var len: Int = zipInputStream.read(buffer)
-
-        while (len > 0) {
-          stringBuffer ++= buffer.take(len)
-          len = zipInputStream.read(buffer)
+  def jsonStringToManifest(content: String): Option[VoyageManifest] = {
+    VoyageManifestParser.parseVoyagePassengerInfo(content) match {
+      case Success(m) =>
+        if (m.EventCode == DqEventCodes.DepartureConfirmed && m.ArrivalPortCode == portCode) {
+          log.info(s"Using ${m.EventCode} manifest for ${m.ArrivalPortCode} arrival ${m.flightCode}")
+          Option(m)
         }
-        val content: String = new String(stringBuffer.toArray, UTF_8)
-        VoyageManifestParser.parseVoyagePassengerInfo(content) match {
-          case Success(m) =>
-            if (m.EventCode == DqEventCodes.DepartureConfirmed && m.ArrivalPortCode == port) {
-              log.info(s"Using ${m.EventCode} manifest for ${m.ArrivalPortCode} arrival ${m.flightCode}")
-              (zipFileName, Option(m))
-            } else (zipFileName, None)
-        }
-      }
-      .toList
-
-    val relevantCount = zipFilesAndMaybeManifests.count { case (_, maybeVm) => maybeVm.isDefined }
-    log.info(s"$relevantCount relevant manifests out of ${zipFilesAndMaybeManifests.length} received in $zipFileName")
-
-    zipFilesAndMaybeManifests
-  }
-
-  def filterToFilesNewerThan(filesSource: Source[String, NotUsed], latestFile: String): Source[String, NotUsed] = {
-    val filterFrom: String = filterFromFileName(latestFile)
-    filesSource.filter(fn => fn >= filterFrom && fn != latestFile)
-  }
-
-  def filterFromFileName(latestFile: String): String = {
-    latestFile match {
-      case dqRegex(dateTime, _) => dateTime
-      case _ => latestFile
+        else None
+      case Failure(t) =>
+        log.error(s"Failed to parse voyage manifest json", t)
+        None
     }
   }
-
-  def filesAsSource: Source[String, NotUsed] = {
-    S3StreamBuilder(s3Client)
-      .listFilesAsStream(bucketName)
-      .map {
-        case (filename, _) => filename
-      }
-  }
-
-  def s3Client: AmazonS3AsyncClient = new AmazonS3AsyncClient(new ProfileCredentialsProvider("drt-prod-s3"))
 }

--- a/server/src/test/scala/services/crunch/ApplicationRestartSpec.scala
+++ b/server/src/test/scala/services/crunch/ApplicationRestartSpec.scala
@@ -53,7 +53,7 @@ class ApplicationRestartSpec extends CrunchTestLike {
 
     offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(Seq(arrivalLive)), SDate.now()))
 
-    crunch.liveTestProbe.expectNoMsg(250 milliseconds)
+    crunch.liveTestProbe.expectNoMessage(250 milliseconds)
 
     true
   }
@@ -108,7 +108,7 @@ class ApplicationRestartSpec extends CrunchTestLike {
 
     offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(Seq(arrivalDay1.copy(Estimated = Some(SDate("2018-01-01T00:05").millisSinceEpoch)))), SDate.now()))
 
-    crunch.forecastTestProbe.expectNoMsg(250 milliseconds)
+    crunch.forecastTestProbe.expectNoMessage(250 milliseconds)
 
     true
   }

--- a/server/src/test/scala/services/crunch/ForecastCrunchSpec.scala
+++ b/server/src/test/scala/services/crunch/ForecastCrunchSpec.scala
@@ -208,7 +208,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
     val crunch = runCrunchGraph(now = () => SDate(forecastScheduled).addDays(-1))
 
     offerAndWait(crunch.forecastArrivalsInput, ArrivalsFeedSuccess(forecastArrivals))
-    crunch.forecastTestProbe.expectNoMsg(1 seconds)
+    crunch.forecastTestProbe.expectNoMessage(1 seconds)
 
     true
   }

--- a/server/src/test/scala/services/crunch/VoyageManifestsGraphStageSpec.scala
+++ b/server/src/test/scala/services/crunch/VoyageManifestsGraphStageSpec.scala
@@ -1,0 +1,143 @@
+package services.crunch
+
+import java.io.InputStream
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{GraphDSL, RunnableGraph, Sink}
+import akka.stream.{ActorMaterializer, ClosedShape, Materializer}
+import akka.testkit.{TestKit, TestProbe}
+import drt.server.feeds.api.ApiProviderLike
+import org.slf4j.{Logger, LoggerFactory}
+import org.specs2.mutable.SpecificationLike
+import passengersplits.AkkaPersistTestConfig
+import server.feeds.ManifestsFeedSuccess
+import services.graphstages.VoyageManifestsGraphStage
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class TestApiProvider() extends ApiProviderLike {
+  val log: Logger = LoggerFactory.getLogger(getClass)
+  var contentToPush: Seq[(String, String)] = Seq()
+
+  override def manifestsFuture(latestFile: String): Future[Seq[(String, String)]] = {
+    contentToPush match {
+      case content if content.isEmpty =>
+        log.info("No json to push")
+        Future(Seq())
+
+      case content =>
+        contentToPush = Seq()
+        Future(content)
+    }
+  }
+
+  def enqueueContent(content: Seq[(String, String)]): Unit = {
+    contentToPush = content
+  }
+
+  def jsonContentStnDc: String = {
+    val jsonInputStream: InputStream = getClass.getClassLoader.getResourceAsStream("s3content/unzippedtest/drt_dq_160617_165737_5153/drt_160302_060000_FR3631_DC_4089.json")
+
+    scala.io.Source.fromInputStream(jsonInputStream).getLines().mkString("\n")
+  }
+
+  def jsonContentStnCi: String = {
+    val jsonInputStream: InputStream = getClass.getClassLoader.getResourceAsStream("s3content/unzippedtest/drt_dq_160617_165737_5153/drt_160302_092500_FR4542_CI_6033.json")
+
+    scala.io.Source.fromInputStream(jsonInputStream).getLines().mkString("\n")
+  }
+
+  def jsonContentNonStn: String = {
+    val jsonInputStream: InputStream = getClass.getClassLoader.getResourceAsStream("s3content/unzippedtest/drt_dq_160617_165737_5153/drt_160302_061500_BA8450_DC_5123.json")
+
+    scala.io.Source.fromInputStream(jsonInputStream).getLines().mkString("\n")
+  }
+}
+
+class VoyageManifestsGraphStageSpec extends TestKit(ActorSystem("VoyageManifestsGraphStageSpec", AkkaPersistTestConfig.inMemoryAkkaPersistConfig))
+  with SpecificationLike {
+
+  implicit val actorSystem: ActorSystem = system
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+
+  "Given a manifests stage with a test provider " +
+    "When I give the test provider a manifest " +
+    "Then I should observe that manifest and its zip file name in the stage's output" >> {
+    val provider = new TestApiProvider()
+    provider.enqueueContent(Seq(("someZip_1234", provider.jsonContentStnDc)))
+
+    val probe = TestProbe()
+
+    val stage: RunnableGraph[NotUsed] = TestableVoyageManifestsGraphStage(probe, "STN", provider)
+
+    stage.run()
+
+    val lastSeenAndManifests = probe
+      .receiveN(1, 5 seconds)
+      .map {
+        case ManifestsFeedSuccess(manifests, _) => (manifests.lastSeenFileName, manifests.manifests.size)
+      }
+      .toList
+
+    val expected = List(("someZip_1234", 1))
+
+    lastSeenAndManifests === expected
+  }
+
+  "Given a manifests stage with a test provider " +
+    "When I give the test provider 3 manifests from different zip files " +
+    "Then I should observe 3 manifests with the latest zip file name in the stage's output" >> {
+    val provider = new TestApiProvider()
+    val zipFileNamesAndManifests = Seq(
+      ("someZip_1234", provider.jsonContentNonStn),
+      ("someZip_4444", provider.jsonContentStnCi),
+      ("someZip_0101", provider.jsonContentStnDc)
+    )
+
+    provider.enqueueContent(zipFileNamesAndManifests)
+
+    val probe = TestProbe()
+
+    val stage: RunnableGraph[NotUsed] = TestableVoyageManifestsGraphStage(probe, "STN", provider)
+
+    stage.run()
+
+    val lastSeenAndManifestCount = probe
+      .receiveN(1, 5 seconds)
+      .map {
+        case ManifestsFeedSuccess(manifests, _) => (manifests.lastSeenFileName, manifests.manifests.size)
+      }
+      .toList
+
+    val expectedManifestCount = 1
+    val expected = List(("someZip_4444", expectedManifestCount))
+
+    lastSeenAndManifestCount === expected
+  }
+}
+
+object TestableVoyageManifestsGraphStage {
+  val oneDayMillis: Int = 60 * 60 * 24 * 1000
+
+  def apply(testProbe: TestProbe, portCode: String, provider: ApiProviderLike)(implicit system: ActorSystem, materializer: Materializer): RunnableGraph[NotUsed] = {
+    val workloadStage = new VoyageManifestsGraphStage(portCode, provider, "", 30000)
+
+    import akka.stream.scaladsl.GraphDSL.Implicits._
+
+    val graph = GraphDSL.create() {
+
+      implicit builder =>
+        val workload = builder.add(workloadStage.async)
+        val sink = builder.add(Sink.actorRef(testProbe.ref, "complete"))
+
+        workload ~> sink
+
+        ClosedShape
+    }
+
+    RunnableGraph.fromGraph(graph)
+  }
+}

--- a/server/src/test/scala/services/crunch/WorkloadGraphStageSpec.scala
+++ b/server/src/test/scala/services/crunch/WorkloadGraphStageSpec.scala
@@ -23,8 +23,8 @@ object TestableWorkloadStage {
   def apply(testProbe: TestProbe,
             now: () => SDateLike,
             airportConfig: AirportConfig,
-            workloadStart: (SDateLike) => SDateLike,
-            workloadEnd: (SDateLike) => SDateLike,
+            workloadStart: SDateLike => SDateLike,
+            workloadEnd: SDateLike => SDateLike,
             earliestAndLatestAffectedPcpTime: (Set[ApiFlightWithSplits], Set[ApiFlightWithSplits]) => Option[(SDateLike, SDateLike)]
            ): RunnableGraph[SourceQueueWithComplete[FlightsWithSplits]] = {
     val workloadStage = new WorkloadGraphStage(
@@ -44,7 +44,7 @@ object TestableWorkloadStage {
     val graph = GraphDSL.create(flightsWithSplitsSource.async) {
 
       implicit builder =>
-        (flights) =>
+        flights =>
           val workload = builder.add(workloadStage.async)
           val sink = builder.add(Sink.actorRef(testProbe.ref, "complete"))
 


### PR DESCRIPTION
- Factor out the API data provider from the manifest stage to make the stage testable
- Add missing failure case for manifest parser
- Unrelated... only purge expired arrivals when they're merged rather than beforehand too - reduces server load on startup