### PR TITLE
DRT-5182 - Resolve Failing E2E Tests

### DIFF
--- a/e2e/cypress/integration/monthly-staffing.js
+++ b/e2e/cypress/integration/monthly-staffing.js
@@ -1,15 +1,15 @@
-let moment = require('moment');
+let moment = require('moment-timezone');
+require('moment/locale/en-gb');
+moment.locale("en-gb");
 
 describe('Monthly Staffing', function () {
-  moment.locale("en_GB");
-  const today = moment();
 
   function setRoles(roles) {
     cy.request("POST", 'v2/test/live/test/mock-roles', {"roles": roles})
   }
 
   function firstMidnightOfThisMonth() {
-    return moment(today.year().toString()+'-'+(today.month()+1).toString() + "-01");
+    return moment().tz('Europe/London').startOf('month');
   }
 
   function firstMidnightOfNextMonth() {
@@ -34,13 +34,11 @@ describe('Monthly Staffing', function () {
   }
 
   function thisMonthDateString() {
-    return today.toISOString().split("T")[0];
+    return moment().toISOString().split("T")[0];
   }
 
   function nextMonthDateString() {
-    let year = today.year();
-    let month = (today.month()+1)%12 + 1;
-    return new Date(year, month, 1, 0, 0).toISOString().split("T")[0];
+    return moment().add(1, 'M').toISOString().split("T")[0];
   }
 
   describe('When adding staff using the monthly staff view', function () {
@@ -53,7 +51,6 @@ describe('Monthly Staffing', function () {
 
       cy.visit('/v2/test/live#terminal/T1/staffing/15///');
       cy.get(cellToTest).contains("1");
-
 
       cy.visit('/v2/test/live#terminal/T1/staffing/15/' + nextMonthDateString() +'//');
       cy.get(cellToTest).contains("2");

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -158,12 +158,12 @@
       "dev": true
     },
     "async": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
-      "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.4.0.tgz",
+      "integrity": "sha1-SZAgDxjqW4N8LMT4wDGmmFw4VhE=",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4"
+        "lodash": "4.17.10"
       }
     },
     "asynckit": {
@@ -409,9 +409,9 @@
       }
     },
     "cypress": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.0.2.tgz",
-      "integrity": "sha512-HoP5FWj2fqtMndKC0Qnc7Xy0v55dx/PQ5uLaKIL9h505H45uFMsc+HR5Qxw24rXaUKaS3oVY5UJaVw9YA2EtLw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.0.3.tgz",
+      "integrity": "sha512-reo2M0/lKTfE/zgHeDtOjd17L+RVM0VY26GxJ7+haz1uNFKU5bytLsS0lZKC0BOYu1Hc6jZGkH+B0pzoexNU/A==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -437,13 +437,13 @@
         "executable": "4.1.1",
         "extract-zip": "1.6.6",
         "fs-extra": "4.0.1",
-        "getos": "2.8.4",
+        "getos": "3.1.0",
         "glob": "7.1.2",
         "is-ci": "1.0.10",
         "is-installed-globally": "0.1.0",
         "lazy-ass": "1.6.0",
         "listr": "0.12.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.10",
         "log-symbols": "2.2.0",
         "minimist": "1.2.0",
         "progress": "1.1.8",
@@ -487,13 +487,14 @@
       "dev": true
     },
     "ecc-jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "elegant-spinner": {
@@ -539,9 +540,9 @@
       "dev": true
     },
     "extend": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true
     },
     "extract-zip": {
@@ -627,7 +628,7 @@
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "2.1.19"
       }
     },
     "fs-extra": {
@@ -654,12 +655,12 @@
       "dev": true
     },
     "getos": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/getos/-/getos-2.8.4.tgz",
-      "integrity": "sha1-e4YD02GcKOOMsP56T2PDrLgNUWM=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/getos/-/getos-3.1.0.tgz",
+      "integrity": "sha512-i9vrxtDu5DlLVFcrbqUqGWYlZN/zZ4pGMICCAcZoYsX3JA54nYp8r5EThw5K+m2q3wszkx4Th746JstspB0H4Q==",
       "dev": true,
       "requires": {
-        "async": "2.1.4"
+        "async": "2.4.0"
       }
     },
     "getpass": {
@@ -1053,9 +1054,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
     },
     "lodash.once": {
@@ -1084,18 +1085,18 @@
       }
     },
     "mime-db": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "version": "1.35.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
+      "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
+      "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
       "dev": true,
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "1.35.0"
       }
     },
     "minimatch": {
@@ -1135,6 +1136,15 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
       "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
       "dev": true
+    },
+    "moment-timezone": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.21.tgz",
+      "integrity": "sha512-j96bAh4otsgj3lKydm3K7kdtA3iKf2m6MY2iSYCzCm5a1zmHo1g+aK3068dDEeocLZQIS9kU8bsdQHLqEvgW0A==",
+      "dev": true,
+      "requires": {
+        "moment": "2.22.2"
+      }
     },
     "ms": {
       "version": "2.0.0",
@@ -1359,7 +1369,7 @@
         "aws4": "1.7.0",
         "caseless": "0.12.0",
         "combined-stream": "1.0.6",
-        "extend": "3.0.1",
+        "extend": "3.0.2",
         "forever-agent": "0.6.1",
         "form-data": "2.3.2",
         "har-validator": "5.0.3",
@@ -1367,7 +1377,7 @@
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
+        "mime-types": "2.1.19",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
         "qs": "6.5.2",
@@ -1460,7 +1470,7 @@
         "assert-plus": "1.0.0",
         "bcrypt-pbkdf": "1.0.2",
         "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
+        "ecc-jsbn": "0.1.2",
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
         "safer-buffer": "2.1.2",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,8 @@
   "author": "UK Home Office",
   "license": "UNLICENSED",
   "devDependencies": {
-    "cypress": "^3.0.2",
-    "moment": "^2.22.2"
+    "cypress": "^3.0.3",
+    "moment": "^2.22.2",
+    "moment-timezone": "^0.5.21"
   }
 }


### PR DESCRIPTION
This fixes the current failing e2e tests called `monthly staffing`.

Included the `moment-timezone` library to set the timezone to `Europe/London`.

This fixes the test by correcting the setup of the data to set the staff at 12am rather than 1am for the first day of this month and next month.

The test will then continue to verify the data for this month and next month have the expected values setup on the first day of the month at 12am using the monthly staffing UI.


