### PR TITLE
DRT-5179 - LGW: Add transits and transfers.

### DIFF
--- a/server/src/main/scala/drt/server/feeds/lgw/ResponseToArrivals.scala
+++ b/server/src/main/scala/drt/server/feeds/lgw/ResponseToArrivals.scala
@@ -9,6 +9,7 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.util.{Failure, Success, Try}
 import scala.xml.Node
 import scala.language.postfixOps
+import scalaz.Scalaz._
 
 case class ResponseToArrivals(data: Array[Byte], locationOption: Option[String] ) {
   val log: Logger = LoggerFactory.getLogger(getClass)
@@ -38,7 +39,10 @@ case class ResponseToArrivals(data: Array[Byte], locationOption: Option[String] 
 
     val operator = (n \ "AirlineIATA") text
     val actPax = parsePaxCount(n, "70A").filter(_!= 0).orElse(None)
-    val transPax = parsePaxCount(n, "TIP")
+    val transitPax = parsePaxCount(n, "TIP")
+    val transferPax = parsePaxCount(n, "TPX")
+    val transPax = transitPax |+| transferPax
+
     val arrival = new Arrival(
       Operator = if (operator.isEmpty) None else Some(operator) ,
       Status = parseStatus(n),


### PR DESCRIPTION

From the GAL documentation:

Sorting | Data Element | Description | IDAHO Field | DB Data Type | AIDX XML Field | AIDX Group
-- | -- | -- | -- | -- | -- | --
1355 | TransferPassengerCount | TransferPassengerCount | PAX_TRANSFER | number(3,0) | PaxCount:Qualifer: TPX:0000 | Cabin Class Data
1356 | TransitPassengerCount | TransitPassengerCount | PAX_TRANSIT | number(3,0) | PaxCount:Qualifer (TIP:0000) | Cabin Class Data

We currently get the TIP qualifier and not the TPX qualifier.

This PR assumes that we should add these two values together if they exist.
