### PR TITLE
Drt 5075 - Loading flights message

### DIFF
--- a/client/src/main/scala/drt/client/actions/Actions.scala
+++ b/client/src/main/scala/drt/client/actions/Actions.scala
@@ -31,15 +31,13 @@ object Actions {
 
   case class GetCrunchState() extends Action
 
-  case class GetCrunchUpdates() extends Action
-
-  case class SetCrunchPending() extends Action
-
   case class UpdateCrunchStateAndContinuePolling(crunchState: CrunchState) extends Action
 
   case class UpdateCrunchStateFromUpdatesAndContinuePolling(crunchUpdates: CrunchUpdates) extends Action
 
   case class UpdateCrunchStateFromCrunchState(crunchState: CrunchState) extends Action
+
+  case class NoCrunchStateUpdates() extends Action
 
   case class UpdateCrunchStateFromUpdates(crunchUpdates: CrunchUpdates) extends Action
 

--- a/client/src/main/scala/drt/client/actions/Actions.scala
+++ b/client/src/main/scala/drt/client/actions/Actions.scala
@@ -37,7 +37,7 @@ object Actions {
 
   case class UpdateCrunchStateFromCrunchState(crunchState: CrunchState) extends Action
 
-  case class NoCrunchStateUpdates() extends Action
+  case class NoCrunchStateUpdatesAndContinuePolling() extends Action
 
   case class UpdateCrunchStateFromUpdates(crunchUpdates: CrunchUpdates) extends Action
 

--- a/client/src/main/scala/drt/client/actions/Actions.scala
+++ b/client/src/main/scala/drt/client/actions/Actions.scala
@@ -37,9 +37,7 @@ object Actions {
 
   case class UpdateCrunchStateFromCrunchState(crunchState: CrunchState) extends Action
 
-  case class NoCrunchStateUpdatesAndContinuePolling() extends Action
-
-  case class UpdateCrunchStateFromUpdates(crunchUpdates: CrunchUpdates) extends Action
+  case class NoCrunchStateUpdatesAndContinuePollingIfNecessary() extends Action
 
   case class GetForecastWeek(startDay: SDateLike, terminalName: TerminalName) extends Action
 

--- a/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
+++ b/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
@@ -71,7 +71,7 @@ object FlightsWithSplitsTable {
                 }.toTagMod)))
         }
         else
-          <.div("Loading flights...")
+          <.div("No flights to display")
       } match {
         case Success(s) => s
         case Failure(f) =>

--- a/client/src/main/scala/drt/client/components/TerminalComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalComponent.scala
@@ -35,10 +35,10 @@ object TerminalComponent {
                             minuteTicker: Int
                           )
 
-  implicit val pageReuse: Reusability[TerminalPageTabLoc] = Reusability.derive[TerminalPageTabLoc]
-  implicit val propsReuse: Reusability[Props] = Reusability.by(p =>
-    (p.terminalPageTab, p.router)
-  )
+//  implicit val pageReuse: Reusability[TerminalPageTabLoc] = Reusability.derive[TerminalPageTabLoc]
+//  implicit val propsReuse: Reusability[Props] = Reusability.by(p =>
+//    (p.terminalPageTab, p.router)
+//  )
 
   val component = ScalaComponent.builder[Props]("Terminal")
     .render_P(props => {
@@ -176,7 +176,7 @@ object TerminalComponent {
       })
     })
     .componentDidMount((p) => Callback.log("TerminalComponent did mount"))
-    .configure(Reusability.shouldComponentUpdate)
+//    .configure(Reusability.shouldComponentUpdate)
     .build
 
   def apply(props: Props): VdomElement = component(props)

--- a/client/src/main/scala/drt/client/components/TerminalComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalComponent.scala
@@ -35,11 +35,6 @@ object TerminalComponent {
                             minuteTicker: Int
                           )
 
-//  implicit val pageReuse: Reusability[TerminalPageTabLoc] = Reusability.derive[TerminalPageTabLoc]
-//  implicit val propsReuse: Reusability[Props] = Reusability.by(p =>
-//    (p.terminalPageTab, p.router)
-//  )
-
   val component = ScalaComponent.builder[Props]("Terminal")
     .render_P(props => {
       val modelRCP = SPACircuit.connect(model => TerminalModel(
@@ -176,7 +171,6 @@ object TerminalComponent {
       })
     })
     .componentDidMount((p) => Callback.log("TerminalComponent did mount"))
-//    .configure(Reusability.shouldComponentUpdate)
     .build
 
   def apply(props: Props): VdomElement = component(props)

--- a/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
@@ -8,7 +8,7 @@ import drt.client.components.FlightComponents.paxComp
 import drt.client.logger.log
 import drt.client.services.JSDateConversions.SDate
 import drt.client.services.{SPACircuit, ViewMode}
-import drt.shared.CrunchApi.{CrunchState, MillisSinceEpoch}
+import drt.shared.CrunchApi.CrunchState
 import drt.shared.FlightsApi.TerminalName
 import drt.shared._
 import japgolly.scalajs.react.extra.Reusability
@@ -195,7 +195,6 @@ object TerminalContentComponent {
     .initialStateFromProps(p => State(p.terminalPageTab.subMode))
     .renderBackend[TerminalContentComponent.Backend]
     .componentDidMount(_ => Callback.log(s"terminal component didMount"))
-    //.configure(Reusability.shouldComponentUpdate)
     .build
 
   def apply(props: Props): VdomElement = component(props)

--- a/client/src/main/scala/drt/client/services/handlers/LoaderHandler.scala
+++ b/client/src/main/scala/drt/client/services/handlers/LoaderHandler.scala
@@ -7,8 +7,10 @@ import drt.client.services.LoadingState
 class LoaderHandler[M](modelRW: ModelRW[M, LoadingState]) extends LoggingActionHandler(modelRW) {
   protected def handle: PartialFunction[Any, ActionResult[M]] = {
     case ShowLoader() =>
+      println("Showing loader")
       updated(LoadingState(isLoading = true))
     case HideLoader() =>
+      println("Hiding loader")
       updated(LoadingState(isLoading = false))
   }
 }

--- a/client/src/main/scala/drt/client/services/handlers/LoaderHandler.scala
+++ b/client/src/main/scala/drt/client/services/handlers/LoaderHandler.scala
@@ -6,11 +6,7 @@ import drt.client.services.LoadingState
 
 class LoaderHandler[M](modelRW: ModelRW[M, LoadingState]) extends LoggingActionHandler(modelRW) {
   protected def handle: PartialFunction[Any, ActionResult[M]] = {
-    case ShowLoader() =>
-      println("Showing loader")
-      updated(LoadingState(isLoading = true))
-    case HideLoader() =>
-      println("Hiding loader")
-      updated(LoadingState(isLoading = false))
+    case ShowLoader() => updated(LoadingState(isLoading = true))
+    case HideLoader() => updated(LoadingState(isLoading = false))
   }
 }

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -1,8 +1,6 @@
 package controllers
 
 import java.nio.ByteBuffer
-import javax.inject.{Inject, Singleton}
-
 import actors._
 import actors.pointInTime.CrunchStateReadActor
 import akka.actor._
@@ -37,15 +35,13 @@ import services.graphstages.Crunch._
 import services.shifts.StaffTimeSlots
 import services.workloadcalculator.PaxLoadCalculator
 import services.workloadcalculator.PaxLoadCalculator.PaxTypeAndQueueCount
-import services.{SDate, _}
+import services._
 import test.TestDrtSystem
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.util.matching.Regex
-//import scala.collection.immutable.Seq // do not import this here, it would break autowire.
 import services.PcpArrival.pcpFrom
 
 object Router extends autowire.Server[ByteBuffer, Pickler, Pickler] {
@@ -213,13 +209,13 @@ class Application @Inject()(implicit val config: Configuration,
 
       def actorSystem: ActorSystem = system
 
-      def getCrunchStateForDay(day: MillisSinceEpoch): Future[Option[CrunchState]] = loadBestCrunchStateForPointInTime(day)
+      def getCrunchStateForDay(day: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] = loadBestCrunchStateForPointInTime(day)
 
       def getApplicationVersion(): String = BuildInfo.version
 
-      override def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Option[CrunchState]] = crunchStateAtPointInTime(pointInTime)
+      override def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] = crunchStateAtPointInTime(pointInTime)
 
-      def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Option[CrunchUpdates]] = {
+      def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Either[CrunchUpdatesError, Option[CrunchUpdates]]] = {
         val liveStateCutOff = getLocalNextMidnight(ctrl.now()).addDays(1).millisSinceEpoch
 
         val stateActor = if (windowStartMillis < liveStateCutOff) liveCrunchStateActor else forecastCrunchStateActor
@@ -227,12 +223,12 @@ class Application @Inject()(implicit val config: Configuration,
         val crunchStateFuture = stateActor.ask(GetUpdatesSince(sinceMillis, windowStartMillis, windowEndMillis))(new Timeout(30 seconds))
 
         crunchStateFuture.map {
-          case Some(cu: CrunchUpdates) => Option(cu)
-          case _ => None
+          case Some(cu: CrunchUpdates) => Right(Option(cu))
+          case _ => Right(None)
         } recover {
           case t =>
             log.warn(s"Didn't get a CrunchUpdates: $t")
-            None
+            Left(CrunchUpdatesError(t.getMessage))
         }
       }
 
@@ -340,31 +336,31 @@ class Application @Inject()(implicit val config: Configuration,
     }
   }
 
-  def loadBestCrunchStateForPointInTime(day: MillisSinceEpoch): Future[Option[CrunchState]] =
+  def loadBestCrunchStateForPointInTime(day: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] =
     if (isHistoricDate(day)) {
       crunchStateForEndOfDay(day)
     } else if (day <= getLocalNextMidnight(SDate.now()).millisSinceEpoch) {
       ctrl.liveCrunchStateActor.ask(GetState).map {
-        case Some(PortState(f, m, s)) => Option(CrunchState(f.values.toSet, m.values.toSet, s.values.toSet))
-        case _ => None
+        case Some(PortState(f, m, s)) => Right(Option(CrunchState(f.values.toSet, m.values.toSet, s.values.toSet)))
+        case _ => Right(None)
       }
     } else {
       crunchStateForDayInForecast(day)
     }
 
-  def crunchStateForDayInForecast(day: MillisSinceEpoch): Future[Option[CrunchState]] = {
+  def crunchStateForDayInForecast(day: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] = {
     val firstMinute = getLocalLastMidnight(SDate(day)).millisSinceEpoch
     val lastMinute = SDate(firstMinute).addHours(airportConfig.dayLengthHours).millisSinceEpoch
 
     val crunchStateFuture = ctrl.forecastCrunchStateActor.ask(GetPortState(firstMinute, lastMinute))(new Timeout(30 seconds))
 
     crunchStateFuture.map {
-      case Some(PortState(f, m, s)) => Option(CrunchState(f.values.toSet, m.values.toSet, s.values.toSet))
-      case _ => None
+      case Some(PortState(f, m, s)) => Right(Option(CrunchState(f.values.toSet, m.values.toSet, s.values.toSet)))
+      case _ => Right(None)
     } recover {
       case t =>
         log.warning(s"Didn't get a CrunchState: $t")
-        None
+        Left(CrunchStateError(t.getMessage))
     }
   }
 
@@ -377,7 +373,7 @@ class Application @Inject()(implicit val config: Configuration,
   }
 
 
-  def crunchStateAtPointInTime(pointInTime: MillisSinceEpoch): Future[Option[CrunchState]] = {
+  def crunchStateAtPointInTime(pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] = {
     val relativeLastMidnight = getLocalLastMidnight(SDate(pointInTime)).millisSinceEpoch
     val startMillis = relativeLastMidnight
     val endMillis = relativeLastMidnight + oneHourMillis * airportConfig.dayLengthHours
@@ -385,7 +381,7 @@ class Application @Inject()(implicit val config: Configuration,
     portStatePeriodAtPointInTime(startMillis, endMillis, pointInTime)
   }
 
-  def crunchStateForEndOfDay(day: MillisSinceEpoch): Future[Option[CrunchState]] = {
+  def crunchStateForEndOfDay(day: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] = {
     val relativeLastMidnight = getLocalLastMidnight(SDate(day)).millisSinceEpoch
     val startMillis = relativeLastMidnight
     val endMillis = relativeLastMidnight + oneHourMillis * airportConfig.dayLengthHours
@@ -394,16 +390,16 @@ class Application @Inject()(implicit val config: Configuration,
     portStatePeriodAtPointInTime(startMillis, endMillis, pointInTime)
   }
 
-  def portStatePeriodAtPointInTime(startMillis: MillisSinceEpoch, endMillis: MillisSinceEpoch, pointInTime: MillisSinceEpoch): Future[Option[CrunchState]] = {
+  def portStatePeriodAtPointInTime(startMillis: MillisSinceEpoch, endMillis: MillisSinceEpoch, pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] = {
     val query = CachableActorQuery(Props(classOf[CrunchStateReadActor], airportConfig.portStateSnapshotInterval, SDate(pointInTime), airportConfig.queues), GetPortState(startMillis, endMillis))
     val portCrunchResult = cacheActorRef.ask(query)(new Timeout(30 seconds))
     portCrunchResult.map {
-      case Some(PortState(f, m, s)) => Option(CrunchState(f.values.toSet, m.values.toSet, s.values.toSet))
-      case _ => None
+      case Some(PortState(f, m, s)) => Right(Option(CrunchState(f.values.toSet, m.values.toSet, s.values.toSet)))
+      case _ => Right(None)
     }.recover {
       case t =>
         log.warning(s"Didn't get a point-in-time CrunchState: $t")
-        None
+        Left(CrunchStateError(t.getMessage))
     }
   }
 
@@ -438,7 +434,7 @@ class Application @Inject()(implicit val config: Configuration,
                         pointInTime: MilliDate,
                         startHour: Int,
                         endHour: Int,
-                        crunchStateFuture: Future[Option[CrunchState]]
+                        crunchStateFuture: Future[Either[CrunchStateError, Option[CrunchState]]]
                       ): Future[Option[String]] = {
 
     val startDateTime = getLocalLastMidnight(pointInTime).addHours(startHour)
@@ -447,7 +443,7 @@ class Application @Inject()(implicit val config: Configuration,
 
     val localTime = SDate(pointInTime, europeLondonTimeZone)
     crunchStateFuture.map {
-      case Some(CrunchState(_, cm, sm)) =>
+      case Right(Some(CrunchState(_, cm, sm))) =>
         log.debug(s"Exports: ${localTime.toISOString()} Got ${cm.size} CMs and ${sm.size} SMs ")
         val cmForDay: Set[CrunchMinute] = cm.filter(cm => isInRange(SDate(cm.minute, europeLondonTimeZone)))
         val smForDay: Set[StaffMinute] = sm.filter(sm => isInRange(SDate(sm.minute, europeLondonTimeZone)))
@@ -647,7 +643,7 @@ class Application @Inject()(implicit val config: Configuration,
                                       pit: MilliDate,
                                       startHour: Int,
                                       endHour: Int,
-                                      crunchStateFuture: Future[Option[CrunchState]]
+                                      crunchStateFuture: Future[Either[CrunchStateError, Option[CrunchState]]]
                                     ): Future[Option[List[ApiFlightWithSplits]]] = {
 
     val startDateTime = getLocalLastMidnight(pit).addHours(startHour)
@@ -655,7 +651,7 @@ class Application @Inject()(implicit val config: Configuration,
     val isInRange = isInRangeOnDay(startDateTime, endDateTime) _
 
     crunchStateFuture.map {
-      case Some(CrunchState(fs, _, _)) =>
+      case Right(Some(CrunchState(fs, _, _))) =>
 
         val flightsForTerminalInRange = fs.toList
           .filter(_.apiFlight.Terminal == terminalName)

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -215,7 +215,7 @@ class Application @Inject()(implicit val config: Configuration,
 
       override def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] = crunchStateAtPointInTime(pointInTime)
 
-      def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Either[CrunchUpdatesError, Option[CrunchUpdates]]] = {
+      def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchUpdates]]] = {
         val liveStateCutOff = getLocalNextMidnight(ctrl.now()).addDays(1).millisSinceEpoch
 
         val stateActor = if (windowStartMillis < liveStateCutOff) liveCrunchStateActor else forecastCrunchStateActor
@@ -228,7 +228,7 @@ class Application @Inject()(implicit val config: Configuration,
         } recover {
           case t =>
             log.warn(s"Didn't get a CrunchUpdates: $t")
-            Left(CrunchUpdatesError(t.getMessage))
+            Left(CrunchStateError(t.getMessage))
         }
       }
 

--- a/server/src/main/scala/services/ApiService.scala
+++ b/server/src/main/scala/services/ApiService.scala
@@ -89,7 +89,7 @@ abstract class ApiService(val airportConfig: AirportConfig,
 
   def getCrunchStateForDay(day: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]]
 
-  def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Either[CrunchUpdatesError, Option[CrunchUpdates]]]
+  def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchUpdates]]]
 
   def forecastWeekSummary(startDay: MillisSinceEpoch, terminal: TerminalName): Future[Option[ForecastPeriodWithHeadlines]]
 

--- a/server/src/main/scala/services/ApiService.scala
+++ b/server/src/main/scala/services/ApiService.scala
@@ -85,11 +85,11 @@ abstract class ApiService(val airportConfig: AirportConfig,
 
   def airportConfiguration(): AirportConfig = airportConfig
 
-  def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Option[CrunchState]]
+  def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]]
 
-  def getCrunchStateForDay(day: MillisSinceEpoch): Future[Option[CrunchState]]
+  def getCrunchStateForDay(day: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]]
 
-  def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Option[CrunchUpdates]]
+  def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Either[CrunchUpdatesError, Option[CrunchUpdates]]]
 
   def forecastWeekSummary(startDay: MillisSinceEpoch, terminal: TerminalName): Future[Option[ForecastPeriodWithHeadlines]]
 

--- a/shared/src/main/scala/drt/shared/Api.scala
+++ b/shared/src/main/scala/drt/shared/Api.scala
@@ -358,6 +358,8 @@ object CrunchApi {
       val windowsStaffMinutes = staffMinutes.filter(sm => start.millisSinceEpoch <= sm.minute && sm.minute <= end.millisSinceEpoch && sm.terminalName == terminalName)
       CrunchState(windowedFlights, windowedCrunchMinutes, windowsStaffMinutes)
     }
+
+    def isEmpty: Boolean = flights.isEmpty && crunchMinutes.isEmpty && staffMinutes.isEmpty
   }
 
   case class PortState(flights: Map[Int, ApiFlightWithSplits],
@@ -500,8 +502,6 @@ object CrunchApi {
 
   case class CrunchMinutes(crunchMinutes: Set[CrunchMinute])
 
-  case class CrunchUpdatesError(message: String)
-
   case class CrunchUpdates(latest: MillisSinceEpoch, flights: Set[ApiFlightWithSplits], minutes: Set[CrunchMinute], staff: Set[StaffMinute])
 
   case class ForecastTimeSlot(startMillis: MillisSinceEpoch, available: Int, required: Int)
@@ -623,7 +623,7 @@ trait Api {
 
   def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]]
 
-  def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Either[CrunchUpdatesError, Option[CrunchUpdates]]]
+  def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchUpdates]]]
 
   def forecastWeekSummary(startDay: MillisSinceEpoch, terminal: TerminalName): Future[Option[ForecastPeriodWithHeadlines]]
 

--- a/shared/src/main/scala/drt/shared/Api.scala
+++ b/shared/src/main/scala/drt/shared/Api.scala
@@ -340,6 +340,8 @@ object PassengerSplits {
 object CrunchApi {
   type MillisSinceEpoch = Long
 
+  case class CrunchStateError(message: String)
+
   case class CrunchState(flights: Set[ApiFlightWithSplits],
                          crunchMinutes: Set[CrunchMinute],
                          staffMinutes: Set[StaffMinute]) {
@@ -498,6 +500,8 @@ object CrunchApi {
 
   case class CrunchMinutes(crunchMinutes: Set[CrunchMinute])
 
+  case class CrunchUpdatesError(message: String)
+
   case class CrunchUpdates(latest: MillisSinceEpoch, flights: Set[ApiFlightWithSplits], minutes: Set[CrunchMinute], staff: Set[StaffMinute])
 
   case class ForecastTimeSlot(startMillis: MillisSinceEpoch, available: Int, required: Int)
@@ -615,11 +619,11 @@ trait Api {
 
   def getShiftsForMonth(month: MillisSinceEpoch, terminalName: TerminalName): Future[String]
 
-  def getCrunchStateForDay(day: MillisSinceEpoch): Future[Option[CrunchState]]
+  def getCrunchStateForDay(day: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]]
 
-  def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Option[CrunchState]]
+  def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]]
 
-  def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Option[CrunchUpdates]]
+  def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Either[CrunchUpdatesError, Option[CrunchUpdates]]]
 
   def forecastWeekSummary(startDay: MillisSinceEpoch, terminal: TerminalName): Future[Option[ForecastPeriodWithHeadlines]]
 


### PR DESCRIPTION
Shows `"No flights to display"` when there are no arrivals in the time period selected but there are crunch state on the selected day on the `Arrivals` tab.
Shows a spinner when it's requesting crunch for a time period. i.e. It does not show the `Desks & Queues`, `Arrivals` and `Staff Movements` tab.
Shows `"Nothing to show for this time period"` when there are no crunch state for the selected time period. i.e. It does not show the `Desks & Queues`, `Arrivals` and `Staff Movements` tab.
Will show the `Desks & Queues`, `Arrivals` and `Staff Movements` tab when the crunch data arrives.