### PR TITLE
DRT-5192 - Remove the GetCrunchUpdates JS error

### DIFF
--- a/client/src/main/scala/drt/client/services/handlers/CrunchUpdatesHandler.scala
+++ b/client/src/main/scala/drt/client/services/handlers/CrunchUpdatesHandler.scala
@@ -124,7 +124,7 @@ class CrunchUpdatesHandler[M](airportConfigPot: () => Pot[AirportConfig],
         log.info(s"Got CrunchUpdates with ${cu.flights.size} flights, ${cu.minutes.size} minutes")
         UpdateCrunchStateFromUpdatesAndContinuePolling(cu)
       case _ =>
-        log.info(s"Failed to GetCrunchState. Re-requesting after $crunchUpdatesRequestFrequency")
+        log.info(s"No updates. Re-requesting after $crunchUpdatesRequestFrequency")
         RetryActionAfter(GetCrunchState(), crunchUpdatesRequestFrequency)
     }.recoverWith {
       case _ =>

--- a/client/src/main/scala/drt/client/services/handlers/CrunchUpdatesHandler.scala
+++ b/client/src/main/scala/drt/client/services/handlers/CrunchUpdatesHandler.scala
@@ -124,11 +124,11 @@ class CrunchUpdatesHandler[M](airportConfigPot: () => Pot[AirportConfig],
         log.info(s"Got CrunchUpdates with ${cu.flights.size} flights, ${cu.minutes.size} minutes")
         UpdateCrunchStateFromUpdatesAndContinuePolling(cu)
       case _ =>
-        log.error(s"Failed to GetCrunchState. Re-requesting after $crunchUpdatesRequestFrequency")
+        log.info(s"Failed to GetCrunchState. Re-requesting after $crunchUpdatesRequestFrequency")
         RetryActionAfter(GetCrunchState(), crunchUpdatesRequestFrequency)
     }.recoverWith {
       case _ =>
-        log.error(s"Failed to GetCrunchState. Re-requesting after ${PollDelay.recoveryDelay}")
+        log.info(s"Failed to GetCrunchState. Re-requesting after ${PollDelay.recoveryDelay}")
         Future(RetryActionAfter(GetCrunchState(), PollDelay.recoveryDelay))
     }
   }


### PR DESCRIPTION
In production we see this JS error
``` javascript
client-opt-library.js?1027:506 Failed to GetCrunchState. Re-requesting after 2 seconds
```

This PR removes it by logging the output at info rather than at error level.
