### PR TITLE
DRT-5182 - wait and do a hard page refresh on acceptance tests 

### DIFF
--- a/e2e/cypress/integration/monthly-staffing.js
+++ b/e2e/cypress/integration/monthly-staffing.js
@@ -1,6 +1,11 @@
 describe('Monthly Staffing', function () {
   const today = new Date();
 
+  function waitAndHardReload(waitTime = 500) {
+      cy.wait(waitTime, {log: true});
+      cy.reload(true, {log: true, timeout: 60000});
+  }
+
   function setRoles(roles) {
     cy.request("POST", 'v2/test/live/test/mock-roles', {"roles": roles})
   }
@@ -47,18 +52,20 @@ describe('Monthly Staffing', function () {
   describe('When adding staff using the monthly staff view', function () {
 
     let cellToTest = ".htCore tbody :nth-child(1) :nth-child(2)";
-    xit("If I enter staff for the current month those staff should still be visible if I change months and change back", function () {
+    it("If I enter staff for the current month those staff should still be visible if I change months and change back", function () {
       saveShifts();
-
       setRoles(["staff:edit"]);
 
       cy.visit('/v2/test/live#terminal/T1/staffing/15///');
+      waitAndHardReload();
       cy.get(cellToTest).contains("1");
 
 
       cy.visit('/v2/test/live#terminal/T1/staffing/15/' + nextMonthDateString() +'//');
+      waitAndHardReload();
       cy.get(cellToTest).contains("2");
       cy.visit('/v2/test/live#terminal/T1/staffing/15/' + thisMonthDateString() +'//');
+      waitAndHardReload();
       cy.get(cellToTest).contains("1");
 
       resetShifts();

--- a/e2e/cypress/integration/staff-movements.js
+++ b/e2e/cypress/integration/staff-movements.js
@@ -1,7 +1,9 @@
+/// <reference types="Cypress" />
+
 describe('Staff movements', function () {
   beforeEach(function () {
     cy.request('DELETE', '/v2/test/live/test/data');
-    var schDT = new Date().toISOString().split("T")[0];
+    let schDT = new Date().toISOString().split("T")[0];
     cy.request('POST',
       '/v2/test/live/test/arrival',
       {
@@ -26,10 +28,17 @@ describe('Staff movements', function () {
         "Origin": "AMS",
         "SchDT": schDT + "T00:15:00Z"
       });
+      waitAndHardReload();
   });
+
+  function waitAndHardReload(waitTime = 500) {
+      cy.wait(waitTime, {log: true});
+      cy.reload(true, {log: true, timeout: 60000});
+  }
 
   function addMovementFor1HourAt(numStaff, hour) {
     for (let i = 0; i < numStaff; i++) {
+      waitAndHardReload();
       cy.get('.staff-adjustments > :nth-child(' + (hour + 1) + ') > :nth-child(3)').contains("+").then((el) => {
         el.click();
         cy.contains("Save").click();
@@ -38,7 +47,7 @@ describe('Staff movements', function () {
   }
 
   function staffDeployedAtRow(row) {
-    var selector = '#sticky-body > :nth-child(' + (row + 1) + ') > :nth-child(14)';
+    let selector = '#sticky-body > :nth-child(' + (row + 1) + ') > :nth-child(14)';
     return cy.get(selector);
   }
 
@@ -58,6 +67,7 @@ describe('Staff movements', function () {
   }
 
   function checkStaffNumbersOnDesksAndQueuesTabAre(numStaff) {
+    waitAndHardReload(1000);
     [0, 1, 2, 3].map((row) => {
       staffMovementsAtRow(row).contains(numStaff);
       staffDeployedAtRow(row).contains(numStaff);
@@ -101,7 +111,8 @@ describe('Staff movements', function () {
   }
 
   function choose24Hours() {
-    cy.get('#current .date-selector .date-view-picker-container').contains('24 hours').click().end();
+    cy.get('#current .date-selector .date-view-picker-container').contains('24 hours').click({force: true}).end();
+    waitAndHardReload(1000);
   }
 
   describe('When adding staff movements on the desks and queues page', function () {
@@ -118,7 +129,7 @@ describe('Staff movements', function () {
       removeXMovements(1);
     });
 
-    xit("Should update the available staff when 1 staff member is added for 1 hour twice", function () {
+    it("Should update the available staff when 1 staff member is added for 1 hour twice", function () {
       navigateToHome();
       navigateToMenuItem('T1');
       choose24Hours();

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -157,15 +157,6 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
-    "async": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
-      "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.4"
-      }
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -409,9 +400,9 @@
       }
     },
     "cypress": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.0.2.tgz",
-      "integrity": "sha512-HoP5FWj2fqtMndKC0Qnc7Xy0v55dx/PQ5uLaKIL9h505H45uFMsc+HR5Qxw24rXaUKaS3oVY5UJaVw9YA2EtLw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.0.3.tgz",
+      "integrity": "sha512-reo2M0/lKTfE/zgHeDtOjd17L+RVM0VY26GxJ7+haz1uNFKU5bytLsS0lZKC0BOYu1Hc6jZGkH+B0pzoexNU/A==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -437,13 +428,13 @@
         "executable": "4.1.1",
         "extract-zip": "1.6.6",
         "fs-extra": "4.0.1",
-        "getos": "2.8.4",
+        "getos": "3.1.0",
         "glob": "7.1.2",
         "is-ci": "1.0.10",
         "is-installed-globally": "0.1.0",
         "lazy-ass": "1.6.0",
         "listr": "0.12.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "log-symbols": "2.2.0",
         "minimist": "1.2.0",
         "progress": "1.1.8",
@@ -454,6 +445,32 @@
         "tmp": "0.0.31",
         "url": "0.11.0",
         "yauzl": "2.8.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.4.0.tgz",
+          "integrity": "sha1-SZAgDxjqW4N8LMT4wDGmmFw4VhE=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.10"
+          }
+        },
+        "getos": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.0.tgz",
+          "integrity": "sha512-i9vrxtDu5DlLVFcrbqUqGWYlZN/zZ4pGMICCAcZoYsX3JA54nYp8r5EThw5K+m2q3wszkx4Th746JstspB0H4Q==",
+          "dev": true,
+          "requires": {
+            "async": "2.4.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.10",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+          "dev": true
+        }
       }
     },
     "dashdash": {
@@ -652,15 +669,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
-    },
-    "getos": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/getos/-/getos-2.8.4.tgz",
-      "integrity": "sha1-e4YD02GcKOOMsP56T2PDrLgNUWM=",
-      "dev": true,
-      "requires": {
-        "async": "2.1.4"
-      }
     },
     "getpass": {
       "version": "0.1.7",
@@ -1051,12 +1059,6 @@
           "dev": true
         }
       }
-    },
-    "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
     },
     "lodash.once": {
       "version": "4.1.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,6 +9,6 @@
   "author": "UK Home Office",
   "license": "UNLICENSED",
   "devDependencies": {
-    "cypress": "^3.0.2"
+    "cypress": "^3.0.3"
   }
 }


### PR DESCRIPTION
To get the acceptance tests to work we need to do a hard page refresh.

This PR can be un-reverted once the app works without doing a hard refresh.

The image below shows that the acceptance tests work locally against dev.

<img width="703" alt="tests work locally against dev" src="https://user-images.githubusercontent.com/369407/43525375-826fd25e-9599-11e8-8a12-6dfc9bc52247.png">
