### PR TITLE
Drt 5149 initialise manifests buffer in splits stage

### DIFF
--- a/server/src/main/scala/services/graphstages/ArrivalSplitsGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/ArrivalSplitsGraphStage.scala
@@ -265,8 +265,9 @@ class ArrivalSplitsGraphStage(name: String = "",
       val newFlightWithAvailableSplits = manifestsBuffer.get(arrivalManifestKey) match {
         case None => newFlightWithSplits
         case Some(vm) =>
-          manifestsBuffer = manifestsBuffer.filterNot { case (manifestKey, _) => manifestKey == arrivalManifestKey }
-          log.debug(s"Found buffered manifest to apply to new flight, and removed from buffer")
+          val scheduledStr = SDate(newFlightWithSplits.apiFlight.Scheduled).toISOString()
+          val iata = newFlightWithSplits.apiFlight.IATA
+          log.info(s"Found buffered manifest to apply to new flight $iata $scheduledStr, and removed from buffer")
           removeManifestsOlderThan(twoDaysAgo)
           updateFlightWithManifests(vm, newFlightWithSplits)
       }
@@ -343,7 +344,7 @@ class ArrivalSplitsGraphStage(name: String = "",
   }
 
   def nowMillis: Option[MillisSinceEpoch] = {
-    Option(SDate.now().millisSinceEpoch)
+    Option(now().millisSinceEpoch)
   }
 
   def mergeDiffSets(latestDiff: Set[ApiFlightWithSplits],
@@ -357,7 +358,7 @@ class ArrivalSplitsGraphStage(name: String = "",
   }
 
   def purgeExpiredManifests(manifests: Map[Int, Set[VoyageManifest]]): Map[Int, Set[VoyageManifest]] = {
-    val expired = hasExpiredForType((m: VoyageManifest) => m.scheduleArrivalDateTime.getOrElse(SDate.now()).millisSinceEpoch)
+    val expired = hasExpiredForType((m: VoyageManifest) => m.scheduleArrivalDateTime.getOrElse(now()).millisSinceEpoch)
     val updated = manifests
       .mapValues(_.filterNot(expired))
       .filterNot { case (_, ms) => ms.isEmpty }
@@ -387,6 +388,6 @@ class ArrivalSplitsGraphStage(name: String = "",
     }
   }
 
-  def twoDaysAgo: MillisSinceEpoch = SDate.now().millisSinceEpoch - (2 * oneDayMillis)
+  def twoDaysAgo: MillisSinceEpoch = now().millisSinceEpoch - (2 * oneDayMillis)
 }
 

--- a/server/src/test/scala/services/crunch/ArrivalSplitsStageSpec.scala
+++ b/server/src/test/scala/services/crunch/ArrivalSplitsStageSpec.scala
@@ -25,6 +25,7 @@ object TestableArrivalSplits {
     val arrivalSplitsStage = new ArrivalSplitsGraphStage(
       name = "",
       optionalInitialFlights = None,
+      optionalInitialManifests = None,
       splitsCalculator = splitsCalculator,
       groupFlightsByCodeShares = groupByCodeShares,
       expireAfterMillis = oneDayMillis,

--- a/server/src/test/scala/services/crunch/CrunchTestLike.scala
+++ b/server/src/test/scala/services/crunch/CrunchTestLike.scala
@@ -126,7 +126,7 @@ class CrunchTestLike
   def runCrunchGraph(initialBaseArrivals: Set[Arrival] = Set(),
                      initialForecastArrivals: Set[Arrival] = Set(),
                      initialLiveArrivals: Set[Arrival] = Set(),
-                     initialManifests: DqManifests = DqManifests("", Set()),
+                     maybeInitialManifestState: Option[VoyageManifestState] = None,
                      initialPortState: Option[PortState] = None,
                      airportConfig: AirportConfig = airportConfig,
                      csvSplitsProvider: SplitsProvider.SplitProvider = (_, _) => None,
@@ -192,6 +192,7 @@ class CrunchTestLike
       initialBaseArrivals = initialBaseArrivals,
       initialFcstArrivals = initialForecastArrivals,
       initialLiveArrivals = initialLiveArrivals,
+      initialManifestsState = maybeInitialManifestState,
       arrivalsBaseSource = baseArrivals,
       arrivalsFcstSource = fcstArrivals,
       arrivalsLiveSource = liveArrivals
@@ -199,7 +200,9 @@ class CrunchTestLike
 
     if (initialShifts.nonEmpty) offerAndWait(crunchInputs.shifts, initialShifts)
     if (initialFixedPoints.nonEmpty) offerAndWait(crunchInputs.fixedPoints, initialFixedPoints)
-    if (initialManifests.manifests.nonEmpty) offerAndWait(crunchInputs.manifestsResponse, ManifestsFeedSuccess(initialManifests))
+    maybeInitialManifestState.foreach(ms => {
+      if (ms.manifests.nonEmpty) offerAndWait(crunchInputs.manifestsResponse, ManifestsFeedSuccess(DqManifests("", ms.manifests)))
+    })
 
     CrunchGraphInputsAndProbes(
       crunchInputs.baseArrivalsResponse,

--- a/server/src/test/scala/services/crunch/VoyageManifestsSpec.scala
+++ b/server/src/test/scala/services/crunch/VoyageManifestsSpec.scala
@@ -291,7 +291,6 @@ class VoyageManifestsSpec extends CrunchTestLike {
         queues = Map("T1" -> Seq(EeaDesk, EGate))
       ))
 
-    //    offerAndWait(crunch.manifestsInput, inputManifests)
     offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(inputFlights))
 
     val expectedSplits = Set(


### PR DESCRIPTION
To counter the API splits going missing some time after an app restart this PR enables the initialisation of the ArrivalSplitsGraphStage with the currently known manifests so that any flights which lose them can have them added again.

It also stops manifests being removed from the stage's manifest buffer when they're matched to flights as an extra guard. Ie the stage will still have the API splits available to add to a flight if that flight's splits go missing