### PR TITLE
DRT-5222 - Add Country of origin in arrivals tab.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 import org.scalajs.core.tools.linker.ModuleInitializer
 import sbt.Keys._
 import sbt.Project.projectToRef
+import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
 
 scalaVersion := Settings.versions.scala
 
@@ -8,7 +9,7 @@ scalaVersion := Settings.versions.scala
 //enablePlugins(net.virtualvoid.optimizer.SbtOptimizerPlugin)
 
 // a special crossProject for configuring a JS/JVM/shared structure
-lazy val shared = (crossProject.crossType(CrossType.Pure) in file("shared"))
+lazy val shared = (crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure) in file("shared"))
   .settings(
     scalaVersion := Settings.versions.scala,
     libraryDependencies ++= Settings.sharedDependencies.value
@@ -44,13 +45,13 @@ lazy val client: Project = (project in file("client"))
     scalacOptions ++= elideOptions.value,
     jsDependencies ++= Settings.jsDependencies.value,
     // reactjs testing
-    jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv(),
+    requiresDOM := true,
     scalaJSStage in Test := FastOptStage,
     // 'new style js dependencies with scalaBundler'
     npmDependencies in Compile ++= Settings.clientNpmDependences,
     npmDevDependencies in Compile += Settings.clientNpmDevDependencies,
     // RuntimeDOM is needed for tests
-    jsEnv in Test := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv(),
+    jsDependencies += RuntimeDOM % "test",
     useYarn := true,
     // yes, we want to package JS dependencies
     skip in packageJSDependencies := false,

--- a/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
+++ b/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
@@ -1,5 +1,7 @@
 package drt.client.components
 
+import diode.data.Pot
+import diode.react.ModelProxy
 import drt.client.components.FlightComponents.SplitsGraph
 import drt.client.components.FlightTableRow.SplitsGraphComponentFn
 import drt.client.logger._
@@ -85,6 +87,7 @@ object FlightsWithSplitsTable {
     val columns = List(
       ("Flight", None),
       ("Origin", None),
+      ("Country", None),
       ("Gate/Stand", Option("gate-stand")),
       ("Status", Option("status")),
       ("Sch", None),
@@ -190,6 +193,9 @@ object FlightTableRow {
         val flightFields = List[(Option[String], TagMod)](
           (None, allCodes.mkString(" - ")),
           (None, props.originMapper(flight.Origin)),
+          (None, TerminalContentComponent.airportWrapper(flight.Origin) { proxy: ModelProxy[Pot[AirportInfo]] =>
+            <.span(proxy().render(ai =>ai.country))
+          }),
           (None, s"${flight.Gate.getOrElse("")}/${flight.Stand.getOrElse("")}"),
           (None, flight.Status),
           (None, localDateTimeWithPopup(Option(flight.Scheduled))),

--- a/client/src/main/scala/drt/client/services/JSDateConversions.scala
+++ b/client/src/main/scala/drt/client/services/JSDateConversions.scala
@@ -7,7 +7,8 @@ import drt.shared.{MilliDate, SDateLike}
 import scala.language.implicitConversions
 import scala.scalajs.js.Date
 import moment._
-import scala.util.Try
+
+import scala.util.{Failure, Try}
 
 object JSDateConversions {
 
@@ -109,7 +110,10 @@ object JSDateConversions {
     }
 
     def stringToSDateLikeOption(dateString: String): Option[SDateLike] = {
-      Try(JSSDate(Moment(dateString).toDate())).toOption
+      Try{
+        val moment = Moment(dateString)
+        if (moment.isValid()) JSSDate(moment.toDate()) else throw new Exception(s"$dateString is not a date")
+      }.toOption
     }
 
     def midnightThisMorning(): SDateLike = {

--- a/client/src/test/scala/drt/client/components/BestArrivalTimeTests.scala
+++ b/client/src/test/scala/drt/client/components/BestArrivalTimeTests.scala
@@ -6,7 +6,7 @@ import utest._
 object BestArrivalTimeTests extends TestSuite {
   import FlightTableRow._
 
-  def tests = TestSuite {
+  def tests = Tests {
 
     "BestArrivalTimeTests" - {
       "When testing for best arrival time" -{

--- a/client/src/test/scala/drt/client/components/BigSummaryBoxTests.scala
+++ b/client/src/test/scala/drt/client/components/BigSummaryBoxTests.scala
@@ -15,7 +15,7 @@ object BigSummaryBoxTests extends TestSuite {
   import ApiFlightGenerator._
   import BigSummaryBoxes._
 
-  def tests = TestSuite {
+  def tests = Tests {
     "Summary for the next 3 hours" - {
       "Given a rootModel with flightsWithSplits with flights arriving 2017-05-01T12:01Z onwards" - {
         "Given 0 flights" - {

--- a/client/src/test/scala/drt/client/components/DashboardComponentTests.scala
+++ b/client/src/test/scala/drt/client/components/DashboardComponentTests.scala
@@ -10,7 +10,7 @@ object DashboardComponentTests extends TestSuite {
   import DashboardTerminalSummary._
 
 
-  def tests = TestSuite {
+  def tests = Tests {
 
     "DashboardComponentTests" - {
 
@@ -87,30 +87,30 @@ object DashboardComponentTests extends TestSuite {
     "When choosing the timeslot to display in a dashboard widget " - {
 
       "given 13:45 I should get back 13:45" - {
-        val time = SDate("2017-11-31T13:45")
+        val time = SDate("2017-11-30T13:45")
         val result = DashboardTerminalSummary.windowStart(time)
-        val expected = SDate("2017-11-31T13:45")
+        val expected = SDate("2017-11-30T13:45")
 
         assert(result.millisSinceEpoch == expected.millisSinceEpoch)
       }
       "given 13:46 I should get back 13:45" - {
-        val time = SDate("2017-11-31T13:46")
+        val time = SDate("2017-11-30T13:46")
         val result = DashboardTerminalSummary.windowStart(time)
-        val expected = SDate("2017-11-31T13:45")
+        val expected = SDate("2017-11-30T13:45")
 
         assert(result.millisSinceEpoch == expected.millisSinceEpoch)
       }
       "given 13:52 I should get back 13:45" - {
-        val time = SDate("2017-11-31T13:52")
+        val time = SDate("2017-11-30T13:52")
         val result = DashboardTerminalSummary.windowStart(time)
-        val expected = SDate("2017-11-31T13:45")
+        val expected = SDate("2017-11-30T13:45")
 
         assert(result.millisSinceEpoch == expected.millisSinceEpoch)
       }
       "given 13:02 I should get back 13:00" - {
-        val time = SDate("2017-11-31T13:02")
+        val time = SDate("2017-11-30T13:02")
         val result = DashboardTerminalSummary.windowStart(time)
-        val expected = SDate("2017-11-31T13:00")
+        val expected = SDate("2017-11-30T13:00")
 
         assert(result.millisSinceEpoch == expected.millisSinceEpoch)
       }

--- a/client/src/test/scala/drt/client/components/FilterCrunchByRangeTests.scala
+++ b/client/src/test/scala/drt/client/components/FilterCrunchByRangeTests.scala
@@ -10,7 +10,7 @@ object FilterCrunchByRangeTests extends TestSuite {
   import ApiFlightGenerator._
   import TerminalContentComponent._
 
-  def tests = TestSuite {
+  def tests = Tests {
     "Given an hour range of 10 to 14" - {
       val range = CustomWindow(10, 14)
       val dateWithinRange = SDate.parse("2017-01-01T11:00:00Z")

--- a/client/src/test/scala/drt/client/components/FlightComponentsTests.scala
+++ b/client/src/test/scala/drt/client/components/FlightComponentsTests.scala
@@ -7,7 +7,7 @@ import utest._
 
 
 object FlightComponentsTests extends TestSuite {
-  def tests = TestSuite {
+  def tests = Tests {
 
     "Given a flight with only act pax " +
       "When I ask for the pax to display " +

--- a/client/src/test/scala/drt/client/components/FlightTimelineTests.scala
+++ b/client/src/test/scala/drt/client/components/FlightTimelineTests.scala
@@ -32,7 +32,7 @@ object ExampleReactScalaJsTest extends TestSuite {
     .componentWillReceiveProps(i => Callback(i.backend.prev = i.currentProps))
     .build
 
-  def tests = TestSuite {
+  def tests = Tests {
     'FlightTablesTests - {
       ReactTestUtils.withRenderedIntoDocument(CP("start")) { m =>
         assert(m.outerHtmlScrubbed() == "<div>none → start</div>")
@@ -50,7 +50,7 @@ object ExampleReactScalaJsTest extends TestSuite {
 
 
 object FlightTimelineTests extends TestSuite {
-  def tests = TestSuite {
+  def tests = Tests {
     'TimelineTests - {
 
       "Given a scheduled DT string and an actual datetime string" - {

--- a/client/src/test/scala/drt/client/components/FlightsTableTests.scala
+++ b/client/src/test/scala/drt/client/components/FlightsTableTests.scala
@@ -20,7 +20,7 @@ object FlightsTableTests extends TestSuite {
   import japgolly.scalajs.react.test._
   import japgolly.scalajs.react.vdom.html_<^._
 
-  def tests = TestSuite {
+  def tests = Tests {
 
     val realComponent = ScalaComponent.builder[String]("RealThing")
       .renderP((_, p) => <.div(p)).build
@@ -74,6 +74,7 @@ object FlightsTableTests extends TestSuite {
             if (timeline) <.th("Timeline") else TagMod(""),
             <.th("Flight"),
             <.th("Origin"),
+            <.th("Country"),
             <.th("Gate/Stand", ^.className := "gate-stand"),
             <.th("Status", ^.className := "status"),
             <.th("Sch"),
@@ -106,7 +107,7 @@ object FlightsTableTests extends TestSuite {
               thead(),
               <.tbody(
                 <.tr(^.className := " before-now",
-                  <.td(testFlight.ICAO), <.td(testFlight.Origin),
+                  <.td(testFlight.ICAO), <.td(testFlight.Origin), <.td(<.span("")),
                   <.td(s"${testFlight.Gate.getOrElse("")}/${testFlight.Stand.getOrElse("")}"),
                   <.td(testFlight.Status),
                   <.td(<.span(^.title := "2016-01-01 13:00", "13:00")), //sch
@@ -142,7 +143,7 @@ object FlightsTableTests extends TestSuite {
                 <.tbody(
                   <.tr(^.className := " before-now",
                     <.td(<.span("herebecallback")),
-                    <.td(testFlight.ICAO), <.td(testFlight.Origin),
+                    <.td(testFlight.ICAO), <.td(testFlight.Origin), <.td(<.span("")),
                     <.td(s"${testFlight.Gate.getOrElse("")}/${testFlight.Stand.getOrElse("")}"),
                     <.td(testFlight.Status),
                     date(Some(testFlight.Scheduled)),
@@ -179,7 +180,7 @@ object FlightsTableTests extends TestSuite {
                 <.tbody(
                   <.tr(^.className := " before-now",
                     <.td(testFlight.ICAO),
-                    <.td(<.span(^.title := "JFK, New York, USA", testFlight.Origin)),
+                    <.td(<.span(^.title := "JFK, New York, USA", testFlight.Origin)), <.td(<.span("")),
                     <.td(s"${testFlight.Gate.getOrElse("")}/${testFlight.Stand.getOrElse("")}"),
                     <.td(testFlight.Status),
                     date(Some(testFlight.Scheduled)),
@@ -245,7 +246,7 @@ object FlightsTableTests extends TestSuite {
               <.tbody(
                 <.tr(^.className := " before-now",
                   <.td(testFlightT.ICAO),
-                  <.td(testFlightT.Origin),
+                  <.td(testFlightT.Origin), <.td(<.span("")),
                   <.td(s"${testFlightT.Gate.getOrElse("")}/${testFlightT.Stand.getOrElse("")}"),
                   <.td(testFlightT.Status),
                   date(Some(testFlightT.Scheduled)),

--- a/client/src/test/scala/drt/client/components/PaxSplitsDisplayTests.scala
+++ b/client/src/test/scala/drt/client/components/PaxSplitsDisplayTests.scala
@@ -8,7 +8,7 @@ object PaxSplitsDisplayTests extends TestSuite {
 
   import ApiSplitsToSplitRatio._
 
-  def tests = TestSuite {
+  def tests = Tests {
     "When calculating the splits for each PaxType and Queue the the split should be applied as a ratio to flight pax" - {
       "Given 1 pax with a split of 1 EeaMachineReadable to Egate then I should get 1 Pax Split of 1 EeaMachineReadable to Egate" - {
 

--- a/client/src/test/scala/drt/client/components/PcpPaxSummaryTests.scala
+++ b/client/src/test/scala/drt/client/components/PcpPaxSummaryTests.scala
@@ -9,7 +9,7 @@ import utest.{TestSuite, _}
 
 object PcpPaxSummaryTests extends TestSuite {
 
-  def tests = TestSuite {
+  def tests = Tests {
     "Given a set of crunch minutes for one terminal" +
       "When I ask for a pax summary for a period of time " +
       "Then I should see total, eea & non-eea pax counts" - {

--- a/client/src/test/scala/drt/client/components/PlanningTests.scala
+++ b/client/src/test/scala/drt/client/components/PlanningTests.scala
@@ -7,7 +7,7 @@ object PlanningTests extends TestSuite {
 
   import TerminalPlanningComponent.getLastSunday
 
-  def tests = TestSuite {
+  def tests = Tests {
     "When getting the previous Sunday for a date" - {
       "Given a Sunday then I should get Midnight same day back" - {
         val start = SDate("2017-10-22T18:15:00")

--- a/client/src/test/scala/drt/client/components/TerminalStaffingTests.scala
+++ b/client/src/test/scala/drt/client/components/TerminalStaffingTests.scala
@@ -10,7 +10,7 @@ import scala.collection.immutable._
 
 object TerminalStaffingTests extends TestSuite {
 
-  def tests = TestSuite {
+  def tests = Tests {
     "Staff Movements" - {
       "should only display movements for the day provided" - {
         val uid1 = UUID.randomUUID()

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -34,7 +34,7 @@ object Settings {
     val autowire = "0.2.6"
     val booPickle = "1.2.6"
     val diode = "1.1.3"
-    val uTest = "0.4.7"
+    val uTest = "0.6.3"
 
     val akka = "2.5.13"
     val akkaStreamContrib = "0.9"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,9 +9,11 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.6")
 
 libraryDependencies += "com.trueaccord.scalapb" %% "compilerplugin" % "0.6.0-pre1"
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.23")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.5.0")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-web-scalajs-bundler" % "0.13.0")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.24")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-web-scalajs-bundler" % "0.13.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-js-engine" % "1.2.2")
 


### PR DESCRIPTION

- Fixed Cross project deprecation warning by following the migration steps here (https://github.com/portable-scala/sbt-crossproject#migration-from-scalajs-default-crossproject).
- Upgraded client test framework
- Removed deprecation warnings when on client tests by using `Tests` instead of `TestSuite`.
- Altered a test using an invalid date of `2017-11-31`
- Scala.js does not handle what it says are `Undefined behaviours` such as the class cast exception. Hence a `scala.util.Try` did not catch it. The code was : `Try(JSSDate(Moment(dateString).toDate())).toOption`. See https://www.scala-js.org/doc/semantics.html
- `requiresDOM := true` - is deprecated but scala.js have not allowed us to use the alternative way it says we should be using it from v1 whenever that gets released.
- Upgraded scala.js to the latest `0.6.24`
- In the Arrivals screen, I've added `Country` which is the Country of Origin, after the `Origin` field which is the Port code of the origin of the flight.

