### PR TITLE
Drt 5203 - Restrict access for users by port

### DIFF
--- a/client/src/main/scala/drt/client/actions/Actions.scala
+++ b/client/src/main/scala/drt/client/actions/Actions.scala
@@ -47,7 +47,7 @@ object Actions {
 
   case class GetAirportConfig() extends Action
 
-  case class UpdateAirportConfig(airportConfig: AirportConfig) extends Action
+  case class UpdateAirportConfig(airportConfigOption: Option[AirportConfig]) extends Action
 
   case class SetFixedPoints(fixedPoints: String, terminalName: Option[String]) extends Action
 

--- a/client/src/main/scala/drt/client/components/Layout.scala
+++ b/client/src/main/scala/drt/client/components/Layout.scala
@@ -1,6 +1,10 @@
 package drt.client.components
 
+import diode.data.Pot
+import diode.react.ModelProxy
 import drt.client.SPAMain._
+import drt.client.services.SPACircuit
+import drt.shared.{AirportConfig, Alert}
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.extra.router.{Resolution, RouterCtl}
 import japgolly.scalajs.react.vdom.html_<^._
@@ -13,13 +17,27 @@ object Layout {
 
   val component = ScalaComponent.builder[Props]("Layout")
     .renderP((_, props: Props) => {
+      val modelRCP = SPACircuit.connect(m => (m.airportConfig, m.loggedInUserPot))
       <.div(
         <.div(^.className := "main-logo"),
         AlertsComponent(),
         <.div(
           // here we use plain Bootstrap class names as these are specific to the top level layout defined here
           Navbar(props.ctl, props.currentLoc.page),
-          <.div(^.className := "container", props.currentLoc.render()),
+          <.div(^.className := "container",
+            modelRCP(modelPotMP => {
+              val (airportConfigPot, loggedInUserPot) = modelPotMP()
+              <.div(
+                loggedInUserPot.render(_ =>
+                  <.div(
+                  airportConfigPot.render(_ => props.currentLoc.render()),
+                  airportConfigPot.renderEmpty( if (!airportConfigPot.isPending) {RestrictedAccessByPortPage()} else "" )
+                  )
+                )
+              )
+            }
+            )
+          ),
           VersionUpdateNotice()
         )
       )

--- a/client/src/main/scala/drt/client/components/MainMenu.scala
+++ b/client/src/main/scala/drt/client/components/MainMenu.scala
@@ -16,7 +16,7 @@ import scala.collection.immutable
 object MainMenu {
   @inline private def bss: BootstrapStyles.type = GlobalStyles.bootstrapStyles
 
-  case class Props(router: RouterCtl[Loc], currentLoc: Loc, feeds: Seq[FeedStatuses], airportConfig: AirportConfig, roles: Seq[Role])
+  case class Props(router: RouterCtl[Loc], currentLoc: Loc, feeds: Seq[FeedStatuses], airportConfig: AirportConfig, roles: Set[Role])
 
   case class MenuItem(idx: Int, label: Props => VdomNode, icon: Icon, location: Loc, classes: List[String] = List())
 
@@ -41,7 +41,7 @@ object MainMenu {
     (ManageUsers, alertsMenuItem _)
   )
 
-  def menuItems(airportConfig: AirportConfig, currentLoc: Loc, userRoles: Seq[Role], feeds: Seq[FeedStatuses]): List[MenuItem] = {
+  def menuItems(airportConfig: AirportConfig, currentLoc: Loc, userRoles: Set[Role], feeds: Seq[FeedStatuses]): List[MenuItem] = {
     def terminalDepsMenuItems(idxOffset: Int): List[MenuItem] = airportConfig.terminalNames.zipWithIndex.map {
       case (tn, idx) =>
         val targetLoc = currentLoc match {
@@ -60,7 +60,7 @@ object MainMenu {
     (nonTerminalMenuItems ::: terminalDepsMenuItems(nonTerminalMenuItems.length)) :+ statusMenuItem(nonTerminalMenuItems.length + airportConfig.terminalNames.length, feeds)
   }
 
-  private def restrictedMenuItemsForRole(roles: Seq[Role], startIndex: Int): List[MenuItem] = {
+  private def restrictedMenuItemsForRole(roles: Set[Role], startIndex: Int): List[MenuItem] = {
     val itemsForLoggedInUser = restrictedMenuItems.collect {
       case (role, menuItemCallback) if roles.contains(role) => menuItemCallback
     }.zipWithIndex.map {
@@ -98,6 +98,6 @@ object MainMenu {
     .renderBackend[Backend]
     .build
 
-  def apply(ctl: RouterCtl[Loc], currentLoc: Loc, feeds: Seq[FeedStatuses], airportConfig: AirportConfig, roles: Seq[Role]): VdomElement
+  def apply(ctl: RouterCtl[Loc], currentLoc: Loc, feeds: Seq[FeedStatuses], airportConfig: AirportConfig, roles: Set[Role]): VdomElement
   = component(Props(ctl, currentLoc, feeds, airportConfig, roles))
 }

--- a/client/src/main/scala/drt/client/components/RestrictedAccessByPortPage.scala
+++ b/client/src/main/scala/drt/client/components/RestrictedAccessByPortPage.scala
@@ -34,18 +34,18 @@ object RestrictedAccessByPortPage {
         modelRCP(modelPotMP => {
           val loggedInUserPot = modelPotMP()
           <.span(
-            <.h2("Access Restricted"),
+            <.h2(^.id:="access-restricted", "Access Restricted"),
             loggedInUserPot.render(loggedInUser => {
               val portsAccessible: Set[String] = allPortsAccessible(loggedInUser.roles)
               <.div(
-                <.p(s"You do not have access to your desired port $portRequested. If you would like access to this port, " +
+                <.p(^.id:="email-for-access", s"You do not have access to your desired port $portRequested. If you would like access to this port, " +
                   "please ", <.a("click here to send an email", ^.href := s"mailto:drtdevteam@digital.homeoffice.gov.uk;drtenquiries@homeoffice.gov.uk?subject=request access to port $portRequested for ${loggedInUser.email}&body=I, ${loggedInUser.email}, would like to request access to $portRequested."), " to request access."),
                 if (portsAccessible.nonEmpty) {
-                  <.div(
+                  <.div(^.id:="alternate-ports",
                     <.p("Alternatively you are able to access the following ports"),
                     <.ul(
                       portsAccessible.map(port =>
-                        <.li(^.key := port, <.a(port, ^.href := url(port)))
+                        <.li(^.key := port, <.a(^.id:=s"$port-link", port, ^.href := url(port)))
                       ).toVdomArray
                     )
                   )

--- a/client/src/main/scala/drt/client/components/RestrictedAccessByPortPage.scala
+++ b/client/src/main/scala/drt/client/components/RestrictedAccessByPortPage.scala
@@ -1,0 +1,65 @@
+package drt.client.components
+
+import drt.client.logger.{Logger, LoggerFactory}
+import drt.client.modules.GoogleEventTracker
+import drt.client.services.SPACircuit
+import drt.shared.CrunchApi.MillisSinceEpoch
+import drt.shared.{AirportConfigs, Role}
+import japgolly.scalajs.react.ScalaComponent
+import japgolly.scalajs.react.vdom.html_<^.{^, _}
+import org.scalajs.dom
+
+object RestrictedAccessByPortPage {
+
+  val log: Logger = LoggerFactory.getLogger(getClass.getName)
+
+  case class State(title: Option[String] = None, message: Option[String] = None, expiryDateTime: Option[MillisSinceEpoch] = None)
+
+  val component = ScalaComponent.builder[Unit]("Restricted Access On Port")
+    .render(_ => {
+      val modelRCP = SPACircuit.connect(m => m.loggedInUserPot)
+
+      val allAirportConfigs = AirportConfigs.allPorts diff AirportConfigs.testPorts
+      val allPorts = allAirportConfigs.map(config => config.portCode.toLowerCase)
+      val urlLowerCase = dom.document.URL.toLowerCase
+      val portRequested = allPorts.find(port => urlLowerCase.contains(s"/$port/")).map(_.toUpperCase).getOrElse("unknown port code")
+
+      def allPortsAccessible(roles: Set[Role]): Set[String] = allAirportConfigs.filter(airportConfig => roles.contains(airportConfig.role)).map(_.portCode).toSet
+
+      def url(port: String) = urlLowerCase.replace(s"/${portRequested.toLowerCase}/", s"/${port.toLowerCase}/")
+
+      GoogleEventTracker.sendPageView(s"$portRequested-access-restricted")
+
+      <.div(
+        modelRCP(modelPotMP => {
+          val loggedInUserPot = modelPotMP()
+          <.span(
+            <.h2("Access Restricted"),
+            loggedInUserPot.render(loggedInUser => {
+              val portsAccessible: Set[String] = allPortsAccessible(loggedInUser.roles)
+              <.div(
+                <.p(s"You do not have access to your desired port $portRequested. If you would like access to this port, " +
+                  "please ", <.a("click here to send an email", ^.href := s"mailto:drtdevteam@digital.homeoffice.gov.uk;drtenquiries@homeoffice.gov.uk?subject=request access to port $portRequested for ${loggedInUser.email}&body=I, ${loggedInUser.email}, would like to request access to $portRequested."), " to request access."),
+                if (portsAccessible.nonEmpty) {
+                  <.div(
+                    <.p("Alternatively you are able to access the following ports"),
+                    <.ul(
+                      portsAccessible.map(port =>
+                        <.li(^.key := port, <.a(port, ^.href := url(port)))
+                      ).toVdomArray
+                    )
+                  )
+                } else ""
+              )
+            }
+
+            )
+
+          )
+        })
+      )
+    })
+    .build
+
+  def apply(): VdomElement = component()
+}

--- a/client/src/main/scala/drt/client/services/handlers/AirportConfigHandler.scala
+++ b/client/src/main/scala/drt/client/services/handlers/AirportConfigHandler.scala
@@ -3,13 +3,12 @@ package drt.client.services.handlers
 import autowire._
 import boopickle.Default._
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
-import diode.data.{Pending, Pot, Ready}
+import diode.data.{Empty, Pending, Pot, Ready}
 import diode.{ActionResult, Effect, ModelRW}
 import drt.client.actions.Actions.{GetAirportConfig, RetryActionAfter, UpdateAirportConfig}
 import drt.client.logger.log
 import drt.client.services.{AjaxClient, PollDelay}
 import drt.shared.{AirportConfig, Api}
-
 import scala.concurrent.Future
 
 class AirportConfigHandler[M](modelRW: ModelRW[M, Pot[AirportConfig]]) extends LoggingActionHandler(modelRW) {
@@ -21,7 +20,8 @@ class AirportConfigHandler[M](modelRW: ModelRW[M, Pot[AirportConfig]]) extends L
           log.error(s"CrunchState request failed. Re-requesting after ${PollDelay.recoveryDelay}")
           Future(RetryActionAfter(GetAirportConfig(), PollDelay.recoveryDelay))
       }))
-    case UpdateAirportConfig(configHolder) =>
-      updated(Ready(configHolder))
+    case UpdateAirportConfig(airportConfigOption) =>
+      val pot = airportConfigOption.map(Ready(_)).getOrElse(Empty)
+      updated(pot)
   }
 }

--- a/e2e/cypress/integration/alerts.js
+++ b/e2e/cypress/integration/alerts.js
@@ -4,14 +4,19 @@ describe('Alerts system', function () {
   let timeAtEndOfDay = "23:59:59";
   let timeAtStartOfDay = "00:00:00";
 
+
   beforeEach(function () {
     deleteAlerts();
-
+    setRoles(["api:view"]);
   });
 
   afterEach(function() {
     deleteAlerts();
   });
+
+  function setRoles(roles) {
+    cy.request("POST", 'v2/test/live/test/mock-roles', {"roles": roles})
+  }
 
   function deleteAlerts() {
     cy.request('DELETE', '/v2/test/live/data/alert');

--- a/e2e/cypress/integration/arrival.js
+++ b/e2e/cypress/integration/arrival.js
@@ -43,6 +43,7 @@ describe('Arrivals page', () => {
 
   before(() => {
     cy.request('DELETE', '/v2/test/live/test/data');
+    setRoles(["api:view"]);
   });
 
   after(() => {
@@ -131,6 +132,7 @@ describe('Arrivals page', () => {
 
   it('Does not show API splits in the flights export for regular users', () => {
     loadManifestFixture();
+    setRoles([""]);
     cy.request('POST', '/v2/test/live/test/manifest', manifest);
     cy.request('GET', '/v2/test/live/export/arrivals/' + currentMillis + '/T1?startHour=0&endHour=24').then((resp) => {
       expect(resp.body).to.equal(csvWithNoApiSplits)

--- a/e2e/cypress/integration/monthly-staffing.js
+++ b/e2e/cypress/integration/monthly-staffing.js
@@ -47,7 +47,7 @@ describe('Monthly Staffing', function () {
     it("If I enter staff for the current month those staff should still be visible if I change months and change back", function () {
       saveShifts();
 
-      setRoles(["staff:edit"]);
+      setRoles(["staff:edit", "api:view"]);
 
       cy.visit('/v2/test/live#terminal/T1/staffing/15///');
       cy.get(cellToTest).contains("1");

--- a/e2e/cypress/integration/restrict-access-by-port.js
+++ b/e2e/cypress/integration/restrict-access-by-port.js
@@ -1,0 +1,52 @@
+describe('Restrict access by port', function () {
+
+
+  function setRoles(roles) {
+    cy.request("POST", 'v2/test/live/test/mock-roles', {"roles": roles})
+  }
+
+  function navigateToHome() {
+    cy.visit('/v2/test/live').then(() => {
+      cy.contains('.navbar .container .navbar-drt', 'DRT TEST').end();
+    }).end();
+  }
+
+  function navigateToHomeAccessRestricted() {
+    cy.visit('/v2/test/live').then(() => {
+      cy.get('#access-restricted').should('exist').end();
+      cy.get('#email-for-access').should('exist').end();
+    }).end();
+  }
+
+  describe('Restrict access by port', function () {
+
+    it("When I have the correct permission to view the port I see the app", function () {
+      setRoles(["api:view"]);
+      navigateToHome();
+    });
+
+    it("When I do not have any permission to view the port I see access restricted page", function () {
+      setRoles(["bogus"]);
+      navigateToHomeAccessRestricted();
+      cy.get('#alternate-ports').should('not.exist');
+    });
+
+    it("When I only have permission to view LHR I see access restricted page with a link to LHR only", function () {
+      setRoles(["LHR"]);
+      navigateToHomeAccessRestricted();
+      cy.get('#alternate-ports').should('exist');
+      cy.contains('#LHR-link', 'LHR');
+      cy.get('#LGW-link').should('not.exist');
+    });
+
+    it("When I have permission to view LHR and LGW I see access restricted page with a link to both ports", function () {
+      setRoles(["LHR", "LGW"]);
+      navigateToHomeAccessRestricted();
+      cy.get('#alternate-ports').should('exist');
+      cy.contains('#LHR-link', 'LHR');
+      cy.contains('#LGW-link', 'LGW');
+    });
+
+  });
+
+});

--- a/e2e/cypress/integration/staff-movements.js
+++ b/e2e/cypress/integration/staff-movements.js
@@ -4,6 +4,7 @@ describe('Staff movements', function () {
   beforeEach(function () {
     deleteTestData();
     var schDT = new Date().toISOString().split("T")[0];
+    setRoles(["api:view"]);
     cy.request('POST',
       '/v2/test/live/test/arrival',
       {
@@ -30,6 +31,10 @@ describe('Staff movements', function () {
       });
   });
 
+  function setRoles(roles) {
+    cy.request("POST", 'v2/test/live/test/mock-roles', {"roles": roles})
+  }
+
   function deleteTestData() {
     cy.request('DELETE', '/v2/test/live/test/data');
   }
@@ -48,9 +53,9 @@ describe('Staff movements', function () {
     return cy.get(selector);
   }
 
-  function staffMovementsAtRow(row) {
+  function staffMovementsAtRow(row, numStaff) {
     const selector = 'td.non-pcp:nth($index)';
-    return cy.get(selector.replace('$index', row * 2 + 1));
+    cy.contains(selector.replace('$index', row * 2 + 1), numStaff);
   }
 
   function staffAvailableAtRow(row) {
@@ -65,14 +70,14 @@ describe('Staff movements', function () {
 
   function checkStaffNumbersOnDesksAndQueuesTabAre(numStaff) {
     [0, 1, 2, 3].map((row) => {
-      staffMovementsAtRow(row).contains(numStaff);
-      staffDeployedAtRow(row).contains(numStaff);
-      staffAvailableAtRow(row).contains(numStaff);
+      staffMovementsAtRow(row, numStaff);
+      staffDeployedAtRow(row, numStaff);
+      staffAvailableAtRow(row, numStaff);
     });
 
-    staffMovementsAtRow(4).contains("0");
+    staffMovementsAtRow(4, 0);
     staffDeployedAtRow(4).contains("0");
-    staffAvailableAtRow(4).contains("0");
+    staffAvailableAtRow(4, 0);
   }
 
   function checkStaffNumbersOnMovementsTabAre(numStaff) {

--- a/server/src/main/scala/actors/DrtSystem.scala
+++ b/server/src/main/scala/actors/DrtSystem.scala
@@ -131,7 +131,7 @@ case class DrtSystem(actorSystem: ActorSystem, config: Configuration, airportCon
   system.log.info(s"useNationalityBasedProcessingTimes: $useNationalityBasedProcessingTimes")
   system.log.info(s"useSplitsPrediction: $useSplitsPrediction")
 
-  def getRoles(config: Configuration, headers: Headers, session: Session): List[Role] =
+  def getRoles(config: Configuration, headers: Headers, session: Session): Set[Role] =
     if (config.getOptional[String]("feature-flags.super-user-mode").isDefined) {
       system.log.info(s"Using Super User Roles")
       Roles.availableRoles

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -142,9 +142,9 @@ class NoCacheFilter @Inject()(
 trait UserRoleProviderLike {
   val log: Logger = LoggerFactory.getLogger(getClass)
 
-  def userRolesFromHeader(headers: Headers): List[Role] = headers.get("X-Auth-Roles").map(_.split(",").flatMap(Roles.parse).toList).getOrElse(List.empty[Role])
+  def userRolesFromHeader(headers: Headers): Set[Role] = headers.get("X-Auth-Roles").map(_.split(",").flatMap(Roles.parse).toSet).getOrElse(Set.empty[Role])
 
-  def getRoles(config: Configuration, headers: Headers, session: Session): List[Role]
+  def getRoles(config: Configuration, headers: Headers, session: Session): Set[Role]
 
   def getLoggedInUser(config: Configuration, headers: Headers, session: Session): LoggedInUser = {
     LoggedInUser(

--- a/server/src/main/scala/services/ApiService.scala
+++ b/server/src/main/scala/services/ApiService.scala
@@ -89,7 +89,7 @@ abstract class ApiService(val airportConfig: AirportConfig,
 
   def saveAlert(alert: Alert): Unit
 
-  def airportConfiguration(): AirportConfig = airportConfig
+  def airportConfiguration(): Option[AirportConfig] = if (getLoggedInUser().roles.contains(airportConfig.role)) Option(airportConfig) else None
 
   def getCrunchStateForPointInTime(pointInTime: MillisSinceEpoch): Future[Either[CrunchStateError, Option[CrunchState]]]
 

--- a/server/src/main/scala/test/TestDrtSystem.scala
+++ b/server/src/main/scala/test/TestDrtSystem.scala
@@ -38,7 +38,7 @@ class TestDrtSystem(override val actorSystem: ActorSystem, override val config: 
 
   override def liveArrivalsSource(portCode: String): Source[ArrivalsFeedResponse, Cancellable] = testFeed
 
-  override def getRoles(config: Configuration, headers: Headers, session: Session): List[Role] = TestUserRoleProvider.getRoles(config, headers, session)
+  override def getRoles(config: Configuration, headers: Headers, session: Session): Set[Role] = TestUserRoleProvider.getRoles(config, headers, session)
 
   override def run(): Unit = {
 

--- a/server/src/test/scala/drt/shared/AirportConfigsSpec.scala
+++ b/server/src/test/scala/drt/shared/AirportConfigsSpec.scala
@@ -50,7 +50,8 @@ class AirportConfigsSpec extends Specification {
         defaultWalkTimeMillis = Map(),
         defaultPaxSplits = SplitRatios("queue", Nil),
         defaultProcessingTimes = Map(),
-        minMaxDesksByTerminalQueue = Map()
+        minMaxDesksByTerminalQueue = Map(),
+        role = LHRAccess
       )
 
       val result = clonedConfig.feedPortCode

--- a/server/src/test/scala/services/crunch/CrunchTestLike.scala
+++ b/server/src/test/scala/services/crunch/CrunchTestLike.scala
@@ -111,7 +111,8 @@ class CrunchTestLike
         Queues.NonEeaDesk -> ((List.fill[Int](24)(1), List.fill[Int](24)(20))),
         Queues.EGate -> ((List.fill[Int](24)(1), List.fill[Int](24)(20))))),
     timeToChoxMillis = 120000L,
-    firstPaxOffMillis = 180000L
+    firstPaxOffMillis = 180000L,
+    role = STNAccess
   )
 
   val splitsPredictorStage = new DummySplitsPredictor()

--- a/server/src/test/scala/services/inputfeeds/StreamFlightCrunchTests.scala
+++ b/server/src/test/scala/services/inputfeeds/StreamFlightCrunchTests.scala
@@ -85,7 +85,8 @@ object TestCrunchConfig {
         "Morning shift, A1, {date}, 07:00, 13:59, 15",
         "Afternoon shift, A1, {date}, 14:00, 16:59, 10",
         "Evening shift, A1, {date}, 17:00, 23:59,17"
-      )
+      ),
+      role = STNAccess
     )
   }
 

--- a/shared/src/main/scala/drt/shared/Api.scala
+++ b/shared/src/main/scala/drt/shared/Api.scala
@@ -609,7 +609,7 @@ trait Api {
 
   def airportInfosByAirportCodes(codes: Set[String]): Future[Map[String, AirportInfo]]
 
-  def airportConfiguration(): AirportConfig
+  def airportConfiguration(): Option[AirportConfig]
 
   def getShifts(pointIntTime: MillisSinceEpoch): Future[String]
 

--- a/shared/src/main/scala/drt/shared/HasAirportConfig.scala
+++ b/shared/src/main/scala/drt/shared/HasAirportConfig.scala
@@ -123,6 +123,7 @@ case class AirportConfig(
                           contactEmail: Option[String] = None,
                           dayLengthHours: Int = 36,
                           nationalityBasedProcTimes: Map[String, Double] = ProcessingTimes.nationalityProcessingTimes,
+                          role: Role,
                           cloneOfPortCode: Option[String] = None
                         ) extends AirportConfigLike {
 
@@ -285,7 +286,8 @@ object AirportConfigs {
       "Morning shift, A1, {date}, 07:00, 13:59, 15",
       "Afternoon shift, A1, {date}, 14:00, 16:59, 10",
       "Evening shift, A1, {date}, 17:00, 23:59, 17"
-    )
+    ),
+    role = EDIAccess
   )
   val lgw = AirportConfig(
     portCode = "LGW",
@@ -342,7 +344,8 @@ object AirportConfigs {
       "Morning shift, N, {date}, 07:00, 13:59, 15",
       "Afternoon shift, N, {date}, 14:00, 16:59, 10",
       "Evening shift, N, {date}, 17:00, 23:59, 17"
-    )
+    ),
+    role = LGWAccess
   )
   val stn = AirportConfig(
     portCode = "STN",
@@ -385,7 +388,8 @@ object AirportConfigs {
     ),
     fixedPointExamples = Seq("Roving Officer, 00:00, 23:59, 1",
       "Referral Officer, 00:00, 23:59, 1",
-      "Forgery Officer, 00:00, 23:59, 1")
+      "Forgery Officer, 00:00, 23:59, 1"),
+    role = STNAccess
   )
   val man = AirportConfig(
     portCode = "MAN",
@@ -422,7 +426,8 @@ object AirportConfigs {
       "Morning shift, T1, {date}, 07:00, 13:59, 30",
       "Afternoon shift, T1, {date}, 14:00, 16:59, 18",
       "Evening shift, T1, {date}, 17:00, 23:59, 22"
-    )
+    ),
+    role = MANAccess
   )
   private val lhrDefaultTerminalProcessingTimes = Map(
     eeaMachineReadableToDesk -> 25d / 60,
@@ -500,7 +505,8 @@ object AirportConfigs {
     hasActualDeskStats = true,
     portStateSnapshotInterval = 250,
     hasEstChox = true,
-    exportQueueOrder = Queues.exportQueueOrderWithFastTrack
+    exportQueueOrder = Queues.exportQueueOrderWithFastTrack,
+    role = LHRAccess
   )
   val ltn = AirportConfig(
     portCode = "LTN",
@@ -518,7 +524,8 @@ object AirportConfigs {
         Queues.EeaDesk -> (List.fill(24)(1), List(6, 9, 9, 9, 9, 9, 9, 8, 6, 6, 6, 6, 6, 6, 7, 7, 7, 8, 6, 6, 7, 8, 6, 6)),
         Queues.NonEeaDesk -> (List.fill(24)(1), List(4, 1, 1, 1, 1, 1, 1, 2, 4, 4, 4, 4, 4, 4, 3, 3, 3, 2, 4, 4, 3, 2, 4, 4))
       )
-    )
+    ),
+    role = LTNAccess
   )
   val ema = AirportConfig(
     portCode = "EMA",
@@ -555,7 +562,8 @@ object AirportConfigs {
         Queues.EGate -> (List(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), List(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)),
         Queues.QueueDesk -> (List(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), List(5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5))
       )
-    )
+    ),
+    role = EMAAccess
   )
 
   val brs = AirportConfig(
@@ -593,7 +601,8 @@ object AirportConfigs {
         Queues.EGate -> (List(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), List(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1)),
         Queues.QueueDesk -> (List(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), List(5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5))
       )
-    )
+    ),
+    role = BRSAccess
   )
 
   val bhx = AirportConfig(
@@ -641,7 +650,8 @@ object AirportConfigs {
         Queues.NonEeaDesk -> (List(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
           List(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1))
       )
-    )
+    ),
+    role = BHXAccess
   )
 
   val test = AirportConfig(
@@ -675,7 +685,8 @@ object AirportConfigs {
         Queues.EeaDesk -> (List(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), List(13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13)),
         Queues.EGate -> (List(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), List(8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8))
       )
-    )
+    ),
+    role = ApiView
   )
 
 
@@ -689,5 +700,6 @@ object AirportConfigs {
   val lhr_nbp_halved: AirportConfig = lhr_ppt_halved.copy(portCode = "LHR_NBP_HALVED", nationalityBasedProcTimes = nationalityProcessingTimesHalved, cloneOfPortCode = Option("LHR")) //use halved default times and halved nationality based times
 
   val allPorts: List[AirportConfig] = ema :: edi :: stn :: man :: ltn :: lhr :: lhr_nbp :: lhr_nbp_halved :: lhr_ppt_halved :: lgw :: bhx :: brs :: test :: Nil
+  val testPorts: List[AirportConfig] = test :: lhr_nbp :: lhr_nbp_halved :: lhr_ppt_halved :: Nil
   val confByPort: Map[String, AirportConfig] = allPorts.map(c => (c.portCode, c)).toMap
 }

--- a/shared/src/main/scala/drt/shared/LoggedInUser.scala
+++ b/shared/src/main/scala/drt/shared/LoggedInUser.scala
@@ -1,7 +1,5 @@
 package drt.shared
 
-import scala.reflect.runtime.universe._
-
 case class LoggedInUser(userName: String, id: String, email: String, roles: Set[Role])
 
 sealed trait Role{
@@ -57,6 +55,7 @@ case object LTNAccess extends Role {
 case object MANAccess extends Role {
   override val name: String = "MAN"
 }
+
 case object STNAccess extends Role {
   override val name: String = "STN"
 }

--- a/shared/src/main/scala/drt/shared/LoggedInUser.scala
+++ b/shared/src/main/scala/drt/shared/LoggedInUser.scala
@@ -1,13 +1,16 @@
 package drt.shared
 
-case class LoggedInUser(userName: String, id: String, email: String, roles: List[Role])
+import scala.reflect.runtime.universe._
+
+case class LoggedInUser(userName: String, id: String, email: String, roles: Set[Role])
 
 sealed trait Role{
   val name: String
 }
 
 object Roles {
-  val availableRoles = List(StaffEdit, ApiView, ManageUsers)
+  val portRoles: Set[Role] = Set(BHXAccess, BRSAccess, EDIAccess, EMAAccess, LGWAccess, LHRAccess, LTNAccess, MANAccess, STNAccess)
+  val availableRoles : Set[Role] = Set(StaffEdit, ApiView, ManageUsers) ++ portRoles
   def parse(roleName: String): Option[Role] = availableRoles.find(role=> role.name == roleName)
 }
 
@@ -21,4 +24,39 @@ case object ApiView extends Role {
 
 case object ManageUsers extends Role {
   override val name: String = "manage-users"
+}
+
+case object BHXAccess extends Role {
+  override val name: String = "BHX"
+}
+
+case object BRSAccess extends Role {
+  override val name: String = "BRS"
+}
+
+case object EDIAccess extends Role {
+  override val name: String = "EDI"
+}
+
+case object EMAAccess extends Role {
+  override val name: String = "EMA"
+}
+
+case object LGWAccess extends Role {
+  override val name: String = "LGW"
+}
+
+case object LHRAccess extends Role {
+  override val name: String = "LHR"
+}
+
+case object LTNAccess extends Role {
+  override val name: String = "LTN"
+}
+
+case object MANAccess extends Role {
+  override val name: String = "MAN"
+}
+case object STNAccess extends Role {
+  override val name: String = "STN"
 }


### PR DESCRIPTION
# Restricted access for users by port

- Restrict users who don't have a port specific role from using the app.
- Allows users to request access by sending an email
- Allows users to click links to ports they do have access to
- Changes user's roles from a List to a Set
- Found out in cyprus tests `cy.contains(selector, value)` works 100% better than flakey `cy.get(selector).contains(value)`
- Added Google analytics to the restricted access page
- AlertsActor test uses an in-memory persistent actor rather than a file based one that fails the second time you run it
- The test port requires a specific role to view ("api:view")

<img width="985" alt="screen shot 2018-08-30 at 09 54 02" src="https://user-images.githubusercontent.com/369407/44841176-a9b39780-ac3a-11e8-9d26-3f0b02b6ae3d.png">
