### PR TITLE
DRT-4661 - Don't adjust flight after chox

### DIFF
--- a/server/src/main/scala/drt/chroma/ArrivalsDiffingStage.scala
+++ b/server/src/main/scala/drt/chroma/ArrivalsDiffingStage.scala
@@ -65,7 +65,7 @@ final class ArrivalsDiffingStage(initialKnownArrivals: Seq[Arrival]) extends Gra
 
     def diff(a: Seq[Arrival], b: Seq[Arrival]): Seq[Arrival] = {
       val aSet = a.toSet
-      val bSet = b.toSet
+      val bSet = b.toSet.filterNot(arr => aSet.find(arr.uniqueId == _.uniqueId).exists(inSetA => inSetA.ActualChox.exists(arr.ActualChox.contains)))
 
       (bSet -- aSet).toList
     }

--- a/server/src/main/scala/drt/chroma/ArrivalsDiffingStage.scala
+++ b/server/src/main/scala/drt/chroma/ArrivalsDiffingStage.scala
@@ -63,11 +63,20 @@ final class ArrivalsDiffingStage(initialKnownArrivals: Seq[Arrival]) extends Gra
       }
     }
 
-    def diff(a: Seq[Arrival], b: Seq[Arrival]): Seq[Arrival] = {
-      val aSet = a.toSet
-      val bSet = b.toSet.filterNot(arr => aSet.find(arr.uniqueId == _.uniqueId).exists(inSetA => inSetA.ActualChox.exists(arr.ActualChox.contains)))
+    def diff(existingArrivalsSeq: Seq[Arrival], newArrivalsSeq: Seq[Arrival]): Seq[Arrival] = {
+      val existingArrival = existingArrivalsSeq.toSet
 
-      (bSet -- aSet).toList
+      def findTheExistingArrival(newArrival: Arrival): Option[Arrival] = existingArrival.find(newArrival.uniqueId == _.uniqueId)
+
+      def isChoxTimeTheSameInBothSets(inInitialSet: Arrival, inNewSet: Arrival): Boolean =
+        inInitialSet.ActualChox.exists(inNewSet.ActualChox.contains)
+
+      def removeArrivalsWithAnUnchangedChoxTime(newArrivalsSet: Set[Arrival]): Set[Arrival] =
+        newArrivalsSet.filterNot(newArrival => findTheExistingArrival(newArrival).exists(existingArrival => isChoxTimeTheSameInBothSets(existingArrival, newArrival)))
+
+      val newArrivals = removeArrivalsWithAnUnchangedChoxTime(newArrivalsSeq.toSet)
+
+      (newArrivals -- existingArrival).toList
     }
   }
 }

--- a/server/src/test/scala/drt/chroma/DiffingAkkaStreamSpec.scala
+++ b/server/src/test/scala/drt/chroma/DiffingAkkaStreamSpec.scala
@@ -87,7 +87,7 @@ class DiffingAkkaStreamSpec extends AkkaStreamTestKitSpecificationLike with Samp
     val date = SDate.now()
     val source = Source(Seq(
       List(flight1),
-      List(flight1.copy(ActDT = "2016-08-04T09:11:00Z"))))
+      List(flight1.copy(ActDT = "2016-08-04T09:11:00Z", ActChoxDT = "2016-08-04T04:54:00Z"))))
 
     "we really can diff it and parse it" in {
       source
@@ -102,11 +102,12 @@ class DiffingAkkaStreamSpec extends AkkaStreamTestKitSpecificationLike with Samp
             "2016-08-04T04:53:00Z", "", "207", 0, 0, 0, "24", "",
             1200980, "EDI", "FRT", "TAY025N", "3V025N", "LGG", "2016-08-04T04:35:00Z"
           )))), date))
-        .requestNext(ArrivalsFeedSuccess(Flights(StreamingChromaFlow.liveChromaToArrival(List(ChromaLiveFlight("Tnt Airways Sa", "On Chocks",
+        .requestNext(ArrivalsFeedSuccess(Flights(StreamingChromaFlow.liveChromaToArrival(List(
+          ChromaLiveFlight("Tnt Airways Sa", "On Chocks",
           "2016-08-04T04:40:00Z",
           "2016-08-04T09:11:00Z",
           "",
-          "2016-08-04T04:53:00Z", "", "207", 0, 0, 0, "24", "",
+          "2016-08-04T04:54:00Z", "", "207", 0, 0, 0, "24", "",
           1200980, "EDI", "FRT", "TAY025N", "3V025N", "LGG", "2016-08-04T04:35:00Z"
         )))), date))
         .expectComplete()

--- a/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
+++ b/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
@@ -1,0 +1,66 @@
+package services.crunch
+
+import controllers.ArrivalGenerator.apiFlight
+import drt.shared.CrunchApi.PortState
+import drt.shared.FlightsApi.Flights
+import drt.shared._
+import org.specs2.matcher.Scope
+import server.feeds.ArrivalsFeedSuccess
+import services.SDate
+import scala.concurrent.duration._
+
+class ArrivalsGraphStageSpec extends CrunchTestLike {
+  sequential
+  isolated
+
+  trait Context extends Scope {
+    val arrival_v1_with_no_chox_time: Arrival = apiFlight(flightId = Option(1), iata = "BA0001",
+      schDt = "2017-01-01T10:25Z", origin = "JFK",
+      actPax = Option(100))
+
+    val arrival_v2_with_chox_time: Arrival = arrival_v1_with_no_chox_time.copy(Stand = Some("Stand1"), ActualChox = Some(SDate("2017-01-01T10:25Z").millisSinceEpoch))
+
+    val dateNow: SDateLike = SDate("2017-01-01T00:00Z")
+
+    val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(
+      airportConfig = airportConfig.copy(terminalNames = Seq("T1")),
+      now = () => dateNow
+    )
+
+    offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(Seq(arrival_v1_with_no_chox_time))))
+    offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(Seq(arrival_v2_with_chox_time))))
+
+    var messages: Seq[Arrival] = Seq[Arrival]()
+  }
+
+  "Arrivals Graph Stage" should {
+
+    "a third arrival with an update to the chox time will change the arrival" in new Context {
+      val arrival_v3_with_an_update_to_chox_time: Arrival = arrival_v2_with_chox_time.copy(ActualChox = Some(SDate("2017-01-01T10:30Z").millisSinceEpoch), Stand = Some("I will update"))
+      offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(Seq(arrival_v3_with_an_update_to_chox_time))))
+
+      crunch.liveTestProbe.receiveWhile(5 seconds) {
+        case ps: PortState => messages = ps.flights.values.map(_.apiFlight).toSeq ++ messages
+      }
+
+      messages must be_===(Seq(arrival_v3_with_an_update_to_chox_time, arrival_v2_with_chox_time, arrival_v1_with_no_chox_time))
+
+    }
+
+    "a third arrival update with the same chox time will not update the arrival" in new Context {
+
+      val arrival_v3_with_an_update_and_same_chox_time: Arrival = arrival_v2_with_chox_time.copy(Stand = Some("Should not update"))
+
+
+      offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(Seq(arrival_v3_with_an_update_and_same_chox_time))))
+
+      crunch.liveTestProbe.receiveWhile(5 seconds) {
+        case ps: PortState => messages = ps.flights.values.map(_.apiFlight).toSeq ++ messages
+      }
+
+      messages must be_===(Seq(arrival_v2_with_chox_time, arrival_v1_with_no_chox_time))
+    }
+  }
+
+
+}


### PR DESCRIPTION
Fights will be moved after chox this data will skew our PCP arrival times. Only subsequent updates that include a change to chox time should be considered.

## Acceptance Criteria

Given a flight with no chox time
When an update to the flight comes through in the feed
Then that change should be reflected on the dashboard

Given a flight which already has a chox time
When an update to the flight comes through the feed that contains the same chox time
Then that change should NOT be reflected in the dashboard

Given a flight which already has a chox time
When an update to the flight comes through the feed that contains a different chox time
Then that change should be reflected along with all other changes in that update