### PR TITLE
Drt 5239 - Create an alert system

### DIFF
--- a/client/src/main/scala/drt/client/SPAMain.scala
+++ b/client/src/main/scala/drt/client/SPAMain.scala
@@ -75,7 +75,8 @@ object SPAMain {
       GetAirportConfig(),
       GetFixedPoints(),
       UpdateMinuteTicker,
-      GetFeedStatuses()
+      GetFeedStatuses(),
+      GetAlerts(0L)
     )
 
     initActions.foreach(SPACircuit.dispatch(_))

--- a/client/src/main/scala/drt/client/actions/Actions.scala
+++ b/client/src/main/scala/drt/client/actions/Actions.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import diode.Action
 import drt.client.services.{StaffAssignment, ViewMode}
-import drt.shared.CrunchApi.{CrunchState, CrunchUpdates, ForecastPeriodWithHeadlines}
+import drt.shared.CrunchApi.{CrunchState, CrunchUpdates, ForecastPeriodWithHeadlines, MillisSinceEpoch}
 import drt.shared.FlightsApi._
 import drt.shared.KeyCloakApi.KeyCloakUser
 import drt.shared._
@@ -100,5 +100,11 @@ object Actions {
   case class SetKeyCloakUsers(users: List[KeyCloakUser]) extends Action
 
   case class AddUserToGroup(userId: String, groupName: String) extends Action
+
+  case class GetAlerts(since: MillisSinceEpoch) extends Action
+
+  case class SetAlerts(alerts: Seq[Alert], since: MillisSinceEpoch) extends Action
+
+  case object CloseAlerts extends Action
 
 }

--- a/client/src/main/scala/drt/client/components/AlertsComponent.scala
+++ b/client/src/main/scala/drt/client/components/AlertsComponent.scala
@@ -1,0 +1,48 @@
+package drt.client.components
+
+import drt.client.actions.Actions.CloseAlerts
+import drt.client.logger.{Logger, LoggerFactory}
+import drt.client.services.SPACircuit
+import drt.shared.Alert
+import japgolly.scalajs.react.vdom.html_<^._
+import japgolly.scalajs.react.{Callback, ReactEventFromInput, ScalaComponent}
+
+object AlertsComponent {
+
+  val log: Logger = LoggerFactory.getLogger(getClass.getName)
+
+  case class Props()
+
+  val component = ScalaComponent.builder[Props]("Alerts")
+    .render_P(_ => {
+
+      def closeAlerts = (_: ReactEventFromInput) =>
+        Callback(SPACircuit.dispatch(CloseAlerts))
+
+      val modelRCP = SPACircuit.connect(m => m.alerts)
+
+      modelRCP { modelMP =>
+        val alertsPot = modelMP()
+
+        <.div(^.id:= "alerts",
+          alertsPot.render((alerts: Seq[Alert]) => {
+          <.span(^.id:= "has-alerts",
+            <.span(^.id :="close-alert", ^.className := "close", ^.onClick ==> closeAlerts, ^.title :="Close", "X"),
+            alerts.map(alert => {
+              <.span(^.key := alert.createdAt,
+              <.h3(alert.title),
+              <.p(^.className :="text", alert.message)
+              )
+            }).toVdomArray
+            )
+
+          }),
+          alertsPot.renderEmpty(<.div(^.id :="empty-alert"))
+
+        )
+      }
+    })
+    .build
+
+  def apply(): VdomElement = component(Props())
+}

--- a/client/src/main/scala/drt/client/components/Layout.scala
+++ b/client/src/main/scala/drt/client/components/Layout.scala
@@ -15,6 +15,7 @@ object Layout {
     .renderP((_, props: Props) => {
       <.div(
         <.div(^.className := "main-logo"),
+        AlertsComponent(),
         <.div(
           // here we use plain Bootstrap class names as these are specific to the top level layout defined here
           Navbar(props.ctl, props.currentLoc.page),

--- a/client/src/main/scala/drt/client/services/SPACircuit.scala
+++ b/client/src/main/scala/drt/client/services/SPACircuit.scala
@@ -49,7 +49,8 @@ case class RootModel(
                       loggedInUserPot: Pot[LoggedInUser] = Empty,
                       minuteTicker: Int = 0,
                       keyCloakUsers: Pot[List[KeyCloakUser]] = Empty,
-                      feedStatuses: Pot[Seq[FeedStatuses]] = Empty
+                      feedStatuses: Pot[Seq[FeedStatuses]] = Empty,
+                      alerts: Pot[Seq[Alert]] = Empty
                     )
 
 object PollDelay {
@@ -61,7 +62,7 @@ object PollDelay {
 trait DrtCircuit extends Circuit[RootModel] with ReactConnector[RootModel] {
   val blockWidth = 15
 
-  def timeProvider(): MillisSinceEpoch = new Date().getTime.toLong
+  def timeProvider(): MillisSinceEpoch = SDate.now().millisSinceEpoch
 
   override protected def initialModel = RootModel()
 
@@ -91,7 +92,8 @@ trait DrtCircuit extends Circuit[RootModel] with ReactConnector[RootModel] {
       new LoggedInUserHandler(zoomRW(_.loggedInUserPot)((m, v) => m.copy(loggedInUserPot = v))),
       new UsersHandler(zoomRW(_.keyCloakUsers)((m, v) => m.copy(keyCloakUsers = v))),
       new MinuteTickerHandler(zoomRW(_.minuteTicker)((m, v) => m.copy(minuteTicker = v))),
-      new FeedsStatusHandler(zoomRW(_.feedStatuses)((m, v) => m.copy(feedStatuses = v)))
+      new FeedsStatusHandler(zoomRW(_.feedStatuses)((m, v) => m.copy(feedStatuses = v))),
+      new AlertsHandler(zoomRW(_.alerts)((m, v) => m.copy(alerts = v)))
     )
 
     composedhandlers

--- a/client/src/main/scala/drt/client/services/handlers/AlertsHandler.scala
+++ b/client/src/main/scala/drt/client/services/handlers/AlertsHandler.scala
@@ -1,0 +1,46 @@
+package drt.client.services.handlers
+
+import autowire._
+import diode.data._
+import diode.{ActionResult, Effect, ModelRW}
+import drt.client.actions.Actions._
+import drt.client.logger.log
+import drt.client.services.JSDateConversions.SDate
+import drt.client.services.{AjaxClient, PollDelay}
+import drt.shared.CrunchApi.MillisSinceEpoch
+import drt.shared.{Alert, Api}
+import diode.Implicits.runAfterImpl
+import scala.concurrent.Future
+import scala.concurrent.duration.{FiniteDuration, _}
+import scala.language.postfixOps
+import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+import boopickle.Default._
+
+class AlertsHandler[M](modelRW: ModelRW[M, Pot[Seq[Alert]]]) extends LoggingActionHandler(modelRW) {
+
+  val alertsRequestFrequency: FiniteDuration = 10 seconds
+  protected def handle: PartialFunction[Any, ActionResult[M]] = {
+
+    case GetAlerts(since: MillisSinceEpoch) =>
+      effectOnly(Effect(AjaxClient[Api].getAlerts(since).call().map(alerts => SetAlerts(alerts, since)).recoverWith {
+        case _ =>
+          log.info(s"Alerts request failed. Re-requesting after ${PollDelay.recoveryDelay}")
+          Future(RetryActionAfter(GetLoggedInUser, PollDelay.recoveryDelay))
+      }))
+
+    case SetAlerts(alerts, since) =>
+      log.info(s"Alerts are: $alerts")
+      val effect = Effect(Future(GetAlerts(since))).after(alertsRequestFrequency)
+      val pot = if (alerts.isEmpty) Empty else Ready(alerts)
+      if (modelRW.value.isPending && since <= SDate.now().addMinutes(-1).millisSinceEpoch) {
+        noChange
+      } else {
+        updated(pot, effect)
+      }
+
+    case CloseAlerts =>
+      val effect = Effect(Future(GetAlerts(SDate.now().millisSinceEpoch))).after(alertsRequestFrequency)
+      updated(Pending(), effect)
+
+  }
+}

--- a/e2e/cypress/integration/alerts.js
+++ b/e2e/cypress/integration/alerts.js
@@ -1,0 +1,74 @@
+describe('Alerts system', function () {
+
+  let today = new Date().toISOString().split("T")[0];
+  let timeAtEndOfDay = "23:59:59";
+  let timeAtStartOfDay = "00:00:00";
+
+  beforeEach(function () {
+    deleteAlerts();
+
+  });
+  function deleteAlerts() {
+    cy.request('DELETE', '/v2/test/live/data/alert');
+
+  }
+  function addAlert(time, number="") {
+    cy.request('POST',
+      '/v2/test/live/data/alert',
+      {
+        "title": "This is an alert"+number,
+        "message": "This is the message of the alert",
+        "expires": today + " " + time
+      }).its("body").should('include', "This is an alert");
+
+  }
+  function navigateToHome() {
+    cy.visit('/v2/test/live').then(() => {
+      cy.wait(500);
+      cy.get('.navbar .container .navbar-drt').contains('DRT TEST').end();
+    }).end();
+
+  }
+  function shouldHaveAlerts(num) {
+    cy.get('#has-alerts .text').should('have.length', num);
+
+  }
+  function closeAlerts() {
+    cy.get("#close-alert").click();
+
+  }
+
+  describe('An alert exists in the app', function () {
+
+    it("When an alert is not expired it should be displayed", function () {
+      addAlert(timeAtEndOfDay);
+      navigateToHome();
+      shouldHaveAlerts(1)
+    });
+
+    it("When there is an expired alert it should not be displayed", function () {
+      addAlert(timeAtStartOfDay);
+      navigateToHome();
+      shouldHaveAlerts(0)
+    });
+
+    it("When the user closes the alerts no alerts are displayed", function () {
+      addAlert(timeAtEndOfDay);
+      navigateToHome();
+      shouldHaveAlerts(1);
+      closeAlerts();
+      shouldHaveAlerts(0);
+    });
+
+  });
+
+  describe('Two alerts exist in the app', function() {
+    it("When there are two alerts that are not expired they should be displayed", function () {
+      addAlert(timeAtEndOfDay, "1");
+      addAlert(timeAtEndOfDay, "2");
+
+      navigateToHome();
+      shouldHaveAlerts(2)
+    });
+  })
+});

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -58,6 +58,7 @@ object Settings {
     val akkaPersistenceInmemory = "2.4.18.1"
     val sshJ = "0.24.0"
     val jodaTime = "2.9.4"
+    val playJsonJoda = "2.6.9"
     val exposeLoader = "0.7.1"
     val log4Javascript = "1.4.15"
     val typesafeConfig = "1.3.0"
@@ -125,6 +126,7 @@ object Settings {
     "io.spray" %% "spray-json" % sprayVersion,
 
     "joda-time" % "joda-time" % jodaTime,
+    "com.typesafe.play" %% "play-json-joda" % playJsonJoda,
     "org.opensaml" % "opensaml" % openSaml excludeAll (ExclusionRule("org.bouncycastle"), ExclusionRule("xerces")),
     "org.pac4j" % "pac4j-saml" % pac4jSaml,
     "org.apache.commons" % "commons-csv" % csvCommons,

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -1647,3 +1647,41 @@ a i.fa.fa-remove {
 .key-cloak-users td {
   padding: 10px;
 }
+
+#has-alerts {
+    font-size: 12px;
+    font-family: tahoma;
+    height: 140px;
+    border: 3px double #ccc;
+    color: #555;
+    display: block;
+    padding: 10px;
+    box-sizing: border-box;
+    text-decoration: none;
+    overflow: auto;
+}
+
+#has-alerts:hover {
+  box-shadow: 2px -5px 5px 0px rgba(0,0,0,.2);
+}
+
+#has-alerts h3 {
+  padding: 0;
+  margin: 0;
+  color: #369;
+}
+
+#has-alerts .close {
+  float:right;
+  display:inline-block;
+  padding:2px 5px;
+  background:#ccc;
+}
+
+#has-alerts .close:hover {
+  float:right;
+  display:inline-block;
+  padding:2px 5px;
+  background:#ccc;
+  color:#fff;
+}

--- a/server/src/main/protobuf/Alert.proto
+++ b/server/src/main/protobuf/Alert.proto
@@ -1,0 +1,14 @@
+syntax = "proto2";
+
+package server.protobuf.messages;
+
+message AlertSnapshotMessage {
+    repeated Alert alerts = 1;
+}
+
+message Alert {
+    optional string message = 1;
+    optional int64 expires = 2;
+    optional int64 createdAt = 3;
+    optional string createdBy = 4;
+}

--- a/server/src/main/protobuf/Alert.proto
+++ b/server/src/main/protobuf/Alert.proto
@@ -7,8 +7,9 @@ message AlertSnapshotMessage {
 }
 
 message Alert {
-    optional string message = 1;
-    optional int64 expires = 2;
-    optional int64 createdAt = 3;
-    optional string createdBy = 4;
+    optional string title = 1;
+    optional string message = 2;
+    optional int64 expires = 3;
+    optional int64 createdAt = 4;
+    optional string createdBy = 5;
 }

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -93,6 +93,9 @@ akka {
       "server.protobuf.messages.VoyageManifest.VoyageManifestLatestFileNameMessage" = protobuf
       "server.protobuf.messages.VoyageManifest.VoyageManifestsMessage" = protobuf
       "server.protobuf.messages.VoyageManifest.VoyageManifestMessage" = protobuf
+      "server.protobuf.messages.Alert.AlertSnapshotMessage" = protobuf
+      "server.protobuf.messages.Alert.Alert" = protobuf
+
     }
   }
   stream.materializer {

--- a/server/src/main/resources/routes
+++ b/server/src/main/resources/routes
@@ -30,8 +30,7 @@ POST        /logging                                      controllers.Applicatio
 POST        /data/staff                                   controllers.Application.saveStaff
 
 POST        /data/alert                                   controllers.Application.addAlert
-
-GET         /data/alert                                    controllers.Application.getAlerts
+DELETE      /data/alert                                   controllers.Application.deleteAlerts
 
 POST        /test/arrival                                 controllers.Test.addArrival
 

--- a/server/src/main/resources/routes
+++ b/server/src/main/resources/routes
@@ -29,6 +29,10 @@ POST        /logging                                      controllers.Applicatio
 
 POST        /data/staff                                   controllers.Application.saveStaff
 
+POST        /data/alert                                   controllers.Application.addAlert
+
+GET         /data/alert                                    controllers.Application.getAlerts
+
 POST        /test/arrival                                 controllers.Test.addArrival
 
 POST        /test/manifest                                controllers.Test.addManifest

--- a/server/src/main/scala/actors/AlertsActor.scala
+++ b/server/src/main/scala/actors/AlertsActor.scala
@@ -50,6 +50,7 @@ case class AlertsActor() extends RecoveryActorLike with PersistentDrtActor[Seq[A
       log.info(s"Saving Alert $alert")
       updateState(Seq(alert))
       persistAndMaybeSnapshot(serialise(alert))
+      sender() ! alert
 
     case GetState =>
       log.info(s"Received GetState request. Sending Alerts with ${state.size} alerts")

--- a/server/src/main/scala/actors/AlertsActor.scala
+++ b/server/src/main/scala/actors/AlertsActor.scala
@@ -1,0 +1,66 @@
+package actors
+
+import actors.Sizes.oneMegaByte
+import akka.persistence.{SaveSnapshotFailure, SaveSnapshotSuccess}
+import com.trueaccord.scalapb.GeneratedMessage
+import drt.shared.Alert
+import org.slf4j.{Logger, LoggerFactory}
+import server.protobuf.messages.Alert.{AlertSnapshotMessage, Alert => ProtobufAlert}
+
+case class AlertsActor() extends RecoveryActorLike with PersistentDrtActor[Seq[Alert]] {
+  override val log: Logger = LoggerFactory.getLogger(getClass)
+  override val snapshotBytesThreshold: Int = oneMegaByte
+
+  override def processRecoveryMessage: PartialFunction[Any, Unit] = {
+    case alert: ProtobufAlert =>
+      log.info(s"ALERTS GOT alert $alert")
+      deserialise(alert).foreach(a => updateState(Seq(a)))
+  }
+
+  override def processSnapshotMessage: PartialFunction[Any, Unit] = {
+    case smm: AlertSnapshotMessage =>
+      log.info(s"ALERTS GOT alert snapshot $smm")
+      updateState(smm.alerts.flatMap(deserialise))
+  }
+
+  def deserialise(alert: ProtobufAlert): Option[Alert] = for {
+    message <- alert.message
+    expires <- alert.expires
+    createdAt <- alert.createdAt
+  } yield Alert(message, expires, createdAt)
+
+  def serialise(alert: Alert): ProtobufAlert = ProtobufAlert(Option(alert.message), Option(alert.expires), Option(alert.createdAt))
+
+
+  def updateState(data: Seq[Alert]): Unit = state = state ++ data
+
+  override def stateToMessage: GeneratedMessage = AlertSnapshotMessage(state.map(serialise))
+
+  override var state: Seq[Alert] = initialState
+
+  override def initialState: Seq[Alert] = Seq.empty[Alert]
+
+  override def receiveCommand: Receive = {
+
+    case alert@Alert(_, _, _) =>
+      log.info(s"Saving Alert $alert")
+      updateState(Seq(alert))
+      persistAndMaybeSnapshot(serialise(alert))
+
+    case GetState =>
+      log.info(s"Received GetState request. Sending Alerts with ${state.size} alerts")
+      sender() ! state
+
+    case SaveSnapshotSuccess(md) =>
+      log.info(s"Save snapshot success: $md")
+
+    case SaveSnapshotFailure(md, cause) =>
+      log.info(s"Save snapshot failure: $md, $cause")
+
+    case other =>
+      log.error(s"Received unexpected message ${other.getClass}")
+
+  }
+
+  override def persistenceId: String = "alerts-store"
+}

--- a/server/src/main/scala/actors/DrtSystem.scala
+++ b/server/src/main/scala/actors/DrtSystem.scala
@@ -50,6 +50,7 @@ trait DrtSystemInterface extends UserRoleProviderLike {
   val shiftsActor: ActorRef
   val fixedPointsActor: ActorRef
   val staffMovementsActor: ActorRef
+  val alertsActor: ActorRef
 
 
   val aclFeed: AclFeed
@@ -109,6 +110,7 @@ case class DrtSystem(actorSystem: ActorSystem, config: Configuration, airportCon
   lazy val fixedPointsActor: ActorRef = system.actorOf(Props(classOf[FixedPointsActor]))
   lazy val staffMovementsActor: ActorRef = system.actorOf(Props(classOf[StaffMovementsActor]))
 
+  lazy val alertsActor: ActorRef = system.actorOf(Props(classOf[AlertsActor]))
   val historicalSplitsProvider: SplitProvider = SplitsProvider.csvProvider
   val useNationalityBasedProcessingTimes: Boolean = config.getOptional[String]("feature-flags.nationality-based-processing-times").isDefined
   val useSplitsPrediction: Boolean = config.getOptional[String]("feature-flags.use-splits-prediction").isDefined

--- a/server/src/main/scala/actors/serializers/ProtoBufSerializer.scala
+++ b/server/src/main/scala/actors/serializers/ProtoBufSerializer.scala
@@ -7,6 +7,7 @@ import server.protobuf.messages.FixedPointMessage.FixedPointsStateSnapshotMessag
 import server.protobuf.messages.FlightsMessage.{FeedStatusMessage, FeedStatusesMessage, FlightStateSnapshotMessage, FlightsDiffMessage}
 import server.protobuf.messages.ShiftMessage.ShiftStateSnapshotMessage
 import server.protobuf.messages.StaffMovementMessages.StaffMovementsStateSnapshotMessage
+import server.protobuf.messages.Alert.{Alert, AlertSnapshotMessage}
 import server.protobuf.messages.VoyageManifest.{VoyageManifestLatestFileNameMessage, VoyageManifestMessage, VoyageManifestStateSnapshotMessage, VoyageManifestsMessage}
 
 class ProtoBufSerializer extends SerializerWithStringManifest {
@@ -27,6 +28,8 @@ class ProtoBufSerializer extends SerializerWithStringManifest {
   final val VoyageManifestLatestFileName: String = classOf[VoyageManifestLatestFileNameMessage].getName
   final val VoyageManifests: String = classOf[VoyageManifestsMessage].getName
   final val VoyageManifest: String = classOf[VoyageManifestMessage].getName
+  final val Alerts: String = classOf[Alert].getName
+  final val AlertSnapshot: String = classOf[AlertSnapshotMessage].getName
 
   override def toBinary(objectToSerialize: AnyRef): Array[Byte] = {
     objectToSerialize match {
@@ -43,6 +46,8 @@ class ProtoBufSerializer extends SerializerWithStringManifest {
       case m: VoyageManifestLatestFileNameMessage => m.toByteArray
       case m: VoyageManifestsMessage => m.toByteArray
       case m: VoyageManifestMessage => m.toByteArray
+      case m: Alert => m.toByteArray
+      case m: AlertSnapshotMessage => m.toByteArray
     }
   }
 
@@ -63,6 +68,8 @@ class ProtoBufSerializer extends SerializerWithStringManifest {
       case VoyageManifestLatestFileName => VoyageManifestLatestFileNameMessage.parseFrom(bytes)
       case VoyageManifests => VoyageManifestsMessage.parseFrom(bytes)
       case VoyageManifest => VoyageManifestMessage.parseFrom(bytes)
+      case AlertSnapshot => AlertSnapshotMessage.parseFrom(bytes)
+      case Alerts => Alert.parseFrom(bytes)
     }
   }
 }

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -330,6 +330,12 @@ class Application @Inject()(implicit val config: Configuration,
         } else throw new Exception("You do not have permission manage users")
       }
 
+      def getAlerts(createdAfter: MillisSinceEpoch): Future[Seq[Alert]] = {
+        for {
+          alerts <- (ctrl.alertsActor ? GetState).mapTo[Seq[Alert]]
+        } yield alerts.filter(a => a.createdAt > createdAfter)
+      }
+
       override def liveCrunchStateActor: AskableActorRef = ctrl.liveCrunchStateActor
 
       override def forecastCrunchStateActor: AskableActorRef = ctrl.forecastCrunchStateActor

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -164,6 +164,7 @@ class Application @Inject()(implicit val config: Configuration,
                             ec: ExecutionContext)
   extends InjectedController
     with AirportConfProvider
+    with ApplicationWithAlerts
     with ProdPassengerSplitProviders
     with ImplicitTimeoutProvider {
 

--- a/server/src/main/scala/controllers/ApplicationWithAlerts.scala
+++ b/server/src/main/scala/controllers/ApplicationWithAlerts.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import actors.GetState
+import actors.{DeleteAlerts, GetState}
 import akka.actor._
 import akka.pattern._
 import akka.util.Timeout
@@ -23,20 +23,24 @@ trait ApplicationWithAlerts {
 
       request.body.asJson.map { json =>
         val alertMessage = json.as[AlertMessage]
-        ctrl.alertsActor ! Alert(alertMessage.message, alertMessage.expires.getMillis, createdAt = DateTime.now.getMillis)
+        ctrl.alertsActor ! Alert(
+          alertMessage.title,
+          alertMessage.message,
+          alertMessage.expires.getMillis,
+          createdAt = DateTime.now.getMillis
+        )
         Ok("done!")
       }.getOrElse {
         BadRequest("{\"error\": \"Unable to parse data\"}")
       }
   }
 
-  def getAlerts = Action.async {
-    val futureShifts = ctrl.alertsActor.ask(GetState)(new Timeout(5 second))
-    futureShifts.map(s =>
+  def deleteAlerts = Action.async {
+    val futureAlerts = ctrl.alertsActor.ask(DeleteAlerts)(new Timeout(5 second))
+    futureAlerts.map(s =>
       Ok(s.toString)
-
     )
   }
 }
 
-case class AlertMessage(message: String, expires: DateTime)
+case class AlertMessage(title: String, message: String, expires: DateTime)

--- a/server/src/main/scala/controllers/ApplicationWithAlerts.scala
+++ b/server/src/main/scala/controllers/ApplicationWithAlerts.scala
@@ -1,0 +1,42 @@
+package controllers
+
+import actors.GetState
+import akka.actor._
+import akka.pattern._
+import akka.util.Timeout
+import drt.shared.Alert
+import org.joda.time.DateTime
+import play.api.libs.json.{JodaReads, Json}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+trait ApplicationWithAlerts {
+  self: Application =>
+  val pattern = "yyyy-MM-dd HH:mm:ss"
+  implicit val dateRead = JodaReads.jodaDateReads(pattern)
+  implicit val alertReads = Json.reads[AlertMessage]
+
+  def addAlert = Action {
+    implicit request =>
+
+      request.body.asJson.map { json =>
+        val alertMessage = json.as[AlertMessage]
+        ctrl.alertsActor ! Alert(alertMessage.message, alertMessage.expires.getMillis, createdAt = DateTime.now.getMillis)
+        Ok("done!")
+      }.getOrElse {
+        BadRequest("{\"error\": \"Unable to parse data\"}")
+      }
+  }
+
+  def getAlerts = Action.async {
+    val futureShifts = ctrl.alertsActor.ask(GetState)(new Timeout(5 second))
+    futureShifts.map(s =>
+      Ok(s.toString)
+
+    )
+  }
+}
+
+case class AlertMessage(message: String, expires: DateTime)

--- a/server/src/main/scala/services/ApiService.scala
+++ b/server/src/main/scala/services/ApiService.scala
@@ -83,6 +83,8 @@ abstract class ApiService(val airportConfig: AirportConfig,
 
   def getApplicationVersion(): String
 
+  def getAlerts(pointIntTime: MillisSinceEpoch): Future[Seq[Alert]]
+
   def airportConfiguration(): AirportConfig = airportConfig
 
   def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]]

--- a/server/src/test/scala/actors/AlertsActorSpec.scala
+++ b/server/src/test/scala/actors/AlertsActorSpec.scala
@@ -50,7 +50,7 @@ class AlertsActorSpec extends Specification {
   "AlertsActor" should {
     "return the message it that was set if only one message is sent" in new Context {
 
-      val alert = Alert("an alert", DateTime.now.plusDays(1).getMillis, DateTime.now.getMillis)
+      val alert = Alert("alert title", "this is the alert message", DateTime.now.plusDays(1).getMillis, DateTime.now.getMillis)
 
       actor ! alert
 

--- a/server/src/test/scala/actors/AlertsActorSpec.scala
+++ b/server/src/test/scala/actors/AlertsActorSpec.scala
@@ -1,0 +1,63 @@
+package actors
+
+import java.util.UUID
+import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.pattern._
+import akka.util.Timeout
+import controllers.AkkaTestkitSpecs2SupportForPersistence
+import drt.shared.Alert
+import org.joda.time.DateTime
+import org.specs2.matcher.Scope
+import org.specs2.mutable.Specification
+import scala.concurrent.Await
+import scala.concurrent.duration._
+import scala.language.reflectiveCalls
+
+class AlertsActorSpec extends Specification {
+  sequential
+  isolated
+
+  private def alertsActor(system: ActorSystem) = {
+    val actor = system.actorOf(Props(classOf[AlertsActor]), "alertsActor")
+    actor
+  }
+
+  implicit val timeout: Timeout = Timeout(5 seconds)
+
+  def getTestKit = {
+    new AkkaTestkitSpecs2SupportForPersistence("target/test") {
+      def getActor: ActorRef = alertsActor(system)
+
+      def getState(actor: ActorRef) = {
+        Await.result(actor ? GetState, 1 second)
+      }
+
+      def getStateAndShutdown(actor: ActorRef): Any = {
+        val s = getState(actor)
+        shutDownActorSystem
+        s
+      }
+    }
+  }
+
+  trait Context extends Scope {
+    val testKit2 = getTestKit
+    val actor: ActorRef = testKit2.getActor
+    val date = "2017-01-01"
+    val movementUuid: UUID = UUID.randomUUID()
+  }
+
+  "AlertsActor" should {
+    "return the message it that was set if only one message is sent" in new Context {
+
+      val alert = Alert("an alert", DateTime.now.plusDays(1).getMillis, DateTime.now.getMillis)
+
+      actor ! alert
+
+      val result = testKit2.getStateAndShutdown(actor)
+
+      result mustEqual List(alert)
+    }
+  }
+
+}

--- a/shared/src/main/scala/drt/shared/Alert.scala
+++ b/shared/src/main/scala/drt/shared/Alert.scala
@@ -1,0 +1,6 @@
+package drt.shared
+
+import drt.shared.CrunchApi.MillisSinceEpoch
+
+case class Alert(message: String, expires: MillisSinceEpoch, createdAt: MillisSinceEpoch)
+

--- a/shared/src/main/scala/drt/shared/Alert.scala
+++ b/shared/src/main/scala/drt/shared/Alert.scala
@@ -2,5 +2,5 @@ package drt.shared
 
 import drt.shared.CrunchApi.MillisSinceEpoch
 
-case class Alert(message: String, expires: MillisSinceEpoch, createdAt: MillisSinceEpoch)
+case class Alert(title: String, message: String, expires: MillisSinceEpoch, createdAt: MillisSinceEpoch)
 

--- a/shared/src/main/scala/drt/shared/Api.scala
+++ b/shared/src/main/scala/drt/shared/Api.scala
@@ -599,6 +599,8 @@ object CrunchApi {
 trait Api {
   def getApplicationVersion(): String
 
+  def getAlerts(createdAfter: MillisSinceEpoch): Future[Seq[Alert]]
+
   def airportInfoByAirportCode(code: String): Future[Option[AirportInfo]]
 
   def airportInfosByAirportCodes(codes: Set[String]): Future[Map[String, AirportInfo]]


### PR DESCRIPTION
# Create an alert system in the app for things like downtime - MVP

#### Rather than sending emails to ports regarding DRT releases, feed issues etc it has been suggested we create a facility to display alerts / notifications within DRT itself.


* A visible message in the top bar

<img width="1222" alt="screen shot 2018-08-20 at 14 59 00" src="https://user-images.githubusercontent.com/369407/44345024-00c2ab00-a48a-11e8-9cc7-a84232d75406.png">

* The message has a mandatory expiry date, however when setting it you have to set it in **UTC** time **not** BST.

* A POST endpoint to set an alert via Postman

```
URL: http://localhost:9000/v2/ema/live/data/alert
{
  "title" : "API is down",
  "message" : "We know that the API is down, our team can currently do nothing to resolve this issue as we are dependant on DPS to resolve issues with their feed. We will update you with more information shortly.",
  "expires" : "2018-08-20 14:25:00"
}
```

* The User has the ability to close all alerts and the page will continue to poll for alerts that have not seen yet.

* There is an endpoint to DELETE all alerts (it's the same url with a DELETE instead of a POST)
