### PR TITLE
DRT-5250 - Staff Movement `Created by` is persisted after a restart

### DIFF
--- a/server/src/main/scala/actors/StaffMovementsActorBase.scala
+++ b/server/src/main/scala/actors/StaffMovementsActorBase.scala
@@ -129,6 +129,7 @@ class StaffMovementsActorBase extends RecoveryActorLike with PersistentDrtActor[
     delta = Some(sm.delta),
     uUID = Some(sm.uUID.toString),
     queueName = sm.queue,
-    createdAt = Option(SDate.now().millisSinceEpoch)
+    createdAt = Option(SDate.now().millisSinceEpoch),
+    createdBy = sm.createdBy
   )
 }


### PR DESCRIPTION
The created by is now persisted. It needed to be serialised into a protobuf message.

The image below show the email address finally being persisted on a staff movement after restarting the application.

<img width="351" alt="screen shot 2018-08-16 at 14 13 11" src="https://user-images.githubusercontent.com/369407/44210501-91ce1500-a15e-11e8-95fc-64140dd54708.png">
