### PR TITLE
Revert 560 fixing e2e tests

### DIFF
--- a/client/src/main/scala/drt/client/SPAMain.scala
+++ b/client/src/main/scala/drt/client/SPAMain.scala
@@ -4,6 +4,7 @@ import diode.Action
 import drt.client.actions.Actions._
 import drt.client.components.{GlobalStyles, KeyCloakUsersPage, Layout, StatusPage, TerminalComponent, TerminalPlanningComponent, TerminalsDashboardPage}
 import drt.client.logger._
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.JSDateConversions.SDate
 import drt.client.services._
 import drt.client.services.handlers.GetFeedStatuses

--- a/client/src/main/scala/drt/client/actions/Actions.scala
+++ b/client/src/main/scala/drt/client/actions/Actions.scala
@@ -33,6 +33,8 @@ object Actions {
 
   case class UpdateCrunchStateAndContinuePolling(crunchState: CrunchState) extends Action
 
+  case class UpdateCrunchStateFromUpdates(crunchUpdates: CrunchUpdates) extends Action
+
   case class UpdateCrunchStateFromUpdatesAndContinuePolling(crunchUpdates: CrunchUpdates) extends Action
 
   case class UpdateCrunchStateFromCrunchState(crunchState: CrunchState) extends Action

--- a/client/src/main/scala/drt/client/actions/Actions.scala
+++ b/client/src/main/scala/drt/client/actions/Actions.scala
@@ -31,17 +31,13 @@ object Actions {
 
   case class GetCrunchState() extends Action
 
-  case class GetCrunchUpdates() extends Action
-
-  case class SetCrunchPending() extends Action
-
   case class UpdateCrunchStateAndContinuePolling(crunchState: CrunchState) extends Action
 
   case class UpdateCrunchStateFromUpdatesAndContinuePolling(crunchUpdates: CrunchUpdates) extends Action
 
   case class UpdateCrunchStateFromCrunchState(crunchState: CrunchState) extends Action
 
-  case class UpdateCrunchStateFromUpdates(crunchUpdates: CrunchUpdates) extends Action
+  case class NoCrunchStateUpdatesAndContinuePollingIfNecessary() extends Action
 
   case class GetForecastWeek(startDay: SDateLike, terminalName: TerminalName) extends Action
 

--- a/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
+++ b/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
@@ -71,7 +71,7 @@ object FlightsWithSplitsTable {
                 }.toTagMod)))
         }
         else
-          <.div("Loading flights...")
+          <.div("No flights to display")
       } match {
         case Success(s) => s
         case Failure(f) =>

--- a/client/src/main/scala/drt/client/components/TerminalComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalComponent.scala
@@ -3,6 +3,7 @@ package drt.client.components
 import diode.data.{Pending, Pot}
 import drt.client.SPAMain.{Loc, TerminalPageTabLoc}
 import drt.client.logger.{Logger, LoggerFactory}
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.JSDateConversions.SDate
 import drt.client.services._
 import drt.shared.CrunchApi.{CrunchState, ForecastPeriodWithHeadlines}
@@ -87,18 +88,22 @@ object TerminalComponent {
 
           val subMode = if (props.terminalPageTab.mode == "staffing") "desksAndQueues" else props.terminalPageTab.subMode
 
+          val gaPage = s"${airportConfig.portCode}-${props.terminalPageTab.terminal}"
+
           <.div(
             <.ul(^.className := "nav nav-tabs",
               <.li(^.className := currentClass,
                 <.a(^.id := "currentTab", VdomAttr("data-toggle") := "tab", "Current"), ^.onClick --> {
-                props.router.set(props.terminalPageTab.copy(
-                  mode = "current",
-                  subMode = subMode,
-                  date = None
-                ))
+                  GoogleEventTracker.sendPageView(s"$gaPage-current")
+                  props.router.set(props.terminalPageTab.copy(
+                    mode = "current",
+                    subMode = subMode,
+                    date = None
+                  ))
               }),
               <.li(^.className := snapshotDataClass,
                 <.a(^.id := "snapshotTab", VdomAttr("data-toggle") := "tab", "Snapshot"), ^.onClick --> {
+                  GoogleEventTracker.sendPageView(s"$gaPage-snapshot")
                   props.router.set(props.terminalPageTab.copy(
                     mode = "snapshot",
                     subMode = subMode,
@@ -108,6 +113,7 @@ object TerminalComponent {
               ),
               <.li(^.className := planningClass,
                 <.a(^.id := "planningTab", VdomAttr("data-toggle") := "tab", "Planning"), ^.onClick --> {
+                  GoogleEventTracker.sendPageView(s"$gaPage-planning")
                   props.router.set(props.terminalPageTab.copy(mode = "planning", subMode = subMode, date = None))
                 }
               ),
@@ -115,6 +121,7 @@ object TerminalComponent {
                 loggedInUser => if (loggedInUser.roles.contains(StaffEdit))
                   <.li(^.className := staffingClass,
                     <.a(^.id := "monthlyStaffingTab", VdomAttr("data-toggle") := "tab", "Monthly Staffing"), ^.onClick --> {
+                      GoogleEventTracker.sendPageView(s"$gaPage-monthly-staffing")
                       props.router.set(props.terminalPageTab.copy(mode = "staffing", subMode = "15", date = None))
                     }
                   ) else ""

--- a/client/src/main/scala/drt/client/components/TerminalComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalComponent.scala
@@ -35,11 +35,6 @@ object TerminalComponent {
                             minuteTicker: Int
                           )
 
-  implicit val pageReuse: Reusability[TerminalPageTabLoc] = Reusability.derive[TerminalPageTabLoc]
-  implicit val propsReuse: Reusability[Props] = Reusability.by(p =>
-    (p.terminalPageTab, p.router)
-  )
-
   val component = ScalaComponent.builder[Props]("Terminal")
     .render_P(props => {
       val modelRCP = SPACircuit.connect(model => TerminalModel(
@@ -176,7 +171,6 @@ object TerminalComponent {
       })
     })
     .componentDidMount((p) => Callback.log("TerminalComponent did mount"))
-    .configure(Reusability.shouldComponentUpdate)
     .build
 
   def apply(props: Props): VdomElement = component(props)

--- a/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
@@ -8,7 +8,7 @@ import drt.client.components.FlightComponents.paxComp
 import drt.client.logger.log
 import drt.client.services.JSDateConversions.SDate
 import drt.client.services.{SPACircuit, ViewMode}
-import drt.shared.CrunchApi.{CrunchState, MillisSinceEpoch}
+import drt.shared.CrunchApi.CrunchState
 import drt.shared.FlightsApi.TerminalName
 import drt.shared._
 import japgolly.scalajs.react.extra.Reusability
@@ -101,81 +101,87 @@ object TerminalContentComponent {
 
       val timeRangeHours: CustomWindow = timeRange(props)
 
-      <.div(^.className := s"view-mode-content $viewModeStr",
-        <.div(^.className := "tabs-with-export",
-          <.ul(^.className := "nav nav-tabs",
-            <.li(^.className := desksAndQueuesActive,
-              <.a(^.id := "desksAndQueuesTab", VdomAttr("data-toggle") := "tab", "Desks & Queues"), ^.onClick --> {
-              props.router.set(props.terminalPageTab.copy(subMode = "desksAndQueues"))
-            }),
-            <.li(^.className := arrivalsActive,
-              <.a(^.id := "arrivalsTab", VdomAttr("data-toggle") := "tab", "Arrivals"), ^.onClick --> {
-              props.router.set(props.terminalPageTab.copy(subMode = "arrivals"))
-            }),
-            <.li(^.className := staffingActive,
-              <.a(^.id := "staffMovementsTab", VdomAttr("data-toggle") := "tab", "Staff Movements"), ^.onClick --> {
-              props.router.set(props.terminalPageTab.copy(subMode = "staffing"))
-            })
-          ),
-          <.div(^.className := "exports",
-            <.a("Export Arrivals",
-              ^.className := "btn btn-default",
-              ^.href := s"${dom.window.location.pathname}/export/arrivals/${props.terminalPageTab.viewMode.millis}/${props.terminalPageTab.terminal}?startHour=${timeRangeHours.start}&endHour=${timeRangeHours.end}",
-              ^.target := "_blank"
+      <.div(
+        props.crunchStatePot.renderPending(_ => if (props.crunchStatePot.isEmpty) <.div(^.id := "terminal-spinner", Icon.spinner) else ""),
+        props.crunchStatePot.renderEmpty( if (!props.crunchStatePot.isPending) { <.div(^.id := "terminal-data", "Nothing to show for this time period")} else ""),
+        props.crunchStatePot.render((crunchState: CrunchState) => {
+          <.div(^.className := s"view-mode-content $viewModeStr",
+            <.div(^.className := "tabs-with-export",
+              <.ul(^.className := "nav nav-tabs",
+                <.li(^.className := desksAndQueuesActive,
+                  <.a(^.id := "desksAndQueuesTab", VdomAttr("data-toggle") := "tab", "Desks & Queues"), ^.onClick --> {
+                    props.router.set(props.terminalPageTab.copy(subMode = "desksAndQueues"))
+                  }),
+                <.li(^.className := arrivalsActive,
+                  <.a(^.id := "arrivalsTab", VdomAttr("data-toggle") := "tab", "Arrivals"), ^.onClick --> {
+                    props.router.set(props.terminalPageTab.copy(subMode = "arrivals"))
+                  }),
+                <.li(^.className := staffingActive,
+                  <.a(^.id := "staffMovementsTab", VdomAttr("data-toggle") := "tab", "Staff Movements"), ^.onClick --> {
+                    props.router.set(props.terminalPageTab.copy(subMode = "staffing"))
+                  })
+              ),
+              <.div(^.className := "exports",
+                <.a("Export Arrivals",
+                  ^.className := "btn btn-default",
+                  ^.href := s"${dom.window.location.pathname}/export/arrivals/${props.terminalPageTab.viewMode.millis}/${props.terminalPageTab.terminal}?startHour=${timeRangeHours.start}&endHour=${timeRangeHours.end}",
+                  ^.target := "_blank"
+                ),
+                <.a(
+                  "Export Desks",
+                  ^.className := "btn btn-default",
+                  ^.href := s"${dom.window.location.pathname}/export/desks/${props.terminalPageTab.viewMode.millis}/${props.terminalPageTab.terminal}?startHour=${timeRangeHours.start}&endHour=${timeRangeHours.end}",
+                  ^.target := "_blank"
+                ),
+                MultiDayExportComponent(props.terminalPageTab.terminal, props.terminalPageTab.dateFromUrlOrNow)
+              )
             ),
-            <.a(
-              "Export Desks",
-              ^.className := "btn btn-default",
-              ^.href := s"${dom.window.location.pathname}/export/desks/${props.terminalPageTab.viewMode.millis}/${props.terminalPageTab.terminal}?startHour=${timeRangeHours.start}&endHour=${timeRangeHours.end}",
-              ^.target := "_blank"
-            ),
-            MultiDayExportComponent(props.terminalPageTab.terminal, props.terminalPageTab.dateFromUrlOrNow)
-          )
-        ),
-        <.div(^.className := "tab-content",
-          <.div(^.id := "desksAndQueues", ^.className := s"tab-pane terminal-desk-recs-container $desksAndQueuesPanelActive",
-            if (state.activeTab == "desksAndQueues") {
-              log.info(s"Rendering desks and queue")
-              props.crunchStatePot.render(crunchState => {
-                props.loggedInUserPot.render( loggedInUser => {
-                  val filteredPortState = filterCrunchStateByRange(props.terminalPageTab.viewMode.time, timeRangeHours, crunchState, props.terminalPageTab.terminal)
-                  TerminalDesksAndQueues(
-                    TerminalDesksAndQueues.Props(
-                      filteredPortState,
-                      props.airportConfig,
-                      props.terminalPageTab.terminal,
-                      props.showActuals,
-                      props.viewMode,
-                      loggedInUser
+            <.div(^.className := "tab-content",
+              <.div(^.id := "desksAndQueues", ^.className := s"tab-pane terminal-desk-recs-container $desksAndQueuesPanelActive",
+                if (state.activeTab == "desksAndQueues") {
+                  log.info(s"Rendering desks and queue")
+                  props.loggedInUserPot.render(loggedInUser => {
+                    val filteredPortState = filterCrunchStateByRange(props.terminalPageTab.viewMode.time, timeRangeHours, crunchState, props.terminalPageTab.terminal)
+                    TerminalDesksAndQueues(
+                      TerminalDesksAndQueues.Props(
+                        filteredPortState,
+                        props.airportConfig,
+                        props.terminalPageTab.terminal,
+                        props.showActuals,
+                        props.viewMode,
+                        loggedInUser
+                      )
                     )
+                  })
+                } else ""
+              ),
+              <.div(^.id := "arrivals", ^.className := s"tab-pane in $arrivalsPanelActive", {
+                if (state.activeTab == "arrivals") {
+                  <.div(props.crunchStatePot.render((crunchState: CrunchState) => {
+                    val filteredPortState = filterCrunchStateByRange(props.terminalPageTab.viewMode.time, timeRangeHours, crunchState, props.terminalPageTab.terminal)
+                    arrivalsTableComponent(FlightsWithSplitsTable.Props(filteredPortState.flights.toList, queueOrder, props.airportConfig.hasEstChox))
+                  }),
+                    props.crunchStatePot.renderEmpty("No flights")
                   )
-                })
-              })
-            } else ""
-          ),
-          <.div(^.id := "arrivals", ^.className := s"tab-pane in $arrivalsPanelActive", {
-            if (state.activeTab == "arrivals") {
-              <.div(props.crunchStatePot.render((crunchState: CrunchState) => {
-                val filteredPortState = filterCrunchStateByRange(props.terminalPageTab.viewMode.time, timeRangeHours, crunchState, props.terminalPageTab.terminal)
-                arrivalsTableComponent(FlightsWithSplitsTable.Props(filteredPortState.flights.toList, queueOrder, props.airportConfig.hasEstChox))
-              }))
-            } else ""
-          }),
-          <.div(^.id := "available-staff", ^.className := s"tab-pane terminal-staffing-container $staffingPanelActive",
-            if (state.activeTab == "staffing") {
-              TerminalStaffing(TerminalStaffing.Props(
-                props.terminalPageTab.terminal,
-                props.potShifts,
-                props.potFixedPoints,
-                props.potStaffMovements,
-                props.airportConfig,
-                props.loggedInUserPot,
-                props.viewMode
+                } else ""
+              }),
+              <.div(^.id := "available-staff", ^.className := s"tab-pane terminal-staffing-container $staffingPanelActive",
+                if (state.activeTab == "staffing") {
+                  TerminalStaffing(TerminalStaffing.Props(
+                    props.terminalPageTab.terminal,
+                    props.potShifts,
+                    props.potFixedPoints,
+                    props.potStaffMovements,
+                    props.airportConfig,
+                    props.loggedInUserPot,
+                    props.viewMode
+                  ))
+                } else ""
               ))
-            } else ""
-          ))
-      )
+          )
+        }))
     }
+
   }
 
   def timeRange(props: Props): CustomWindow = {
@@ -189,7 +195,6 @@ object TerminalContentComponent {
     .initialStateFromProps(p => State(p.terminalPageTab.subMode))
     .renderBackend[TerminalContentComponent.Backend]
     .componentDidMount(_ => Callback.log(s"terminal component didMount"))
-    .configure(Reusability.shouldComponentUpdate)
     .build
 
   def apply(props: Props): VdomElement = component(props)

--- a/client/src/main/scala/drt/client/components/TerminalsDashboardPage.scala
+++ b/client/src/main/scala/drt/client/components/TerminalsDashboardPage.scala
@@ -1,6 +1,7 @@
 package drt.client.components
 
 import drt.client.SPAMain.{Loc, TerminalsDashboardLoc}
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.JSDateConversions.SDate
 import drt.client.services.SPACircuit
 import drt.shared.{ApiFlightWithSplits, SDateLike}

--- a/client/src/main/scala/drt/client/modules/GoogleAnalytics.scala
+++ b/client/src/main/scala/drt/client/modules/GoogleAnalytics.scala
@@ -1,0 +1,26 @@
+package drt.client.modules
+
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobalScope
+
+object GoogleEventTracker {
+  def isScriptLoaded: Boolean =js.Dynamic.global.analytics.isInstanceOf[js.Function]
+  def sendPageView(page:String):Unit={
+    if (isScriptLoaded) GoogleAnalytics.analytics("send","event","pageView", page)
+  }
+  def sendEvent(category:String,action:String,label:String):Unit={
+    if (isScriptLoaded) GoogleAnalytics.analytics("send","event",category,action,label)
+  }
+  def sendEvent(category:String,action:String,label:String,value:String):Unit={
+    if (isScriptLoaded) GoogleAnalytics.analytics("send","event",category,action,label,value)
+  }
+}
+
+@js.native
+@JSGlobalScope
+object GoogleAnalytics extends js.Any {
+  def analytics(send:String,event:String,category:String,action:String): Unit = js.native
+  def analytics(send:String,event:String,category:String,action:String,label:String ): Unit = js.native
+  def analytics(send:String,event:String,category:String,action:String,label:String,value:js.Any ): Unit = js.native
+}

--- a/client/src/main/scala/drt/client/services/handlers/CrunchUpdatesHandler.scala
+++ b/client/src/main/scala/drt/client/services/handlers/CrunchUpdatesHandler.scala
@@ -2,7 +2,6 @@ package drt.client.services.handlers
 
 import autowire._
 import boopickle.Default._
-import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 import diode.Implicits.runAfterImpl
 import diode._
 import diode.data._
@@ -44,14 +43,24 @@ class CrunchUpdatesHandler[M](airportConfigPot: () => Pot[AirportConfig],
 
       crunchState match {
         case Ready(thing) =>
-          log.info(s"set crunchstate pendingstale")
           updated((PendingStale(thing), latestUpdateMillis), effects)
         case _ =>
           effectOnly(effects)
       }
 
+    case NoCrunchStateUpdatesAndContinuePollingIfNecessary() =>
+      val pollCrunchUpdatesIfTodayOrAFutureDate = viewMode() match {
+        case ViewDay(time) => time.millisSinceEpoch > midnightThisMorning.millisSinceEpoch
+        case ViewPointInTime(_) => false
+        case _ => true
+      }
+      val thereIsNoData = modelRW.value._1.headOption.isEmpty
+      val allEffects = if (pollCrunchUpdatesIfTodayOrAFutureDate) Effect(Future(HideLoader())) + getCrunchUpdatesAfterDelay else Effect(Future(HideLoader()))
+      if (thereIsNoData) updated((Empty, latestUpdateMillis), allEffects) else effectOnly(allEffects)
+
     case UpdateCrunchStateFromCrunchState(crunchState: CrunchState) =>
-      val oldCodes = value._1.map(cs => cs.flights.map(_.apiFlight.Origin)).getOrElse(Set())
+      val oldCodes =
+        value._1.map(cs => cs.flights.map(_.apiFlight.Origin)).getOrElse(Set())
       val newCodes = crunchState.flights.map(_.apiFlight.Origin)
       val unseenCodes = newCodes -- oldCodes
       val allEffects = if (unseenCodes.nonEmpty) {
@@ -64,27 +73,14 @@ class CrunchUpdatesHandler[M](airportConfigPot: () => Pot[AirportConfig],
       updated((Ready(crunchState), 0L), allEffects)
 
     case UpdateCrunchStateFromUpdatesAndContinuePolling(crunchUpdates: CrunchUpdates) =>
-      val getCrunchStateAfterDelay = Effect(Future(GetCrunchState())).after(crunchUpdatesRequestFrequency)
-      val updateCrunchState = Effect(Future(UpdateCrunchStateFromUpdates(crunchUpdates)))
-      val effects = getCrunchStateAfterDelay + updateCrunchState
-
+      log.info(s"Client got ${crunchUpdates.flights.size} flights & ${crunchUpdates.minutes.size} minutes from CrunchUpdates")
       val oldCodes = value._1.map(cs => cs.flights.map(_.apiFlight.Origin)).getOrElse(Set())
       val newCodes = crunchUpdates.flights.map(_.apiFlight.Origin)
       val unseenCodes = newCodes -- oldCodes
       val allEffects = if (unseenCodes.nonEmpty) {
         log.info(s"Requesting airport infos. Got unseen origin ports: ${unseenCodes.mkString(",")}")
-        effects + Effect(Future(GetAirportInfos(newCodes)))
-      } else effects
-
-      effectOnly(allEffects)
-
-    case SetCrunchPending() =>
-      log.info(s"Clearing out the crunch stuff")
-      log.info(s"set crunchstate pending")
-      updated((Pending(), 0L))
-
-    case UpdateCrunchStateFromUpdates(crunchUpdates) =>
-      log.info(s"Client got ${crunchUpdates.flights.size} flights & ${crunchUpdates.minutes.size} minutes from CrunchUpdates")
+        getCrunchUpdatesAfterDelay + Effect(Future(GetAirportInfos(newCodes)))
+      } else getCrunchUpdatesAfterDelay + Effect(Future(HideLoader()))
 
       val someStateExists = !value._1.isEmpty
 
@@ -93,9 +89,10 @@ class CrunchUpdatesHandler[M](airportConfigPot: () => Pot[AirportConfig],
         updateStateFromUpdates(crunchUpdates, existingState)
       } else newStateFromUpdates(crunchUpdates)
 
-      log.info(s"set crunchstate pendingstale")
-      updated((PendingStale(newState), crunchUpdates.latest), Effect(Future(HideLoader())))
+      updated((PendingStale(newState), crunchUpdates.latest), allEffects)
   }
+
+  def getCrunchUpdatesAfterDelay: Effect = Effect(Future(GetCrunchState())).after(crunchUpdatesRequestFrequency)
 
   def requestHistoricCrunchState(viewMode: ViewMode): Future[Action] = {
     log.info(s"Requesting CrunchState for point in time ${viewMode.time.prettyDateTime()}")
@@ -109,28 +106,32 @@ class CrunchUpdatesHandler[M](airportConfigPot: () => Pot[AirportConfig],
       case ViewDay(time) =>
         log.info(s"Calling getCrunchStateForDay ${time.prettyDateTime()}")
         AjaxClient[Api].getCrunchStateForDay(time.millisSinceEpoch).call()
-      case _ => Future(None)
+      case _ => Future(Right(None))
     }
 
     processFutureCrunch(futureCrunchState)
   }
 
-  def processFutureCrunch[U](call: Future[Option[U]]): Future[Action] = {
+  def processFutureCrunch[U, E](call: Future[Either[E, Option[U]]]): Future[Action] = {
     call.map {
-      case Some(cs: CrunchState) =>
-        log.info(s"Got CrunchState with ${cs.flights.size} flights, ${cs.crunchMinutes.size} minutes")
-        UpdateCrunchStateFromCrunchState(cs)
-      case Some(cu: CrunchUpdates) =>
-        log.info(s"Got CrunchUpdates with ${cu.flights.size} flights, ${cu.minutes.size} minutes")
-        UpdateCrunchStateFromUpdatesAndContinuePolling(cu)
-      case _ =>
-        log.info(s"No updates. Re-requesting after $crunchUpdatesRequestFrequency")
-        RetryActionAfter(GetCrunchState(), crunchUpdatesRequestFrequency)
-    }.recoverWith {
-      case _ =>
-        log.info(s"Failed to GetCrunchState. Re-requesting after ${PollDelay.recoveryDelay}")
-        Future(RetryActionAfter(GetCrunchState(), PollDelay.recoveryDelay))
-    }
+        case Right(Some(cs: CrunchState)) =>
+          log.info(s"Got CrunchState with ${cs.flights.size} flights, ${cs.crunchMinutes.size} minutes")
+          if (cs.isEmpty) NoCrunchStateUpdatesAndContinuePollingIfNecessary() else UpdateCrunchStateFromCrunchState(cs)
+        case Right(Some(cu: CrunchUpdates)) =>
+          log.info(s"Got CrunchUpdates with ${cu.flights.size} flights, ${cu.minutes.size} minutes")
+          UpdateCrunchStateFromUpdatesAndContinuePolling(cu)
+        case Left(e: CrunchStateError) =>
+          log.error(s"Failed to GetCrunchState ${e.message}. Re-requesting after ${PollDelay.recoveryDelay}")
+          RetryActionAfter(GetCrunchState(), PollDelay.recoveryDelay)
+        case _ =>
+          log.info(s"No CrunchUpdates ${SDate.now().getSeconds()}")
+          NoCrunchStateUpdatesAndContinuePollingIfNecessary()
+      }
+      .recoverWith {
+        case _ =>
+          log.error(s"Failed to GetCrunchState. Re-requesting after ${PollDelay.recoveryDelay}")
+          Future(RetryActionAfter(GetCrunchState(), PollDelay.recoveryDelay))
+      }
   }
 
   def requestCrunchUpdates(pointInTime: SDateLike): Future[Action] = {

--- a/client/src/main/scala/drt/client/services/handlers/LoaderHandler.scala
+++ b/client/src/main/scala/drt/client/services/handlers/LoaderHandler.scala
@@ -6,9 +6,7 @@ import drt.client.services.LoadingState
 
 class LoaderHandler[M](modelRW: ModelRW[M, LoadingState]) extends LoggingActionHandler(modelRW) {
   protected def handle: PartialFunction[Any, ActionResult[M]] = {
-    case ShowLoader() =>
-      updated(LoadingState(isLoading = true))
-    case HideLoader() =>
-      updated(LoadingState(isLoading = false))
+    case ShowLoader() => updated(LoadingState(isLoading = true))
+    case HideLoader() => updated(LoadingState(isLoading = false))
   }
 }

--- a/client/src/main/scala/drt/client/services/handlers/ViewModeHandler.scala
+++ b/client/src/main/scala/drt/client/services/handlers/ViewModeHandler.scala
@@ -1,7 +1,7 @@
 package drt.client.services.handlers
 
 import diode.data.{Empty, Pending, PendingStale, Pot}
-import diode.{data, _}
+import diode.{ActionResult, Effect, ModelR, ModelRW}
 import drt.client.actions.Actions.{GetCrunchState, GetShifts, GetStaffMovements, SetViewMode}
 import drt.client.logger.log
 import drt.client.services.JSDateConversions.SDate
@@ -42,6 +42,9 @@ class ViewModeHandler[M](viewModeCrunchStateMP: ModelRW[M, (ViewMode, Pot[Crunch
           updated((newViewMode, Pending(), latestUpdateMillis))
         case (cv, nv, Empty) if cv != nv && isViewModeAbleToPoll(cv) && isViewModeAbleToPoll(nv)  =>
           log.info("crunch: Setting to Pending from Empty")
+          updated((newViewMode, Pending(), latestUpdateMillis))
+        case (cv, nv, Empty) if cv == nv && isViewModeAbleToPoll(cv) && latestUpdateMillis != 0L =>
+          log.info("crunch: Setting to Pending from Empty for live or future")
           updated((newViewMode, Pending(), latestUpdateMillis))
         case _ =>
           log.info("crunch: will poll")

--- a/client/src/main/scala/drt/client/services/handlers/ViewModeHandler.scala
+++ b/client/src/main/scala/drt/client/services/handlers/ViewModeHandler.scala
@@ -1,16 +1,27 @@
 package drt.client.services.handlers
 
-import diode.data.{Pending, PendingStale, Pot}
-import diode.{ActionResult, Effect, ModelR, ModelRW}
+import diode.data.{Empty, Pending, PendingStale, Pot}
+import diode.{data, _}
 import drt.client.actions.Actions.{GetCrunchState, GetShifts, GetStaffMovements, SetViewMode}
 import drt.client.logger.log
+import drt.client.services.JSDateConversions.SDate
 import drt.client.services.{ViewDay, ViewLive, ViewMode}
 import drt.shared.CrunchApi.{CrunchState, MillisSinceEpoch}
+import drt.shared.SDateLike
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class ViewModeHandler[M](viewModeCrunchStateMP: ModelRW[M, (ViewMode, Pot[CrunchState], MillisSinceEpoch)], crunchStateMP: ModelR[M, Pot[CrunchState]]) extends LoggingActionHandler(viewModeCrunchStateMP) {
+
+  def midnightThisMorning: SDateLike = SDate.dayStart(SDate.now())
+
+  def isViewModeAbleToPoll(viewMode: ViewMode): Boolean =   viewMode match {
+    case ViewLive() => true
+    case ViewDay(time) if time.millisSinceEpoch >= midnightThisMorning.millisSinceEpoch => true
+    case _ => false
+  }
+
   protected def handle: PartialFunction[Any, ActionResult[M]] = {
     case SetViewMode(newViewMode) =>
       val (currentViewMode, _, currentLatestUpdateMillis) = value
@@ -21,15 +32,19 @@ class ViewModeHandler[M](viewModeCrunchStateMP: ModelRW[M, (ViewMode, Pot[Crunch
         case _ => currentLatestUpdateMillis
       }
 
-      log.info(s"VM: Set client newViewMode from $currentViewMode to $newViewMode. latestUpdateMillis: $latestUpdateMillis")
+      log.info(s"VM: Set client newViewMode from $currentViewMode to $newViewMode. latestUpdateMillis: $latestUpdateMillis, crunchStateMP: ${crunchStateMP.value.getClass.getSimpleName}")
       (currentViewMode, newViewMode, crunchStateMP.value) match {
-        case (_, _, cs@Pending(_)) =>
-          updated((newViewMode, cs, latestUpdateMillis))
-        case (ViewLive(), nvm, PendingStale(_, _)) if nvm != ViewLive() =>
+        case (cv, nv, pendingStale@PendingStale(_, _)) if cv == nv && isViewModeAbleToPoll(cv) =>
+          log.info("crunch: Setting to PS from PS for live or future")
+          updated((newViewMode, pendingStale, latestUpdateMillis))
+        case (_, nv, PendingStale(_, _)) if isViewModeAbleToPoll(nv)  =>
+          log.info("crunch: Setting to Pending from PS")
           updated((newViewMode, Pending(), latestUpdateMillis))
-        case (_, _, cs@PendingStale(_, _)) =>
-          updated((newViewMode, cs, latestUpdateMillis))
+        case (cv, nv, Empty) if cv != nv && isViewModeAbleToPoll(cv) && isViewModeAbleToPoll(nv)  =>
+          log.info("crunch: Setting to Pending from Empty")
+          updated((newViewMode, Pending(), latestUpdateMillis))
         case _ =>
+          log.info("crunch: will poll")
           val effects = Effect(Future(GetCrunchState())) + Effect(Future(GetStaffMovements())) + Effect(Future(GetShifts()))
           updated((newViewMode, Pending(), latestUpdateMillis), effects)
       }

--- a/e2e/cypress.json
+++ b/e2e/cypress.json
@@ -1,6 +1,7 @@
 {
   "baseUrl": "http://localhost:9000",
   "defaultCommandTimeout": 15000,
+  "pageLoadTimeout": 100000,
   "viewportWidth": 1440,
   "viewportHeight": 900
 }

--- a/e2e/cypress/integration/alerts.js
+++ b/e2e/cypress/integration/alerts.js
@@ -8,6 +8,11 @@ describe('Alerts system', function () {
     deleteAlerts();
 
   });
+
+  afterEach(function() {
+    deleteAlerts();
+  });
+
   function deleteAlerts() {
     cy.request('DELETE', '/v2/test/live/data/alert');
 

--- a/e2e/cypress/integration/arrival.js
+++ b/e2e/cypress/integration/arrival.js
@@ -45,6 +45,10 @@ describe('Arrivals page', () => {
     cy.request('DELETE', '/v2/test/live/test/data');
   });
 
+  after(() => {
+    cy.request('DELETE', '/v2/test/live/test/data');
+  });
+
   const manifest = {
     "EventCode": "DC",
     "DeparturePortCode": "AMS",

--- a/e2e/cypress/integration/staff-movements.js
+++ b/e2e/cypress/integration/staff-movements.js
@@ -2,7 +2,7 @@ describe('Staff movements', function () {
   var userName = "Unknown";
 
   beforeEach(function () {
-    cy.request('DELETE', '/v2/test/live/test/data');
+    deleteTestData();
     var schDT = new Date().toISOString().split("T")[0];
     cy.request('POST',
       '/v2/test/live/test/arrival',
@@ -29,6 +29,10 @@ describe('Staff movements', function () {
         "SchDT": schDT + "T00:15:00Z"
       });
   });
+
+  function deleteTestData() {
+    cy.request('DELETE', '/v2/test/live/test/data');
+  }
 
   function addMovementFor1HourAt(numStaff, hour) {
     for (let i = 0; i < numStaff; i++) {
@@ -149,6 +153,7 @@ describe('Staff movements', function () {
       checkStaffNumbersOnMovementsTabAre(2);
       checkUserNameOnMovementsTab(2);
       removeXMovements(2);
+      deleteTestData();
     });
   });
 });

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -146,10 +146,13 @@
       "dev": true
     },
     "asn1": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-      "dev": true
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "2.1.2"
+      }
     },
     "assert-plus": {
       "version": "1.0.0",
@@ -179,9 +182,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "babel-runtime": {
@@ -255,7 +258,7 @@
       "requires": {
         "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "supports-color": "5.4.0"
+        "supports-color": "5.5.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -268,9 +271,9 @@
           }
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "3.0.0"
@@ -285,9 +288,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-      "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.4.0.tgz",
+      "integrity": "sha512-Oqmw2pVfCl8sCL+1QgMywPfdxPJPkC51y4usw0iiE2S9qnEOAqXy8bwl1CpMpnoU39g4iKJTz6QZj+28FvOnjQ==",
       "dev": true
     },
     "cli-cursor": {
@@ -403,15 +406,15 @@
       "requires": {
         "nice-try": "1.0.4",
         "path-key": "2.0.1",
-        "semver": "5.5.0",
+        "semver": "5.5.1",
         "shebang-command": "1.2.0",
         "which": "1.3.1"
       }
     },
     "cypress": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.0.3.tgz",
-      "integrity": "sha512-reo2M0/lKTfE/zgHeDtOjd17L+RVM0VY26GxJ7+haz1uNFKU5bytLsS0lZKC0BOYu1Hc6jZGkH+B0pzoexNU/A==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-3.1.0.tgz",
+      "integrity": "sha512-UqLbXgHvM8Y6Y+roHrepZMWcyMN5u4KcjpTbJTZi0d5O2Prvtqmnpoky7a4C65q4oRQXeSc6cBZUhxJkhU4pbQ==",
       "dev": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "0.4.1",
@@ -780,7 +783,7 @@
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.3"
+        "ci-info": "1.4.0"
       }
     },
     "is-finite": {
@@ -1366,7 +1369,7 @@
       "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
+        "aws4": "1.8.0",
         "caseless": "0.12.0",
         "combined-stream": "1.0.6",
         "extend": "3.0.2",
@@ -1428,9 +1431,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
       "dev": true
     },
     "shebang-command": {
@@ -1466,7 +1469,7 @@
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
+        "asn1": "0.2.4",
         "assert-plus": "1.0.0",
         "bcrypt-pbkdf": "1.0.2",
         "dashdash": "1.14.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -9,7 +9,7 @@
   "author": "UK Home Office",
   "license": "UNLICENSED",
   "devDependencies": {
-    "cypress": "^3.0.3",
+    "cypress": "^3.1.0",
     "moment": "^2.22.2",
     "moment-timezone": "^0.5.21"
   }

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -1,8 +1,6 @@
 package controllers
 
 import java.nio.ByteBuffer
-import javax.inject.{Inject, Singleton}
-
 import actors._
 import actors.pointInTime.CrunchStateReadActor
 import akka.actor._
@@ -37,15 +35,13 @@ import services.graphstages.Crunch._
 import services.shifts.StaffTimeSlots
 import services.workloadcalculator.PaxLoadCalculator
 import services.workloadcalculator.PaxLoadCalculator.PaxTypeAndQueueCount
-import services.{SDate, _}
+import services._
 import test.TestDrtSystem
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.language.postfixOps
 import scala.util.matching.Regex
-//import scala.collection.immutable.Seq // do not import this here, it would break autowire.
 import services.PcpArrival.pcpFrom
 
 object Router extends autowire.Server[ByteBuffer, Pickler, Pickler] {
@@ -214,13 +210,13 @@ class Application @Inject()(implicit val config: Configuration,
 
       def actorSystem: ActorSystem = system
 
-      def getCrunchStateForDay(day: MillisSinceEpoch): Future[Option[CrunchState]] = loadBestCrunchStateForPointInTime(day)
+      def getCrunchStateForDay(day: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] = loadBestCrunchStateForPointInTime(day)
 
       def getApplicationVersion(): String = BuildInfo.version
 
-      override def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Option[CrunchState]] = crunchStateAtPointInTime(pointInTime)
+      override def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] = crunchStateAtPointInTime(pointInTime)
 
-      def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Option[CrunchUpdates]] = {
+      def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchUpdates]]] = {
         val liveStateCutOff = getLocalNextMidnight(ctrl.now()).addDays(1).millisSinceEpoch
 
         val stateActor = if (windowStartMillis < liveStateCutOff) liveCrunchStateActor else forecastCrunchStateActor
@@ -228,12 +224,12 @@ class Application @Inject()(implicit val config: Configuration,
         val crunchStateFuture = stateActor.ask(GetUpdatesSince(sinceMillis, windowStartMillis, windowEndMillis))(new Timeout(30 seconds))
 
         crunchStateFuture.map {
-          case Some(cu: CrunchUpdates) => Option(cu)
-          case _ => None
+          case Some(cu: CrunchUpdates) => Right(Option(cu))
+          case _ => Right(None)
         } recover {
           case t =>
             log.warn(s"Didn't get a CrunchUpdates: $t")
-            None
+            Left(CrunchStateError(t.getMessage))
         }
       }
 
@@ -347,31 +343,31 @@ class Application @Inject()(implicit val config: Configuration,
     }
   }
 
-  def loadBestCrunchStateForPointInTime(day: MillisSinceEpoch): Future[Option[CrunchState]] =
+  def loadBestCrunchStateForPointInTime(day: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] =
     if (isHistoricDate(day)) {
       crunchStateForEndOfDay(day)
     } else if (day <= getLocalNextMidnight(SDate.now()).millisSinceEpoch) {
       ctrl.liveCrunchStateActor.ask(GetState).map {
-        case Some(PortState(f, m, s)) => Option(CrunchState(f.values.toSet, m.values.toSet, s.values.toSet))
-        case _ => None
+        case Some(PortState(f, m, s)) => Right(Option(CrunchState(f.values.toSet, m.values.toSet, s.values.toSet)))
+        case _ => Right(None)
       }
     } else {
       crunchStateForDayInForecast(day)
     }
 
-  def crunchStateForDayInForecast(day: MillisSinceEpoch): Future[Option[CrunchState]] = {
+  def crunchStateForDayInForecast(day: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] = {
     val firstMinute = getLocalLastMidnight(SDate(day)).millisSinceEpoch
     val lastMinute = SDate(firstMinute).addHours(airportConfig.dayLengthHours).millisSinceEpoch
 
     val crunchStateFuture = ctrl.forecastCrunchStateActor.ask(GetPortState(firstMinute, lastMinute))(new Timeout(30 seconds))
 
     crunchStateFuture.map {
-      case Some(PortState(f, m, s)) => Option(CrunchState(f.values.toSet, m.values.toSet, s.values.toSet))
-      case _ => None
+      case Some(PortState(f, m, s)) => Right(Option(CrunchState(f.values.toSet, m.values.toSet, s.values.toSet)))
+      case _ => Right(None)
     } recover {
       case t =>
         log.warning(s"Didn't get a CrunchState: $t")
-        None
+        Left(CrunchStateError(t.getMessage))
     }
   }
 
@@ -384,7 +380,7 @@ class Application @Inject()(implicit val config: Configuration,
   }
 
 
-  def crunchStateAtPointInTime(pointInTime: MillisSinceEpoch): Future[Option[CrunchState]] = {
+  def crunchStateAtPointInTime(pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] = {
     val relativeLastMidnight = getLocalLastMidnight(SDate(pointInTime)).millisSinceEpoch
     val startMillis = relativeLastMidnight
     val endMillis = relativeLastMidnight + oneHourMillis * airportConfig.dayLengthHours
@@ -392,7 +388,7 @@ class Application @Inject()(implicit val config: Configuration,
     portStatePeriodAtPointInTime(startMillis, endMillis, pointInTime)
   }
 
-  def crunchStateForEndOfDay(day: MillisSinceEpoch): Future[Option[CrunchState]] = {
+  def crunchStateForEndOfDay(day: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] = {
     val relativeLastMidnight = getLocalLastMidnight(SDate(day)).millisSinceEpoch
     val startMillis = relativeLastMidnight
     val endMillis = relativeLastMidnight + oneHourMillis * airportConfig.dayLengthHours
@@ -401,16 +397,16 @@ class Application @Inject()(implicit val config: Configuration,
     portStatePeriodAtPointInTime(startMillis, endMillis, pointInTime)
   }
 
-  def portStatePeriodAtPointInTime(startMillis: MillisSinceEpoch, endMillis: MillisSinceEpoch, pointInTime: MillisSinceEpoch): Future[Option[CrunchState]] = {
+  def portStatePeriodAtPointInTime(startMillis: MillisSinceEpoch, endMillis: MillisSinceEpoch, pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]] = {
     val query = CachableActorQuery(Props(classOf[CrunchStateReadActor], airportConfig.portStateSnapshotInterval, SDate(pointInTime), airportConfig.queues), GetPortState(startMillis, endMillis))
     val portCrunchResult = cacheActorRef.ask(query)(new Timeout(30 seconds))
     portCrunchResult.map {
-      case Some(PortState(f, m, s)) => Option(CrunchState(f.values.toSet, m.values.toSet, s.values.toSet))
-      case _ => None
+      case Some(PortState(f, m, s)) => Right(Option(CrunchState(f.values.toSet, m.values.toSet, s.values.toSet)))
+      case _ => Right(None)
     }.recover {
       case t =>
         log.warning(s"Didn't get a point-in-time CrunchState: $t")
-        None
+        Left(CrunchStateError(t.getMessage))
     }
   }
 
@@ -445,7 +441,7 @@ class Application @Inject()(implicit val config: Configuration,
                         pointInTime: MilliDate,
                         startHour: Int,
                         endHour: Int,
-                        crunchStateFuture: Future[Option[CrunchState]]
+                        crunchStateFuture: Future[Either[CrunchStateError, Option[CrunchState]]]
                       ): Future[Option[String]] = {
 
     val startDateTime = getLocalLastMidnight(pointInTime).addHours(startHour)
@@ -454,7 +450,7 @@ class Application @Inject()(implicit val config: Configuration,
 
     val localTime = SDate(pointInTime, europeLondonTimeZone)
     crunchStateFuture.map {
-      case Some(CrunchState(_, cm, sm)) =>
+      case Right(Some(CrunchState(_, cm, sm))) =>
         log.debug(s"Exports: ${localTime.toISOString()} Got ${cm.size} CMs and ${sm.size} SMs ")
         val cmForDay: Set[CrunchMinute] = cm.filter(cm => isInRange(SDate(cm.minute, europeLondonTimeZone)))
         val smForDay: Set[StaffMinute] = sm.filter(sm => isInRange(SDate(sm.minute, europeLondonTimeZone)))
@@ -654,7 +650,7 @@ class Application @Inject()(implicit val config: Configuration,
                                       pit: MilliDate,
                                       startHour: Int,
                                       endHour: Int,
-                                      crunchStateFuture: Future[Option[CrunchState]]
+                                      crunchStateFuture: Future[Either[CrunchStateError, Option[CrunchState]]]
                                     ): Future[Option[List[ApiFlightWithSplits]]] = {
 
     val startDateTime = getLocalLastMidnight(pit).addHours(startHour)
@@ -662,7 +658,7 @@ class Application @Inject()(implicit val config: Configuration,
     val isInRange = isInRangeOnDay(startDateTime, endDateTime) _
 
     crunchStateFuture.map {
-      case Some(CrunchState(fs, _, _)) =>
+      case Right(Some(CrunchState(fs, _, _))) =>
 
         val flightsForTerminalInRange = fs.toList
           .filter(_.apiFlight.Terminal == terminalName)

--- a/server/src/main/scala/services/ApiService.scala
+++ b/server/src/main/scala/services/ApiService.scala
@@ -87,11 +87,11 @@ abstract class ApiService(val airportConfig: AirportConfig,
 
   def airportConfiguration(): AirportConfig = airportConfig
 
-  def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Option[CrunchState]]
+  def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]]
 
-  def getCrunchStateForDay(day: MillisSinceEpoch): Future[Option[CrunchState]]
+  def getCrunchStateForDay(day: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]]
 
-  def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Option[CrunchUpdates]]
+  def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchUpdates]]]
 
   def forecastWeekSummary(startDay: MillisSinceEpoch, terminal: TerminalName): Future[Option[ForecastPeriodWithHeadlines]]
 

--- a/server/src/main/twirl/views/index.scala.html
+++ b/server/src/main/twirl/views/index.scala.html
@@ -12,18 +12,12 @@
         <link href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
         <link rel="shortcut icon" type="image/png" href=@_asset("images/favicon.png") >
         <script>
-                (function (i, s, o, g, r, a, m) {
-                    i['GoogleAnalyticsObject'] = r;
-                    i[r] = i[r] || function () {
-                                (i[r].q = i[r].q || []).push(arguments)
-                            }, i[r].l = 1 * new Date();
-                    a = s.createElement(o),
-                            m = s.getElementsByTagName(o)[0];
-                    a.async = 1;
-                    a.src = g;
-                    m.parentNode.insertBefore(a, m)
-                })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
-                ga('create', 'UA-83931001-1', 'auto');
+                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                })(window,document,'script','//www.google-analytics.com/analytics.js','analytics');
+
+                analytics('create', 'UA-83931001-1', 'auto');
         </script>
     </head>
 

--- a/shared/src/main/scala/drt/shared/Api.scala
+++ b/shared/src/main/scala/drt/shared/Api.scala
@@ -340,6 +340,8 @@ object PassengerSplits {
 object CrunchApi {
   type MillisSinceEpoch = Long
 
+  case class CrunchStateError(message: String)
+
   case class CrunchState(flights: Set[ApiFlightWithSplits],
                          crunchMinutes: Set[CrunchMinute],
                          staffMinutes: Set[StaffMinute]) {
@@ -356,6 +358,8 @@ object CrunchApi {
       val windowsStaffMinutes = staffMinutes.filter(sm => start.millisSinceEpoch <= sm.minute && sm.minute <= end.millisSinceEpoch && sm.terminalName == terminalName)
       CrunchState(windowedFlights, windowedCrunchMinutes, windowsStaffMinutes)
     }
+
+    def isEmpty: Boolean = flights.isEmpty && crunchMinutes.isEmpty && staffMinutes.isEmpty
   }
 
   case class PortState(flights: Map[Int, ApiFlightWithSplits],
@@ -617,11 +621,11 @@ trait Api {
 
   def getShiftsForMonth(month: MillisSinceEpoch, terminalName: TerminalName): Future[String]
 
-  def getCrunchStateForDay(day: MillisSinceEpoch): Future[Option[CrunchState]]
+  def getCrunchStateForDay(day: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]]
 
-  def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Option[CrunchState]]
+  def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]]
 
-  def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Option[CrunchUpdates]]
+  def getCrunchUpdates(sinceMillis: MillisSinceEpoch, windowStartMillis: MillisSinceEpoch, windowEndMillis: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchUpdates]]]
 
   def forecastWeekSummary(startDay: MillisSinceEpoch, terminal: TerminalName): Future[Option[ForecastPeriodWithHeadlines]]
 


### PR DESCRIPTION
This is the puts back the PR [#552 Loading flights message](https://github.com/UKHomeOffice/drt-v2/pull/552)

> - Shows "No flights to display" when there are no arrivals in the time period selected but there are crunch state on the selected day on the Arrivals tab.
> - Shows a spinner when it's requesting crunch for a time period. i.e. It does not show the Desks & Queues, Arrivals and Staff Movements tab.
> - Shows "Nothing to show for this time period" when there are no crunch state for the selected time period. i.e. It does not show the Desks & Queues, Arrivals and Staff Movements tab.
> - Will show the Desks & Queues, Arrivals and Staff Movements tab when the crunch data arrives.

The PR was fine when running locally, however not when running it in production mode. There was a Javascript bug around google analytics that caused the site to stop working. It seemed to complain about two functions with the name `ga` are in scope. I do not know how this would stop the site from working but it did!

- I renamed the google analytics function so that it does not clash with the other unknown function with the name `ga`.
- We were not logging any page views which defeats the point of google analytics, so I logged a few.

If you ever see a JS function with the name of `ga` do rename it.
 
