### PR TITLE
DRT-5148 - Improve codeshare matching criteria

### DIFF
--- a/client/src/test/scala/drt/client/components/BigSummaryBoxTests.scala
+++ b/client/src/test/scala/drt/client/components/BigSummaryBoxTests.scala
@@ -373,6 +373,7 @@ object ApiFlightGenerator {
       rawICAO = rawICAO,
       rawIATA = iataFlightCode,
       Origin = Origin,
+      FeedSources = Set(ApiFeed),
       PcpTime = if (PcpTime != 0) Some(PcpTime) else Some(SDate.parse(SchDT).millisSinceEpoch),
       Scheduled = if (SchDT != "") SDate.parse(SchDT).millisSinceEpoch else 0L
     )

--- a/client/src/test/scala/drt/client/components/BigSummaryBoxTests.scala
+++ b/client/src/test/scala/drt/client/components/BigSummaryBoxTests.scala
@@ -373,7 +373,7 @@ object ApiFlightGenerator {
       rawICAO = rawICAO,
       rawIATA = iataFlightCode,
       Origin = Origin,
-      FeedSources = Set(ApiFeed),
+      FeedSources = Set(ApiFeedSource),
       PcpTime = if (PcpTime != 0) Some(PcpTime) else Some(SDate.parse(SchDT).millisSinceEpoch),
       Scheduled = if (SchDT != "") SDate.parse(SchDT).millisSinceEpoch else 0L
     )

--- a/client/src/test/scala/drt/client/components/FlightComponentsTests.scala
+++ b/client/src/test/scala/drt/client/components/FlightComponentsTests.scala
@@ -2,7 +2,7 @@ package drt.client.components
 
 import drt.client.components.FlightComponents.bestPaxToDisplay
 import drt.client.services.JSDateConversions.SDate
-import drt.shared.{Arrival, ApiFeed}
+import drt.shared.{Arrival, ApiFeedSource}
 import utest._
 
 
@@ -97,6 +97,6 @@ object ArrivalGenerator {
       PcpTime = if (schDt != "") Some(SDate.parse(schDt).millisSinceEpoch) else None,
       Scheduled = if (schDt != "") SDate.parse(schDt).millisSinceEpoch else 0L,
       LastKnownPax = lastKnownPax,
-      FeedSources = Set(ApiFeed)
+      FeedSources = Set(ApiFeedSource)
     )
 }

--- a/client/src/test/scala/drt/client/components/FlightComponentsTests.scala
+++ b/client/src/test/scala/drt/client/components/FlightComponentsTests.scala
@@ -2,7 +2,7 @@ package drt.client.components
 
 import drt.client.components.FlightComponents.bestPaxToDisplay
 import drt.client.services.JSDateConversions.SDate
-import drt.shared.Arrival
+import drt.shared.{Arrival, ApiFeed}
 import utest._
 
 
@@ -96,6 +96,7 @@ object ArrivalGenerator {
       Origin = origin,
       PcpTime = if (schDt != "") Some(SDate.parse(schDt).millisSinceEpoch) else None,
       Scheduled = if (schDt != "") SDate.parse(schDt).millisSinceEpoch else 0L,
-      LastKnownPax = lastKnownPax
+      LastKnownPax = lastKnownPax,
+      FeedSources = Set(ApiFeed)
     )
 }

--- a/client/src/test/scala/drt/client/components/FlightsTableTests.scala
+++ b/client/src/test/scala/drt/client/components/FlightsTableTests.scala
@@ -62,7 +62,7 @@ object FlightsTableTests extends TestSuite {
         Origin = "JFK",
         PcpTime = Some(1451655000000L), // 2016-01-01 13:30:00 UTC
         Scheduled = SDate("2016-01-01T13:00").millisSinceEpoch,
-        FeedSources = Set(ApiFeed)
+        FeedSources = Set(ApiFeedSource)
       )
 
       def withSplits(flights: Seq[Arrival]) = {

--- a/client/src/test/scala/drt/client/components/FlightsTableTests.scala
+++ b/client/src/test/scala/drt/client/components/FlightsTableTests.scala
@@ -61,7 +61,8 @@ object FlightsTableTests extends TestSuite {
         rawIATA = "BAA0001",
         Origin = "JFK",
         PcpTime = Some(1451655000000L), // 2016-01-01 13:30:00 UTC
-        Scheduled = SDate("2016-01-01T13:00").millisSinceEpoch
+        Scheduled = SDate("2016-01-01T13:00").millisSinceEpoch,
+        FeedSources = Set(ApiFeed)
       )
 
       def withSplits(flights: Seq[Arrival]) = {

--- a/server/src/main/protobuf/FlightsMessage.proto
+++ b/server/src/main/protobuf/FlightsMessage.proto
@@ -30,6 +30,7 @@ message FlightMessage {
     optional int64 EstimatedChox = 20;
     optional int64 ActualChox = 21;
     optional int32 LastKnownPax = 22;
+    repeated string FeedSources = 23;
 }
 
 message FlightsDiffMessage {

--- a/server/src/main/scala/actors/FlightMessageConversion.scala
+++ b/server/src/main/scala/actors/FlightMessageConversion.scala
@@ -101,7 +101,7 @@ object FlightMessageConversion {
       iATA = Option(StringUtils.trimToNull(apiFlight.rawIATA)),
       origin = Option(StringUtils.trimToNull(apiFlight.Origin)),
       pcpTime = apiFlight.PcpTime.filter(_ != 0),
-
+      feedSources = apiFlight.FeedSources.map(_.toString).toSeq,
       scheduled = Option(apiFlight.Scheduled).filter(_ != 0),
       estimated = apiFlight.Estimated.filter(_ != 0),
       touchdown = apiFlight.Actual.filter(_ != 0),
@@ -144,7 +144,8 @@ object FlightMessageConversion {
       Origin = flightMessage.origin.getOrElse(""),
       PcpTime = flightMessage.pcpTime.filter(_ != 0),
       LastKnownPax = flightMessage.lastKnownPax,
-      Scheduled = flightMessage.scheduled.getOrElse(0L)
+      Scheduled = flightMessage.scheduled.getOrElse(0L),
+      FeedSources = flightMessage.feedSources.flatMap(FeedSource(_)).toSet
     )
   }
 

--- a/server/src/main/scala/controllers/Test.scala
+++ b/server/src/main/scala/controllers/Test.scala
@@ -3,11 +3,11 @@ package controllers
 import akka.actor.{ActorRef, ActorSystem}
 import akka.stream.Materializer
 import akka.util.Timeout
-import javax.inject.{Singleton, Inject}
+import javax.inject.{Inject, Singleton}
 import drt.chroma.chromafetcher.ChromaFetcher.ChromaLiveFlight
 import drt.chroma.chromafetcher.ChromaParserProtocol._
 import passengersplits.parsing.VoyageManifestParser.FlightPassengerInfoProtocol._
-import drt.shared.{Arrival, SDateLike}
+import drt.shared.{Arrival, LiveFeed, SDateLike}
 import org.slf4j.{Logger, LoggerFactory}
 import passengersplits.parsing.VoyageManifestParser.{VoyageManifest, VoyageManifests}
 import play.api.mvc.{Action, Controller, InjectedController, Session}
@@ -96,6 +96,7 @@ class Test @Inject()(implicit val config: Configuration,
             rawIATA = flight.IATA,
             Origin = flight.Origin,
             PcpTime = Some(pcpTime),
+            FeedSources = Set(LiveFeed),
             Scheduled = SDate(flight.SchDT).millisSinceEpoch
           )
           saveArrival(arrival)

--- a/server/src/main/scala/controllers/Test.scala
+++ b/server/src/main/scala/controllers/Test.scala
@@ -7,7 +7,7 @@ import javax.inject.{Inject, Singleton}
 import drt.chroma.chromafetcher.ChromaFetcher.ChromaLiveFlight
 import drt.chroma.chromafetcher.ChromaParserProtocol._
 import passengersplits.parsing.VoyageManifestParser.FlightPassengerInfoProtocol._
-import drt.shared.{Arrival, LiveFeed, SDateLike}
+import drt.shared.{Arrival, LiveFeedSource, SDateLike}
 import org.slf4j.{Logger, LoggerFactory}
 import passengersplits.parsing.VoyageManifestParser.{VoyageManifest, VoyageManifests}
 import play.api.mvc.{Action, Controller, InjectedController, Session}
@@ -96,7 +96,7 @@ class Test @Inject()(implicit val config: Configuration,
             rawIATA = flight.IATA,
             Origin = flight.Origin,
             PcpTime = Some(pcpTime),
-            FeedSources = Set(LiveFeed),
+            FeedSources = Set(LiveFeedSource),
             Scheduled = SDate(flight.SchDT).millisSinceEpoch
           )
           saveArrival(arrival)

--- a/server/src/main/scala/drt/chroma/StreamingChromaFlow.scala
+++ b/server/src/main/scala/drt/chroma/StreamingChromaFlow.scala
@@ -6,7 +6,7 @@ import akka.event.LoggingAdapter
 import akka.stream.scaladsl.Source
 import drt.chroma.chromafetcher.{ChromaFetcher, ChromaFetcherForecast}
 import drt.chroma.chromafetcher.ChromaFetcher.{ChromaForecastFlight, ChromaLiveFlight}
-import drt.shared.{Arrival, ForecastFeed, LiveFeed}
+import drt.shared.{Arrival, ForecastFeedSource, LiveFeedSource}
 import drt.shared.FlightsApi.Flights
 import org.springframework.util.StringUtils
 import server.feeds.{ArrivalsFeedFailure, ArrivalsFeedResponse, ArrivalsFeedSuccess}
@@ -77,7 +77,7 @@ object StreamingChromaFlow {
           Origin = flight.Origin,
           PcpTime = Some(pcpTime),
           Scheduled = SDate(flight.SchDT).millisSinceEpoch,
-          FeedSources = Set(LiveFeed)
+          FeedSources = Set(LiveFeedSource)
         )
       }).toList
   }
@@ -107,7 +107,7 @@ object StreamingChromaFlow {
           rawIATA = flight.IATA,
           Origin = flight.Origin,
           PcpTime = Option(pcpTime),
-          FeedSources = Set(ForecastFeed),
+          FeedSources = Set(ForecastFeedSource),
           Scheduled = SDate(flight.SchDT).millisSinceEpoch
         )
       }).toList

--- a/server/src/main/scala/drt/chroma/StreamingChromaFlow.scala
+++ b/server/src/main/scala/drt/chroma/StreamingChromaFlow.scala
@@ -6,10 +6,10 @@ import akka.event.LoggingAdapter
 import akka.stream.scaladsl.Source
 import drt.chroma.chromafetcher.{ChromaFetcher, ChromaFetcherForecast}
 import drt.chroma.chromafetcher.ChromaFetcher.{ChromaForecastFlight, ChromaLiveFlight}
-import drt.shared.Arrival
+import drt.shared.{Arrival, ForecastFeed, LiveFeed}
 import drt.shared.FlightsApi.Flights
 import org.springframework.util.StringUtils
-import server.feeds.{ArrivalsFeedFailure, ArrivalsFeedSuccess, ArrivalsFeedResponse}
+import server.feeds.{ArrivalsFeedFailure, ArrivalsFeedResponse, ArrivalsFeedSuccess}
 import services.SDate
 
 import scala.collection.immutable.Seq
@@ -76,7 +76,8 @@ object StreamingChromaFlow {
           rawIATA = flight.IATA,
           Origin = flight.Origin,
           PcpTime = Some(pcpTime),
-          Scheduled = SDate(flight.SchDT).millisSinceEpoch
+          Scheduled = SDate(flight.SchDT).millisSinceEpoch,
+          FeedSources = Set(LiveFeed)
         )
       }).toList
   }
@@ -106,6 +107,7 @@ object StreamingChromaFlow {
           rawIATA = flight.IATA,
           Origin = flight.Origin,
           PcpTime = Option(pcpTime),
+          FeedSources = Set(ForecastFeed),
           Scheduled = SDate(flight.SchDT).millisSinceEpoch
         )
       }).toList

--- a/server/src/main/scala/drt/server/feeds/acl/AclFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/acl/AclFeed.scala
@@ -200,7 +200,7 @@ object AclFeed {
         Origin = fields(AclColIndex.Origin),
         Scheduled = SDate(dateAndTimeToDateTimeIso(fields(AclColIndex.Date), fields(AclColIndex.Time))).millisSinceEpoch,
         PcpTime = None,
-        FeedSources = Set(shared.AclFeed),
+        FeedSources = Set(shared.AclFeedSource),
         None
       )
     }

--- a/server/src/main/scala/drt/server/feeds/acl/AclFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/acl/AclFeed.scala
@@ -4,6 +4,7 @@ import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.zip.{ZipEntry, ZipInputStream}
 
+import drt.shared
 import drt.shared.Arrival
 import drt.shared.FlightsApi.{Flights, TerminalName}
 import net.schmizz.sshj.SSHClient
@@ -11,9 +12,8 @@ import net.schmizz.sshj.sftp.SFTPClient
 import net.schmizz.sshj.transport.verification.PromiscuousVerifier
 import net.schmizz.sshj.xfer.InMemoryDestFile
 import org.slf4j.{Logger, LoggerFactory}
-
 import server.feeds.{ArrivalsFeedFailure, ArrivalsFeedResponse, ArrivalsFeedSuccess, FeedResponse}
-import server.feeds.acl.AclFeed.{arrivalsFromCsvContent, contentFromFileName, latestFileForPort, sshClient, sftpClient}
+import server.feeds.acl.AclFeed.{arrivalsFromCsvContent, contentFromFileName, latestFileForPort, sftpClient, sshClient}
 import services.SDate
 
 import scala.collection.JavaConverters._
@@ -200,6 +200,7 @@ object AclFeed {
         Origin = fields(AclColIndex.Origin),
         Scheduled = SDate(dateAndTimeToDateTimeIso(fields(AclColIndex.Date), fields(AclColIndex.Time))).millisSinceEpoch,
         PcpTime = None,
+        FeedSources = Set(shared.AclFeed),
         None
       )
     }

--- a/server/src/main/scala/drt/server/feeds/bhx/BHXArrivals.scala
+++ b/server/src/main/scala/drt/server/feeds/bhx/BHXArrivals.scala
@@ -1,6 +1,6 @@
 package drt.server.feeds.bhx
 
-import drt.shared.{Arrival, FeedSource, ForecastFeed, LiveFeed}
+import drt.shared.{Arrival, FeedSource, ForecastFeedSource, LiveFeedSource}
 import javax.xml.datatype.XMLGregorianCalendar
 import org.joda.time.DateTime
 import services.SDate
@@ -58,7 +58,7 @@ trait BHXLiveArrivals extends BHXArrivals {
       Origin = flightRecord.getOrigin,
       Scheduled = convertToUTC(flightRecord.getScheduledTime).map(SDate(_).millisSinceEpoch).getOrElse(0),
       PcpTime = None,
-      FeedSources = Set(LiveFeed),
+      FeedSources = Set(LiveFeedSource),
       None)
   }
 }
@@ -90,7 +90,7 @@ trait BHXForecastArrivals extends BHXArrivals {
       Origin = flightRecord.getOrigin,
       Scheduled = SDate(convertToUTCPlusOneHour(flightRecord.getScheduledTime)).millisSinceEpoch,
       PcpTime = None,
-      FeedSources = Set(ForecastFeed),
+      FeedSources = Set(ForecastFeedSource),
       None)
   }
 }

--- a/server/src/main/scala/drt/server/feeds/bhx/BHXArrivals.scala
+++ b/server/src/main/scala/drt/server/feeds/bhx/BHXArrivals.scala
@@ -1,6 +1,6 @@
 package drt.server.feeds.bhx
 
-import drt.shared.Arrival
+import drt.shared.{Arrival, FeedSource, ForecastFeed, LiveFeed}
 import javax.xml.datatype.XMLGregorianCalendar
 import org.joda.time.DateTime
 import services.SDate
@@ -58,6 +58,7 @@ trait BHXLiveArrivals extends BHXArrivals {
       Origin = flightRecord.getOrigin,
       Scheduled = convertToUTC(flightRecord.getScheduledTime).map(SDate(_).millisSinceEpoch).getOrElse(0),
       PcpTime = None,
+      FeedSources = Set(LiveFeed),
       None)
   }
 }
@@ -89,6 +90,7 @@ trait BHXForecastArrivals extends BHXArrivals {
       Origin = flightRecord.getOrigin,
       Scheduled = SDate(convertToUTCPlusOneHour(flightRecord.getScheduledTime)).millisSinceEpoch,
       PcpTime = None,
+      FeedSources = Set(ForecastFeed),
       None)
   }
 }

--- a/server/src/main/scala/drt/server/feeds/lgw/LGWForecastFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/lgw/LGWForecastFeed.scala
@@ -9,7 +9,7 @@ import akka.stream.scaladsl.Source
 import akka.stream.{ActorAttributes, Supervision}
 import com.box.sdk.{BoxFile, BoxFolder, _}
 import drt.server.feeds.lgw.LGWFeed.log
-import drt.shared.{Arrival, ForecastFeed}
+import drt.shared.{Arrival, ForecastFeedSource}
 import drt.shared.FlightsApi.Flights
 import org.apache.commons.lang3.StringUtils
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter, ISODateTimeFormat}
@@ -108,7 +108,7 @@ class LGWForecastFeed(boxConfigFilePath: String, userId: String, ukBfGalForecast
       Origin = fields(AIRPORT_CODE),
       Scheduled = SDate(dateAsISOStringWithoutZone(fields(DATE_TIME)), Crunch.europeLondonTimeZone).millisSinceEpoch,
       PcpTime = None,
-      FeedSources = Set(ForecastFeed),
+      FeedSources = Set(ForecastFeedSource),
       None
     )
   } match {

--- a/server/src/main/scala/drt/server/feeds/lgw/LGWForecastFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/lgw/LGWForecastFeed.scala
@@ -9,12 +9,12 @@ import akka.stream.scaladsl.Source
 import akka.stream.{ActorAttributes, Supervision}
 import com.box.sdk.{BoxFile, BoxFolder, _}
 import drt.server.feeds.lgw.LGWFeed.log
-import drt.shared.Arrival
+import drt.shared.{Arrival, ForecastFeed}
 import drt.shared.FlightsApi.Flights
 import org.apache.commons.lang3.StringUtils
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter, ISODateTimeFormat}
 import org.slf4j.{Logger, LoggerFactory}
-import server.feeds.{ArrivalsFeedFailure, ArrivalsFeedSuccess, ArrivalsFeedResponse}
+import server.feeds.{ArrivalsFeedFailure, ArrivalsFeedResponse, ArrivalsFeedSuccess}
 import services.SDate
 import services.graphstages.Crunch
 
@@ -108,6 +108,7 @@ class LGWForecastFeed(boxConfigFilePath: String, userId: String, ukBfGalForecast
       Origin = fields(AIRPORT_CODE),
       Scheduled = SDate(dateAsISOStringWithoutZone(fields(DATE_TIME)), Crunch.europeLondonTimeZone).millisSinceEpoch,
       PcpTime = None,
+      FeedSources = Set(ForecastFeed),
       None
     )
   } match {

--- a/server/src/main/scala/drt/server/feeds/lgw/ResponseToArrivals.scala
+++ b/server/src/main/scala/drt/server/feeds/lgw/ResponseToArrivals.scala
@@ -2,7 +2,7 @@ package drt.server.feeds.lgw
 
 import java.io.ByteArrayInputStream
 
-import drt.shared.{Arrival, FeedSource, LiveFeed}
+import drt.shared.{Arrival, FeedSource, LiveFeedSource}
 import drt.shared.CrunchApi.MillisSinceEpoch
 import org.apache.commons.io.IOUtils
 import org.apache.commons.lang3.StringUtils
@@ -63,7 +63,7 @@ case class ResponseToArrivals(data: Array[Byte], locationOption: Option[String] 
       Origin = parseOrigin(n),
       Scheduled = (((n \ "FlightLeg").head \ "LegData").head \\ "OperationTime").find(n => (n \ "@OperationQualifier" text).equals("ONB") && (n \ "@TimeType" text).equals("SCT")).map(n => services.SDate.parseString(n text).millisSinceEpoch).getOrElse(0),
       PcpTime = None,
-      FeedSources = Set(LiveFeed),
+      FeedSources = Set(LiveFeedSource),
       LastKnownPax = None)
     log.info(s"parsed arrival: $arrival")
     (arrival, locationOption)

--- a/server/src/main/scala/drt/server/feeds/lgw/ResponseToArrivals.scala
+++ b/server/src/main/scala/drt/server/feeds/lgw/ResponseToArrivals.scala
@@ -1,11 +1,13 @@
 package drt.server.feeds.lgw
 
 import java.io.ByteArrayInputStream
-import drt.shared.Arrival
+
+import drt.shared.{Arrival, FeedSource, LiveFeed}
 import drt.shared.CrunchApi.MillisSinceEpoch
 import org.apache.commons.io.IOUtils
 import org.apache.commons.lang3.StringUtils
 import org.slf4j.{Logger, LoggerFactory}
+
 import scala.util.{Failure, Success, Try}
 import scala.xml.Node
 import scala.language.postfixOps
@@ -61,6 +63,7 @@ case class ResponseToArrivals(data: Array[Byte], locationOption: Option[String] 
       Origin = parseOrigin(n),
       Scheduled = (((n \ "FlightLeg").head \ "LegData").head \\ "OperationTime").find(n => (n \ "@OperationQualifier" text).equals("ONB") && (n \ "@TimeType" text).equals("SCT")).map(n => services.SDate.parseString(n text).millisSinceEpoch).getOrElse(0),
       PcpTime = None,
+      FeedSources = Set(LiveFeed),
       LastKnownPax = None)
     log.info(s"parsed arrival: $arrival")
     (arrival, locationOption)

--- a/server/src/main/scala/drt/server/feeds/lhr/LHRFlightFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/lhr/LHRFlightFeed.scala
@@ -5,7 +5,7 @@ import akka.actor.Cancellable
 import akka.stream.scaladsl.Source
 import com.typesafe.config.ConfigFactory
 import drt.server.feeds.lhr.LHRFlightFeed.{emptyStringToOption, parseDateTime}
-import drt.shared.{Arrival, LiveFeed}
+import drt.shared.{Arrival, LiveFeedSource}
 import drt.shared.FlightsApi.Flights
 import org.apache.commons.csv.{CSVFormat, CSVParser, CSVRecord}
 import org.joda.time.DateTime
@@ -117,7 +117,7 @@ case class LHRFlightFeed(csvRecords: Iterator[Int => String]) {
         rawIATA = flight.flightCode,
         Origin = flight.from,
         PcpTime = if (pcpTime == 0) None else Some(pcpTime),
-        FeedSources = Set(LiveFeed),
+        FeedSources = Set(LiveFeedSource),
         Scheduled = SDate(schDtIso).millisSinceEpoch)
     }).toList
 }

--- a/server/src/main/scala/drt/server/feeds/lhr/LHRFlightFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/lhr/LHRFlightFeed.scala
@@ -5,7 +5,7 @@ import akka.actor.Cancellable
 import akka.stream.scaladsl.Source
 import com.typesafe.config.ConfigFactory
 import drt.server.feeds.lhr.LHRFlightFeed.{emptyStringToOption, parseDateTime}
-import drt.shared.Arrival
+import drt.shared.{Arrival, LiveFeed}
 import drt.shared.FlightsApi.Flights
 import org.apache.commons.csv.{CSVFormat, CSVParser, CSVRecord}
 import org.joda.time.DateTime
@@ -117,6 +117,7 @@ case class LHRFlightFeed(csvRecords: Iterator[Int => String]) {
         rawIATA = flight.flightCode,
         Origin = flight.from,
         PcpTime = if (pcpTime == 0) None else Some(pcpTime),
+        FeedSources = Set(LiveFeed),
         Scheduled = SDate(schDtIso).millisSinceEpoch)
     }).toList
 }

--- a/server/src/main/scala/drt/server/feeds/lhr/LHRForecastFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/lhr/LHRForecastFeed.scala
@@ -1,7 +1,7 @@
 package drt.server.feeds.lhr
 
 import drt.server.feeds.lhr.forecast.{LHRForecastEmail, LHRForecastFlightRow, LHRForecastXLSExtractor}
-import drt.shared.{Arrival, ForecastFeed}
+import drt.shared.{Arrival, ForecastFeedSource}
 import drt.shared.FlightsApi.Flights
 import org.slf4j.{Logger, LoggerFactory}
 import server.feeds.{ArrivalsFeedFailure, ArrivalsFeedResponse, ArrivalsFeedSuccess}
@@ -60,7 +60,7 @@ object LHRForecastFeed {
         Origin = flightRow.origin,
         Scheduled = flightRow.scheduledDate.millisSinceEpoch,
         PcpTime = None,
-        FeedSources = Set(ForecastFeed),
+        FeedSources = Set(ForecastFeedSource),
         None
       )
     }

--- a/server/src/main/scala/drt/server/feeds/lhr/LHRForecastFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/lhr/LHRForecastFeed.scala
@@ -1,7 +1,7 @@
 package drt.server.feeds.lhr
 
 import drt.server.feeds.lhr.forecast.{LHRForecastEmail, LHRForecastFlightRow, LHRForecastXLSExtractor}
-import drt.shared.Arrival
+import drt.shared.{Arrival, ForecastFeed}
 import drt.shared.FlightsApi.Flights
 import org.slf4j.{Logger, LoggerFactory}
 import server.feeds.{ArrivalsFeedFailure, ArrivalsFeedResponse, ArrivalsFeedSuccess}
@@ -60,6 +60,7 @@ object LHRForecastFeed {
         Origin = flightRow.origin,
         Scheduled = flightRow.scheduledDate.millisSinceEpoch,
         PcpTime = None,
+        FeedSources = Set(ForecastFeed),
         None
       )
     }

--- a/server/src/main/scala/drt/server/feeds/lhr/forecast/LhrForecastArrivals.scala
+++ b/server/src/main/scala/drt/server/feeds/lhr/forecast/LhrForecastArrivals.scala
@@ -1,6 +1,6 @@
 package drt.server.feeds.lhr.forecast
 
-import drt.shared.{Arrival, SDateLike}
+import drt.shared.{Arrival, ForecastFeed, SDateLike}
 import org.joda.time.DateTimeZone
 import org.slf4j.{Logger, LoggerFactory}
 import org.springframework.util.StringUtils
@@ -87,6 +87,7 @@ object LhrForecastArrival {
         Origin = origin(fields),
         Scheduled = scheduled(fields).millisSinceEpoch,
         PcpTime = None,
+        FeedSources = Set(ForecastFeed),
         LastKnownPax = None
       )
     } match {

--- a/server/src/main/scala/drt/server/feeds/lhr/forecast/LhrForecastArrivals.scala
+++ b/server/src/main/scala/drt/server/feeds/lhr/forecast/LhrForecastArrivals.scala
@@ -1,6 +1,6 @@
 package drt.server.feeds.lhr.forecast
 
-import drt.shared.{Arrival, ForecastFeed, SDateLike}
+import drt.shared.{Arrival, ForecastFeedSource, SDateLike}
 import org.joda.time.DateTimeZone
 import org.slf4j.{Logger, LoggerFactory}
 import org.springframework.util.StringUtils
@@ -87,7 +87,7 @@ object LhrForecastArrival {
         Origin = origin(fields),
         Scheduled = scheduled(fields).millisSinceEpoch,
         PcpTime = None,
-        FeedSources = Set(ForecastFeed),
+        FeedSources = Set(ForecastFeedSource),
         LastKnownPax = None
       )
     } match {

--- a/server/src/main/scala/drt/server/feeds/lhr/live/LHRLiveFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/lhr/live/LHRLiveFeed.scala
@@ -5,7 +5,7 @@ import akka.actor.{ActorSystem, Cancellable}
 import akka.stream.scaladsl.Source
 import akka.util.Timeout
 import drt.http.{ProdSendAndReceive, WithSendAndReceive}
-import drt.shared.Arrival
+import drt.shared.{Arrival, LiveFeed}
 import drt.shared.CrunchApi.MillisSinceEpoch
 import drt.shared.FlightsApi.Flights
 import org.slf4j.{Logger, LoggerFactory}
@@ -60,6 +60,7 @@ object LHRLiveFeed {
         Origin = lhrArrival.AIRPORTCODE,
         Scheduled = localTimeDateStringToMaybeMillis(lhrArrival.SCHEDULEDFLIGHTOPERATIONTIME).getOrElse(0L),
         PcpTime = None,
+        FeedSources = Set(LiveFeed),
         LastKnownPax = None
       )
     }

--- a/server/src/main/scala/drt/server/feeds/lhr/live/LHRLiveFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/lhr/live/LHRLiveFeed.scala
@@ -5,7 +5,7 @@ import akka.actor.{ActorSystem, Cancellable}
 import akka.stream.scaladsl.Source
 import akka.util.Timeout
 import drt.http.{ProdSendAndReceive, WithSendAndReceive}
-import drt.shared.{Arrival, LiveFeed}
+import drt.shared.{Arrival, LiveFeedSource}
 import drt.shared.CrunchApi.MillisSinceEpoch
 import drt.shared.FlightsApi.Flights
 import org.slf4j.{Logger, LoggerFactory}
@@ -60,7 +60,7 @@ object LHRLiveFeed {
         Origin = lhrArrival.AIRPORTCODE,
         Scheduled = localTimeDateStringToMaybeMillis(lhrArrival.SCHEDULEDFLIGHTOPERATIONTIME).getOrElse(0L),
         PcpTime = None,
-        FeedSources = Set(LiveFeed),
+        FeedSources = Set(LiveFeedSource),
         LastKnownPax = None
       )
     }

--- a/server/src/main/scala/drt/server/feeds/ltn/LtnLiveFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/ltn/LtnLiveFeed.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.scaladsl.Source
-import drt.shared.{Arrival, LiveFeed}
+import drt.shared.{Arrival, LiveFeedSource}
 import drt.shared.CrunchApi.MillisSinceEpoch
 import drt.shared.FlightsApi.Flights
 import org.joda.time.DateTimeZone
@@ -99,7 +99,7 @@ case class LtnLiveFeed(endPoint: String, token: String, username: String, passwo
     Origin = ltnFeedFlight.OriginDestAirportIATA.getOrElse(throw new Exception("Missing origin IATA port code")),
     Scheduled = sdateWithTimeZoneApplied(ltnFeedFlight.ScheduledDateTime.getOrElse(throw new Exception("Missing scheduled date time"))),
     PcpTime = None,
-    FeedSources = Set(LiveFeed),
+    FeedSources = Set(LiveFeedSource),
     LastKnownPax = None
   )
 

--- a/server/src/main/scala/drt/server/feeds/ltn/LtnLiveFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/ltn/LtnLiveFeed.scala
@@ -7,7 +7,7 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.RawHeader
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.scaladsl.Source
-import drt.shared.Arrival
+import drt.shared.{Arrival, LiveFeed}
 import drt.shared.CrunchApi.MillisSinceEpoch
 import drt.shared.FlightsApi.Flights
 import org.joda.time.DateTimeZone
@@ -99,6 +99,7 @@ case class LtnLiveFeed(endPoint: String, token: String, username: String, passwo
     Origin = ltnFeedFlight.OriginDestAirportIATA.getOrElse(throw new Exception("Missing origin IATA port code")),
     Scheduled = sdateWithTimeZoneApplied(ltnFeedFlight.ScheduledDateTime.getOrElse(throw new Exception("Missing scheduled date time"))),
     PcpTime = None,
+    FeedSources = Set(LiveFeed),
     LastKnownPax = None
   )
 

--- a/server/src/main/scala/services/graphstages/ArrivalSplitsGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/ArrivalSplitsGraphStage.scala
@@ -339,7 +339,8 @@ class ArrivalSplitsGraphStage(name: String = "",
         case _ => false
       } + splitsFromManifest
 
-      flightWithSplits.copy(splits = updatedSplitsSet)
+      val apiFlight = flightWithSplits.apiFlight
+      flightWithSplits.copy(apiFlight = apiFlight.copy(FeedSources = apiFlight.FeedSources + ApiFeed) ,splits = updatedSplitsSet)
     }
   }
 

--- a/server/src/main/scala/services/graphstages/ArrivalSplitsGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/ArrivalSplitsGraphStage.scala
@@ -340,7 +340,10 @@ class ArrivalSplitsGraphStage(name: String = "",
       } + splitsFromManifest
 
       val apiFlight = flightWithSplits.apiFlight
-      flightWithSplits.copy(apiFlight = apiFlight.copy(FeedSources = apiFlight.FeedSources + ApiFeed) ,splits = updatedSplitsSet)
+      flightWithSplits.copy(
+        apiFlight = apiFlight.copy(FeedSources = apiFlight.FeedSources + ApiFeedSource),
+        splits = updatedSplitsSet
+      )
     }
   }
 

--- a/server/src/main/scala/services/graphstages/ArrivalsGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/ArrivalsGraphStage.scala
@@ -172,7 +172,7 @@ class ArrivalsGraphStage(name: String = "",
               (notFoundSoFar + 1, mergedSoFar)
             case Some(baseArrival) =>
               val actPax = forecastArrival.ActPax.filter(_ > 0).orElse(baseArrival.ActPax)
-              val mergedArrival = baseArrival.copy(ActPax = actPax, TranPax = forecastArrival.TranPax, Status = forecastArrival.Status)
+              val mergedArrival = baseArrival.copy(ActPax = actPax, TranPax = forecastArrival.TranPax, Status = forecastArrival.Status, FeedSources = baseArrival.FeedSources ++ forecastArrival.FeedSources)
               (notFoundSoFar, mergedSoFar.updated(fcstId, mergedArrival))
           }
       }
@@ -186,8 +186,9 @@ class ArrivalsGraphStage(name: String = "",
             rawIATA = baseArrival.rawIATA,
             rawICAO = baseArrival.rawICAO,
             ActPax = liveArrival.ActPax.filter(_ > 0).orElse(mergedSoFarArrival.ActPax),
-            TranPax = liveArrival.ActPax.filter(_ > 0).flatMap(_ => liveArrival.TranPax).orElse(mergedSoFarArrival.TranPax))
-
+            TranPax = liveArrival.ActPax.filter(_ > 0).flatMap(_ => liveArrival.TranPax).orElse(mergedSoFarArrival.TranPax),
+            FeedSources = liveArrival.FeedSources ++ mergedSoFarArrival.FeedSources
+          )
           mergedSoFar.updated(liveId, mergedArrival)
       }
 

--- a/server/src/test/scala/controllers/ArrivalGenerator.scala
+++ b/server/src/test/scala/controllers/ArrivalGenerator.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import drt.shared.{Arrival, FeedSource, LiveFeed}
+import drt.shared.{Arrival, FeedSource, LiveFeedSource}
 import org.joda.time.DateTimeZone
 import org.springframework.util.StringUtils
 import services.SDate
@@ -29,7 +29,7 @@ object ArrivalGenerator {
                  runwayId: Option[String] = None,
                  baggageReclaimId: Option[String] = None,
                  airportId: String = "",
-                 feedSources: Set[FeedSource] = Set(LiveFeed)
+                 feedSources: Set[FeedSource] = Set(LiveFeedSource)
                ): Arrival =
     Arrival(
       FlightID = flightId,

--- a/server/src/test/scala/controllers/ArrivalGenerator.scala
+++ b/server/src/test/scala/controllers/ArrivalGenerator.scala
@@ -1,6 +1,6 @@
 package controllers
 
-import drt.shared.Arrival
+import drt.shared.{Arrival, FeedSource, LiveFeed}
 import org.joda.time.DateTimeZone
 import org.springframework.util.StringUtils
 import services.SDate
@@ -28,7 +28,8 @@ object ArrivalGenerator {
                  tranPax: Option[Int] = None,
                  runwayId: Option[String] = None,
                  baggageReclaimId: Option[String] = None,
-                 airportId: String = ""
+                 airportId: String = "",
+                 feedSources: Set[FeedSource] = Set(LiveFeed)
                ): Arrival =
     Arrival(
       FlightID = flightId,
@@ -52,6 +53,7 @@ object ArrivalGenerator {
       AirportID = airportId,
       PcpTime = if (!StringUtils.isEmpty(schDt)) Some(SDate(schDt, DateTimeZone.UTC).millisSinceEpoch) else None,
       LastKnownPax = lastKnownPax,
-      Scheduled = if (!StringUtils.isEmpty(schDt)) SDate(schDt, DateTimeZone.UTC).millisSinceEpoch else 0
+      Scheduled = if (!StringUtils.isEmpty(schDt)) SDate(schDt, DateTimeZone.UTC).millisSinceEpoch else 0,
+      FeedSources = feedSources
     )
 }

--- a/server/src/test/scala/feeds/BHXFeedSpec.scala
+++ b/server/src/test/scala/feeds/BHXFeedSpec.scala
@@ -6,7 +6,7 @@ import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import drt.server.feeds.bhx.BHXFeed
-import drt.shared.{Arrival, ForecastFeed, LiveFeed}
+import drt.shared.{Arrival, ForecastFeedSource, LiveFeedSource}
 import javax.xml.datatype.DatatypeFactory
 import javax.xml.ws.BindingProvider
 import org.joda.time.DateTimeZone
@@ -117,7 +117,7 @@ class BHXFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.p
         Origin = "CPH",
         Scheduled = 1338619560000L,
         PcpTime = None,
-        FeedSources = Set(LiveFeed),
+        FeedSources = Set(LiveFeedSource),
         LastKnownPax = None)
     }
 
@@ -148,7 +148,7 @@ class BHXFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.p
         Origin = "CPH",
         Scheduled = 1338623160000L, // BHX Forecast is incorrect. This should be 1338619613123L or 2012-06-02T06:46:53.123Z
         PcpTime = None,
-        FeedSources = Set(ForecastFeed),
+        FeedSources = Set(ForecastFeedSource),
         LastKnownPax = None)
     }
 

--- a/server/src/test/scala/feeds/BHXFeedSpec.scala
+++ b/server/src/test/scala/feeds/BHXFeedSpec.scala
@@ -6,7 +6,7 @@ import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import drt.server.feeds.bhx.BHXFeed
-import drt.shared.Arrival
+import drt.shared.{Arrival, ForecastFeed, LiveFeed}
 import javax.xml.datatype.DatatypeFactory
 import javax.xml.ws.BindingProvider
 import org.joda.time.DateTimeZone
@@ -117,6 +117,7 @@ class BHXFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.p
         Origin = "CPH",
         Scheduled = 1338619560000L,
         PcpTime = None,
+        FeedSources = Set(LiveFeed),
         LastKnownPax = None)
     }
 
@@ -147,6 +148,7 @@ class BHXFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.p
         Origin = "CPH",
         Scheduled = 1338623160000L, // BHX Forecast is incorrect. This should be 1338619613123L or 2012-06-02T06:46:53.123Z
         PcpTime = None,
+        FeedSources = Set(ForecastFeed),
         LastKnownPax = None)
     }
 

--- a/server/src/test/scala/feeds/LGWFeedSpec.scala
+++ b/server/src/test/scala/feeds/LGWFeedSpec.scala
@@ -6,7 +6,7 @@ import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import com.typesafe.config.{Config, ConfigFactory}
 import drt.server.feeds.lgw.{GatwickAzureToken, LGWFeed}
-import drt.shared.Arrival
+import drt.shared.{Arrival, LiveFeed}
 import org.specs2.mock.Mockito
 import org.specs2.mutable.SpecificationLike
 import org.specs2.specification.Scope
@@ -105,7 +105,7 @@ class LGWFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.e
       BaggageReclaimId = None,
       FlightID = None,
       AirportID = "LGW",
-      Terminal = "N", rawICAO = "VIR808", rawIATA = "VS808", Origin = "LHR",
+      Terminal = "N", rawICAO = "VIR808", rawIATA = "VS808", Origin = "LHR", FeedSources = Set(LiveFeed),
       Scheduled = SDate("2018-06-03T19:50:00Z").millisSinceEpoch, PcpTime = None, LastKnownPax = None)
 
     deleteCalled must beTrue

--- a/server/src/test/scala/feeds/LGWFeedSpec.scala
+++ b/server/src/test/scala/feeds/LGWFeedSpec.scala
@@ -6,7 +6,7 @@ import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import com.typesafe.config.{Config, ConfigFactory}
 import drt.server.feeds.lgw.{GatwickAzureToken, LGWFeed}
-import drt.shared.{Arrival, LiveFeed}
+import drt.shared.{Arrival, LiveFeedSource}
 import org.specs2.mock.Mockito
 import org.specs2.mutable.SpecificationLike
 import org.specs2.specification.Scope
@@ -105,7 +105,7 @@ class LGWFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.e
       BaggageReclaimId = None,
       FlightID = None,
       AirportID = "LGW",
-      Terminal = "N", rawICAO = "VIR808", rawIATA = "VS808", Origin = "LHR", FeedSources = Set(LiveFeed),
+      Terminal = "N", rawICAO = "VIR808", rawIATA = "VS808", Origin = "LHR", FeedSources = Set(LiveFeedSource),
       Scheduled = SDate("2018-06-03T19:50:00Z").millisSinceEpoch, PcpTime = None, LastKnownPax = None)
 
     deleteCalled must beTrue

--- a/server/src/test/scala/feeds/LGWForecastFeedSpec.scala
+++ b/server/src/test/scala/feeds/LGWForecastFeedSpec.scala
@@ -2,7 +2,7 @@ package feeds
 
 import com.box.sdk.{BoxAPIResponse, BoxAPIResponseException, BoxConfig, BoxDeveloperEditionAPIConnection}
 import drt.server.feeds.lgw.LGWForecastFeed
-import drt.shared.Arrival
+import drt.shared.{Arrival, ForecastFeed}
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
@@ -61,6 +61,7 @@ class LGWForecastFeedSpec extends Specification with Mockito {
         Origin = "TNG",
         Scheduled = SDate("2018-05-19T10:05:00Z").millisSinceEpoch,
         PcpTime = None,
+        FeedSources = Set(ForecastFeed),
         LastKnownPax = None)
     }
 

--- a/server/src/test/scala/feeds/LGWForecastFeedSpec.scala
+++ b/server/src/test/scala/feeds/LGWForecastFeedSpec.scala
@@ -2,7 +2,7 @@ package feeds
 
 import com.box.sdk.{BoxAPIResponse, BoxAPIResponseException, BoxConfig, BoxDeveloperEditionAPIConnection}
 import drt.server.feeds.lgw.LGWForecastFeed
-import drt.shared.{Arrival, ForecastFeed}
+import drt.shared.{Arrival, ForecastFeedSource}
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
@@ -61,7 +61,7 @@ class LGWForecastFeedSpec extends Specification with Mockito {
         Origin = "TNG",
         Scheduled = SDate("2018-05-19T10:05:00Z").millisSinceEpoch,
         PcpTime = None,
-        FeedSources = Set(ForecastFeed),
+        FeedSources = Set(ForecastFeedSource),
         LastKnownPax = None)
     }
 

--- a/server/src/test/scala/feeds/LHRFeedSpec.scala
+++ b/server/src/test/scala/feeds/LHRFeedSpec.scala
@@ -8,7 +8,7 @@ import akka.stream.scaladsl.{Sink, Source}
 import akka.testkit.{TestKit, TestProbe}
 import com.typesafe.config.ConfigFactory
 import drt.server.feeds.lhr.{LHRFlightFeed, LHRLiveFlight}
-import drt.shared.{Arrival, LiveFeed}
+import drt.shared.{Arrival, LiveFeedSource}
 import org.apache.commons.csv.{CSVFormat, CSVParser, CSVRecord}
 import org.specs2.mutable.SpecificationLike
 import services.SDate
@@ -70,7 +70,7 @@ class LHRFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.e
         Gate = None, Stand = Some("10"), MaxPax = Some(795), ActPax = Some(142), TranPax = Some(1), RunwayID = None, BaggageReclaimId = None,
         FlightID = Some(-54860421), AirportID = "LHR", Terminal = "T4", rawICAO = "QR005", rawIATA = "QR005", Origin = "DOH",
         Scheduled = SDate("2017-03-09T22:00:00.000Z").millisSinceEpoch,
-        PcpTime = Some(SDate("2017-03-09T22:04:00.000Z").millisSinceEpoch), FeedSources = Set(LiveFeed),
+        PcpTime = Some(SDate("2017-03-09T22:04:00.000Z").millisSinceEpoch), FeedSources = Set(LiveFeedSource),
         LastKnownPax = None)))
     }
 

--- a/server/src/test/scala/feeds/LHRFeedSpec.scala
+++ b/server/src/test/scala/feeds/LHRFeedSpec.scala
@@ -8,7 +8,7 @@ import akka.stream.scaladsl.{Sink, Source}
 import akka.testkit.{TestKit, TestProbe}
 import com.typesafe.config.ConfigFactory
 import drt.server.feeds.lhr.{LHRFlightFeed, LHRLiveFlight}
-import drt.shared.Arrival
+import drt.shared.{Arrival, LiveFeed}
 import org.apache.commons.csv.{CSVFormat, CSVParser, CSVRecord}
 import org.specs2.mutable.SpecificationLike
 import services.SDate
@@ -70,7 +70,7 @@ class LHRFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.e
         Gate = None, Stand = Some("10"), MaxPax = Some(795), ActPax = Some(142), TranPax = Some(1), RunwayID = None, BaggageReclaimId = None,
         FlightID = Some(-54860421), AirportID = "LHR", Terminal = "T4", rawICAO = "QR005", rawIATA = "QR005", Origin = "DOH",
         Scheduled = SDate("2017-03-09T22:00:00.000Z").millisSinceEpoch,
-        PcpTime = Some(SDate("2017-03-09T22:04:00.000Z").millisSinceEpoch),
+        PcpTime = Some(SDate("2017-03-09T22:04:00.000Z").millisSinceEpoch), FeedSources = Set(LiveFeed),
         LastKnownPax = None)))
     }
 

--- a/server/src/test/scala/feeds/lhr/live/LHRLiveFeedSpec.scala
+++ b/server/src/test/scala/feeds/lhr/live/LHRLiveFeedSpec.scala
@@ -5,7 +5,7 @@ import akka.testkit.TestKit
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import drt.server.feeds.lhr.live.LHRLiveFeed
-import drt.shared.{Arrival, LiveFeed}
+import drt.shared.{Arrival, LiveFeedSource}
 import org.specs2.mutable.SpecificationLike
 import services.SDate
 import spray.http.{HttpEntity, _}
@@ -107,7 +107,7 @@ class LHRLiveFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFacto
         ActualChox = Some(SDate("2018-02-12T10:02:00Z").millisSinceEpoch), Gate = None,
         Stand = Some("1"), MaxPax = Some(469), ActPax = Some(414), TranPax = Some(218), RunwayID = None, BaggageReclaimId = None, FlightID = None,
         AirportID = "LHR", Terminal = "T2", rawICAO = "FL002", rawIATA = "FL002", Origin = "JNB",
-        Scheduled = SDate("2018-02-12T10:20:00").millisSinceEpoch, FeedSources = Set(LiveFeed),
+        Scheduled = SDate("2018-02-12T10:20:00").millisSinceEpoch, FeedSources = Set(LiveFeedSource),
         PcpTime = None, LastKnownPax = None
       )
 
@@ -129,7 +129,7 @@ class LHRLiveFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFacto
         ActualChox = Some(SDate("2018-04-12T09:02:00Z").millisSinceEpoch),
         Gate = None, Stand = Some("1"), MaxPax = None, ActPax = None, TranPax = None, RunwayID = None, BaggageReclaimId = None,
         FlightID = None, AirportID = "LHR", Terminal = "T2", rawICAO = "FL002", rawIATA = "FL002", Origin = "JNB",
-        Scheduled = SDate("2018-04-12T09:20:00Z").millisSinceEpoch, PcpTime = None, FeedSources = Set(LiveFeed),
+        Scheduled = SDate("2018-04-12T09:20:00Z").millisSinceEpoch, PcpTime = None, FeedSources = Set(LiveFeedSource),
         LastKnownPax = None
       )
 
@@ -152,7 +152,7 @@ class LHRLiveFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFacto
         ActualChox = Some(SDate("2018-02-12T10:02:00Z").millisSinceEpoch),
         Gate = None, Stand = Some("1"), MaxPax = None, ActPax = None, TranPax = None, RunwayID = None, BaggageReclaimId = None,
         FlightID = None, AirportID = "LHR", Terminal = "T2", rawICAO = "FL002", rawIATA = "FL002", Origin = "JNB",
-        Scheduled = SDate("2018-02-12T10:20:00").millisSinceEpoch, FeedSources = Set(LiveFeed),
+        Scheduled = SDate("2018-02-12T10:20:00").millisSinceEpoch, FeedSources = Set(LiveFeedSource),
         PcpTime = None, LastKnownPax = None
       )
 
@@ -177,7 +177,7 @@ class LHRLiveFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFacto
           ActualChox = Some(SDate("2018-02-12T10:02:00").millisSinceEpoch),
           Gate = None, Stand = Some("1"), MaxPax = Some(469), ActPax = Some(414), TranPax = Some(218), RunwayID = None, BaggageReclaimId = None,
           FlightID = None, AirportID = "LHR", Terminal = "T2", rawICAO = "FL002", rawIATA = "FL002",
-          Origin = "JNB", FeedSources = Set(LiveFeed),
+          Origin = "JNB", FeedSources = Set(LiveFeedSource),
           Scheduled = SDate("2018-02-12T10:20:00").millisSinceEpoch, PcpTime = None, LastKnownPax = None
         ),
         Arrival(
@@ -185,7 +185,7 @@ class LHRLiveFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFacto
           EstimatedChox = None, ActualChox = None, Gate = None, Stand = Some("2"),
           MaxPax = Some(214), ActPax = Some(163), TranPax = Some(104), RunwayID = None, BaggageReclaimId = None, FlightID = None,
           AirportID = "LHR", Terminal = "T2", rawICAO = "FL001", rawIATA = "FL001", Origin = "JNB",
-          Scheduled = SDate("2018-02-12T18:20:00").millisSinceEpoch, FeedSources = Set(LiveFeed),
+          Scheduled = SDate("2018-02-12T18:20:00").millisSinceEpoch, FeedSources = Set(LiveFeedSource),
           PcpTime = None, LastKnownPax = None
         )
       )
@@ -208,14 +208,14 @@ class LHRLiveFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFacto
           Estimated = Some(SDate("2018-02-12T09:53:43").millisSinceEpoch),
           Actual = None,
           EstimatedChox = Some(SDate("2018-02-12T10:03:00").millisSinceEpoch),
-          ActualChox = Some(SDate("2018-02-12T10:02:00").millisSinceEpoch), FeedSources = Set(LiveFeed),
+          ActualChox = Some(SDate("2018-02-12T10:02:00").millisSinceEpoch), FeedSources = Set(LiveFeedSource),
           Gate = None, Stand = Some("1"), MaxPax = None, ActPax = None, TranPax = None, RunwayID = None, BaggageReclaimId = None,
           FlightID = None, AirportID = "LHR", Terminal = "T2", rawICAO = "FL002", rawIATA = "FL002", Origin = "JNB",
           Scheduled = SDate("2018-02-12T10:20:00").millisSinceEpoch, PcpTime = None, LastKnownPax = None
         ),
         Arrival(
           Operator = Some("FL"), Status = "Scheduled", Estimated = None, Actual = None, EstimatedChox = None, ActualChox = None, Gate = None, Stand = Some("2"), MaxPax = None, ActPax = None, TranPax = None, RunwayID = None, BaggageReclaimId = None, FlightID = None, AirportID = "LHR", Terminal = "T2", rawICAO = "FL001", rawIATA = "FL001", Origin = "JNB",
-          Scheduled = SDate("2018-02-12T18:20:00").millisSinceEpoch, PcpTime = None, LastKnownPax = None, FeedSources = Set(LiveFeed)
+          Scheduled = SDate("2018-02-12T18:20:00").millisSinceEpoch, PcpTime = None, LastKnownPax = None, FeedSources = Set(LiveFeedSource)
         )
       )
 

--- a/server/src/test/scala/feeds/lhr/live/LHRLiveFeedSpec.scala
+++ b/server/src/test/scala/feeds/lhr/live/LHRLiveFeedSpec.scala
@@ -5,7 +5,7 @@ import akka.testkit.TestKit
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import drt.server.feeds.lhr.live.LHRLiveFeed
-import drt.shared.Arrival
+import drt.shared.{Arrival, LiveFeed}
 import org.specs2.mutable.SpecificationLike
 import services.SDate
 import spray.http.{HttpEntity, _}
@@ -107,7 +107,7 @@ class LHRLiveFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFacto
         ActualChox = Some(SDate("2018-02-12T10:02:00Z").millisSinceEpoch), Gate = None,
         Stand = Some("1"), MaxPax = Some(469), ActPax = Some(414), TranPax = Some(218), RunwayID = None, BaggageReclaimId = None, FlightID = None,
         AirportID = "LHR", Terminal = "T2", rawICAO = "FL002", rawIATA = "FL002", Origin = "JNB",
-        Scheduled = SDate("2018-02-12T10:20:00").millisSinceEpoch,
+        Scheduled = SDate("2018-02-12T10:20:00").millisSinceEpoch, FeedSources = Set(LiveFeed),
         PcpTime = None, LastKnownPax = None
       )
 
@@ -129,7 +129,7 @@ class LHRLiveFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFacto
         ActualChox = Some(SDate("2018-04-12T09:02:00Z").millisSinceEpoch),
         Gate = None, Stand = Some("1"), MaxPax = None, ActPax = None, TranPax = None, RunwayID = None, BaggageReclaimId = None,
         FlightID = None, AirportID = "LHR", Terminal = "T2", rawICAO = "FL002", rawIATA = "FL002", Origin = "JNB",
-        Scheduled = SDate("2018-04-12T09:20:00Z").millisSinceEpoch, PcpTime = None,
+        Scheduled = SDate("2018-04-12T09:20:00Z").millisSinceEpoch, PcpTime = None, FeedSources = Set(LiveFeed),
         LastKnownPax = None
       )
 
@@ -152,7 +152,7 @@ class LHRLiveFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFacto
         ActualChox = Some(SDate("2018-02-12T10:02:00Z").millisSinceEpoch),
         Gate = None, Stand = Some("1"), MaxPax = None, ActPax = None, TranPax = None, RunwayID = None, BaggageReclaimId = None,
         FlightID = None, AirportID = "LHR", Terminal = "T2", rawICAO = "FL002", rawIATA = "FL002", Origin = "JNB",
-        Scheduled = SDate("2018-02-12T10:20:00").millisSinceEpoch,
+        Scheduled = SDate("2018-02-12T10:20:00").millisSinceEpoch, FeedSources = Set(LiveFeed),
         PcpTime = None, LastKnownPax = None
       )
 
@@ -177,7 +177,7 @@ class LHRLiveFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFacto
           ActualChox = Some(SDate("2018-02-12T10:02:00").millisSinceEpoch),
           Gate = None, Stand = Some("1"), MaxPax = Some(469), ActPax = Some(414), TranPax = Some(218), RunwayID = None, BaggageReclaimId = None,
           FlightID = None, AirportID = "LHR", Terminal = "T2", rawICAO = "FL002", rawIATA = "FL002",
-          Origin = "JNB",
+          Origin = "JNB", FeedSources = Set(LiveFeed),
           Scheduled = SDate("2018-02-12T10:20:00").millisSinceEpoch, PcpTime = None, LastKnownPax = None
         ),
         Arrival(
@@ -185,7 +185,7 @@ class LHRLiveFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFacto
           EstimatedChox = None, ActualChox = None, Gate = None, Stand = Some("2"),
           MaxPax = Some(214), ActPax = Some(163), TranPax = Some(104), RunwayID = None, BaggageReclaimId = None, FlightID = None,
           AirportID = "LHR", Terminal = "T2", rawICAO = "FL001", rawIATA = "FL001", Origin = "JNB",
-          Scheduled = SDate("2018-02-12T18:20:00").millisSinceEpoch,
+          Scheduled = SDate("2018-02-12T18:20:00").millisSinceEpoch, FeedSources = Set(LiveFeed),
           PcpTime = None, LastKnownPax = None
         )
       )
@@ -208,14 +208,14 @@ class LHRLiveFeedSpec extends TestKit(ActorSystem("testActorSystem", ConfigFacto
           Estimated = Some(SDate("2018-02-12T09:53:43").millisSinceEpoch),
           Actual = None,
           EstimatedChox = Some(SDate("2018-02-12T10:03:00").millisSinceEpoch),
-          ActualChox = Some(SDate("2018-02-12T10:02:00").millisSinceEpoch),
+          ActualChox = Some(SDate("2018-02-12T10:02:00").millisSinceEpoch), FeedSources = Set(LiveFeed),
           Gate = None, Stand = Some("1"), MaxPax = None, ActPax = None, TranPax = None, RunwayID = None, BaggageReclaimId = None,
           FlightID = None, AirportID = "LHR", Terminal = "T2", rawICAO = "FL002", rawIATA = "FL002", Origin = "JNB",
           Scheduled = SDate("2018-02-12T10:20:00").millisSinceEpoch, PcpTime = None, LastKnownPax = None
         ),
         Arrival(
           Operator = Some("FL"), Status = "Scheduled", Estimated = None, Actual = None, EstimatedChox = None, ActualChox = None, Gate = None, Stand = Some("2"), MaxPax = None, ActPax = None, TranPax = None, RunwayID = None, BaggageReclaimId = None, FlightID = None, AirportID = "LHR", Terminal = "T2", rawICAO = "FL001", rawIATA = "FL001", Origin = "JNB",
-          Scheduled = SDate("2018-02-12T18:20:00").millisSinceEpoch, PcpTime = None, LastKnownPax = None
+          Scheduled = SDate("2018-02-12T18:20:00").millisSinceEpoch, PcpTime = None, LastKnownPax = None, FeedSources = Set(LiveFeed)
         )
       )
 

--- a/server/src/test/scala/services/ApiFlightsToProtoBufSpec.scala
+++ b/server/src/test/scala/services/ApiFlightsToProtoBufSpec.scala
@@ -1,6 +1,6 @@
 package services
 
-import drt.shared.{Arrival, MilliDate, SDateLike}
+import drt.shared.{ApiFeed, Arrival, MilliDate, SDateLike}
 import org.specs2.mutable.Specification
 import server.protobuf.messages.FlightsMessage.FlightMessage
 import actors.FlightMessageConversion._
@@ -30,7 +30,8 @@ class ApiFlightsToProtoBufSpec extends Specification {
         rawIATA = "BAA0001",
         Origin = "JFK",
         PcpTime = Some(1451655000000L), // 2016-01-01 13:30:00 UTC
-        Scheduled = SDate("2016-01-01T13:00:00Z").millisSinceEpoch
+        Scheduled = SDate("2016-01-01T13:00:00Z").millisSinceEpoch,
+        FeedSources = Set(ApiFeed)
       )
       val flightMessage = apiFlightToFlightMessage(apiFlight)
 
@@ -50,6 +51,7 @@ class ApiFlightsToProtoBufSpec extends Specification {
         iCAO = Some("BA0001"),
         iATA = Some("BAA0001"),
         origin = Some("JFK"),
+        feedSources = Seq("ApiFeed"),
         pcpTime = Some(1451655000000L), // 2016-01-01 13:30:00 UTC
         scheduled = Some(1451653200000L), // 2016-01-01 13:00:00 UTC
         estimated = Some(1451653500000L), // 2016-01-01 13:05:00 UTC

--- a/server/src/test/scala/services/ApiFlightsToProtoBufSpec.scala
+++ b/server/src/test/scala/services/ApiFlightsToProtoBufSpec.scala
@@ -1,6 +1,6 @@
 package services
 
-import drt.shared.{ApiFeed, Arrival, MilliDate, SDateLike}
+import drt.shared.{ApiFeedSource, Arrival, MilliDate, SDateLike}
 import org.specs2.mutable.Specification
 import server.protobuf.messages.FlightsMessage.FlightMessage
 import actors.FlightMessageConversion._
@@ -31,7 +31,7 @@ class ApiFlightsToProtoBufSpec extends Specification {
         Origin = "JFK",
         PcpTime = Some(1451655000000L), // 2016-01-01 13:30:00 UTC
         Scheduled = SDate("2016-01-01T13:00:00Z").millisSinceEpoch,
-        FeedSources = Set(ApiFeed)
+        FeedSources = Set(ApiFeedSource)
       )
       val flightMessage = apiFlightToFlightMessage(apiFlight)
 
@@ -51,7 +51,7 @@ class ApiFlightsToProtoBufSpec extends Specification {
         iCAO = Some("BA0001"),
         iATA = Some("BAA0001"),
         origin = Some("JFK"),
-        feedSources = Seq("ApiFeed"),
+        feedSources = Seq("ApiFeedSource"),
         pcpTime = Some(1451655000000L), // 2016-01-01 13:30:00 UTC
         scheduled = Some(1451653200000L), // 2016-01-01 13:00:00 UTC
         estimated = Some(1451653500000L), // 2016-01-01 13:05:00 UTC

--- a/server/src/test/scala/services/CodeSharesSpec.scala
+++ b/server/src/test/scala/services/CodeSharesSpec.scala
@@ -1,6 +1,6 @@
 package services
 
-import drt.shared.{ApiFeed, Arrival, LiveFeed}
+import drt.shared.{ApiFeedSource, Arrival, LiveFeedSource}
 import org.specs2.mutable.Specification
 import controllers.ArrivalGenerator.apiFlight
 
@@ -121,9 +121,9 @@ class CodeSharesSpec extends Specification {
     "Given three similar flights all with API data "+
       "When we ask for unique flights "+
       "Then we should see three tuple of only of flights with no codeshares" in {
-      val flight1: Arrival = apiFlight(flightId = Option(1), iata = "BA0001", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(100), feedSources = Set(ApiFeed, LiveFeed))
-      val flight2: Arrival = apiFlight(flightId = Option(2), iata = "AA8778", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(150), feedSources = Set(ApiFeed, LiveFeed))
-      val flight3: Arrival = apiFlight(flightId = Option(3), iata = "ZZ5566", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(175), feedSources = Set(ApiFeed, LiveFeed))
+      val flight1: Arrival = apiFlight(flightId = Option(1), iata = "BA0001", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(100), feedSources = Set(ApiFeedSource, LiveFeedSource))
+      val flight2: Arrival = apiFlight(flightId = Option(2), iata = "AA8778", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(150), feedSources = Set(ApiFeedSource, LiveFeedSource))
+      val flight3: Arrival = apiFlight(flightId = Option(3), iata = "ZZ5566", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(175), feedSources = Set(ApiFeedSource, LiveFeedSource))
 
       val result = uniqueArrivalsWithCodeShares(identity[Arrival])(Seq(flight1, flight2, flight3))
 
@@ -139,9 +139,9 @@ class CodeSharesSpec extends Specification {
     "Given three similar flights one with API data " +
       "When we ask for unique flights " +
       "Then we should see a tuple of only one flight with two code shares" in {
-      val flight1: Arrival = apiFlight(flightId = Option(1), iata = "BA0001", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(100), feedSources = Set(ApiFeed, LiveFeed))
-      val flight2: Arrival = apiFlight(flightId = Option(2), iata = "AA8778", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(150), feedSources = Set(LiveFeed))
-      val flight3: Arrival = apiFlight(flightId = Option(3), iata = "ZZ5566", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(175), feedSources = Set(LiveFeed))
+      val flight1: Arrival = apiFlight(flightId = Option(1), iata = "BA0001", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(100), feedSources = Set(ApiFeedSource, LiveFeedSource))
+      val flight2: Arrival = apiFlight(flightId = Option(2), iata = "AA8778", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(150), feedSources = Set(LiveFeedSource))
+      val flight3: Arrival = apiFlight(flightId = Option(3), iata = "ZZ5566", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(175), feedSources = Set(LiveFeedSource))
 
       val result = uniqueArrivalsWithCodeShares(identity[Arrival])(Seq(flight1, flight2, flight3))
 
@@ -154,9 +154,9 @@ class CodeSharesSpec extends Specification {
     "Given three similar flights two with API data " +
       "When we ask for unique flights " +
       "Then we should see a tuple of only one flight with one code shares and another with no code share" in {
-      val flight1: Arrival = apiFlight(flightId = Option(1), iata = "BA0001", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(100), feedSources = Set(ApiFeed, LiveFeed))
-      val flight2: Arrival = apiFlight(flightId = Option(2), iata = "AA8778", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(150), feedSources = Set(LiveFeed))
-      val flight3: Arrival = apiFlight(flightId = Option(3), iata = "ZZ5566", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(175), feedSources = Set(ApiFeed, LiveFeed))
+      val flight1: Arrival = apiFlight(flightId = Option(1), iata = "BA0001", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(100), feedSources = Set(ApiFeedSource, LiveFeedSource))
+      val flight2: Arrival = apiFlight(flightId = Option(2), iata = "AA8778", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(150), feedSources = Set(LiveFeedSource))
+      val flight3: Arrival = apiFlight(flightId = Option(3), iata = "ZZ5566", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(175), feedSources = Set(ApiFeedSource, LiveFeedSource))
 
       val result = uniqueArrivalsWithCodeShares(identity[Arrival])(Seq(flight1, flight2, flight3))
 

--- a/server/src/test/scala/services/CodeSharesSpec.scala
+++ b/server/src/test/scala/services/CodeSharesSpec.scala
@@ -1,6 +1,6 @@
 package services
 
-import drt.shared.Arrival
+import drt.shared.{ApiFeed, Arrival, LiveFeed}
 import org.specs2.mutable.Specification
 import controllers.ArrivalGenerator.apiFlight
 
@@ -114,5 +114,58 @@ class CodeSharesSpec extends Specification {
     )
 
     result === expected
+  }
+
+  "Codeshares with API data" should {
+
+    "Given three similar flights all with API data "+
+      "When we ask for unique flights "+
+      "Then we should see three tuple of only of flights with no codeshares" in {
+      val flight1: Arrival = apiFlight(flightId = Option(1), iata = "BA0001", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(100), feedSources = Set(ApiFeed, LiveFeed))
+      val flight2: Arrival = apiFlight(flightId = Option(2), iata = "AA8778", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(150), feedSources = Set(ApiFeed, LiveFeed))
+      val flight3: Arrival = apiFlight(flightId = Option(3), iata = "ZZ5566", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(175), feedSources = Set(ApiFeed, LiveFeed))
+
+      val result = uniqueArrivalsWithCodeShares(identity[Arrival])(Seq(flight1, flight2, flight3))
+
+      val expected = List(
+        (flight1, Set()),
+        (flight2, Set()),
+        (flight3, Set())
+      )
+
+      result mustEqual expected
+    }
+
+    "Given three similar flights one with API data " +
+      "When we ask for unique flights " +
+      "Then we should see a tuple of only one flight with two code shares" in {
+      val flight1: Arrival = apiFlight(flightId = Option(1), iata = "BA0001", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(100), feedSources = Set(ApiFeed, LiveFeed))
+      val flight2: Arrival = apiFlight(flightId = Option(2), iata = "AA8778", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(150), feedSources = Set(LiveFeed))
+      val flight3: Arrival = apiFlight(flightId = Option(3), iata = "ZZ5566", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(175), feedSources = Set(LiveFeed))
+
+      val result = uniqueArrivalsWithCodeShares(identity[Arrival])(Seq(flight1, flight2, flight3))
+
+      val expected = List(
+        (flight1, Set(flight2, flight3))
+      )
+      result mustEqual expected
+    }
+
+    "Given three similar flights two with API data " +
+      "When we ask for unique flights " +
+      "Then we should see a tuple of only one flight with one code shares and another with no code share" in {
+      val flight1: Arrival = apiFlight(flightId = Option(1), iata = "BA0001", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(100), feedSources = Set(ApiFeed, LiveFeed))
+      val flight2: Arrival = apiFlight(flightId = Option(2), iata = "AA8778", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(150), feedSources = Set(LiveFeed))
+      val flight3: Arrival = apiFlight(flightId = Option(3), iata = "ZZ5566", schDt = "2016-01-01T10:25Z", terminal = "T1", origin = "JFK", actPax = Option(175), feedSources = Set(ApiFeed, LiveFeed))
+
+      val result = uniqueArrivalsWithCodeShares(identity[Arrival])(Seq(flight1, flight2, flight3))
+
+      val expected = List(
+        (flight1, Set(flight2)),
+        (flight3, Set())
+      )
+      result mustEqual expected
+    }
+
   }
 }

--- a/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
+++ b/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
@@ -21,7 +21,7 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
   trait Context extends Scope {
     val arrival_v1_with_no_chox_time: Arrival = apiFlight(flightId = Option(1), iata = "BA0001",
       schDt = "2017-01-01T10:25Z", origin = "JFK",
-      actPax = Option(100), feedSources = Set(LiveFeed))
+      actPax = Option(100), feedSources = Set(LiveFeedSource))
 
     val arrival_v2_with_chox_time: Arrival = arrival_v1_with_no_chox_time.copy(Stand = Some("Stand1"), ActualChox = Some(SDate("2017-01-01T10:25Z").millisSinceEpoch))
 
@@ -83,19 +83,19 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
           if (portStateSources.size > feedSources.size)
           feedSources =portStateSources
       }
-      feedSources === Set(LiveFeed, ApiFeed)
+      feedSources === Set(LiveFeedSource, ApiFeedSource)
     }
 
     "once a acl and a forecast input arrives for the flight, it will update the arrivals FeedSource so that it has a ACLFeed, LiveFeed and a ForecastFeed" in new Context {
       val forecastScheduled = "2017-01-01T10:25Z"
 
       val aclFlight = Flights(List(
-        ArrivalGenerator.apiFlight(flightId = Option(1), actPax = Option(10), schDt = forecastScheduled, iata = "BA0001", feedSources = Set(AclFeed))
+        ArrivalGenerator.apiFlight(flightId = Option(1), actPax = Option(10), schDt = forecastScheduled, iata = "BA0001", feedSources = Set(AclFeedSource))
       ))
 
       offerAndWait(crunch.baseArrivalsInput, ArrivalsFeedSuccess(aclFlight))
 
-      val forecastArrival = apiFlight(schDt = forecastScheduled, iata = "BA0001", terminal = "T1", actPax = Option(21), feedSources = Set(ForecastFeed))
+      val forecastArrival = apiFlight(schDt = forecastScheduled, iata = "BA0001", terminal = "T1", actPax = Option(21), feedSources = Set(ForecastFeedSource))
       val forecastArrivals = ArrivalsFeedSuccess(Flights(List(forecastArrival)))
 
 
@@ -109,7 +109,7 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
           if (portStateSources.size > feedSources.size)
           feedSources =portStateSources
       }
-      feedSources === Set(LiveFeed, ForecastFeed, AclFeed)
+      feedSources === Set(LiveFeedSource, ForecastFeedSource, AclFeedSource)
     }
 
   }

--- a/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
+++ b/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
@@ -1,12 +1,17 @@
 package services.crunch
 
+import controllers.ArrivalGenerator
 import controllers.ArrivalGenerator.apiFlight
 import drt.shared.CrunchApi.PortState
 import drt.shared.FlightsApi.Flights
 import drt.shared._
 import org.specs2.matcher.Scope
-import server.feeds.ArrivalsFeedSuccess
+import passengersplits.parsing.VoyageManifestParser.{PassengerInfoJson, VoyageManifest}
+import server.feeds.{ArrivalsFeedSuccess, ManifestsFeedSuccess}
 import services.SDate
+import services.graphstages.DqManifests
+
+import scala.collection.immutable.List
 import scala.concurrent.duration._
 
 class ArrivalsGraphStageSpec extends CrunchTestLike {
@@ -16,7 +21,7 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
   trait Context extends Scope {
     val arrival_v1_with_no_chox_time: Arrival = apiFlight(flightId = Option(1), iata = "BA0001",
       schDt = "2017-01-01T10:25Z", origin = "JFK",
-      actPax = Option(100))
+      actPax = Option(100), feedSources = Set(LiveFeed))
 
     val arrival_v2_with_chox_time: Arrival = arrival_v1_with_no_chox_time.copy(Stand = Some("Stand1"), ActualChox = Some(SDate("2017-01-01T10:25Z").millisSinceEpoch))
 
@@ -60,6 +65,53 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
 
       messages must be_===(Seq(arrival_v2_with_chox_time, arrival_v1_with_no_chox_time))
     }
+
+    "once an API (advanced passenger information) input arrives for the flight, it will update the arrivals FeedSource so that it has a LiveFeed and a ApiFeed" in new Context {
+
+      val voyageManifests = ManifestsFeedSuccess(DqManifests("", Set(
+        VoyageManifest(DqEventCodes.CheckIn, "STN", "JFK", "0001", "BA", "2017-01-01", "10:25", List(
+          PassengerInfoJson(Some("P"), "GBR", "EEA", Some("22"), Some("LHR"), "N", Some("GBR"), Option("GBR"), None)
+        ))
+      )))
+
+      offerAndWait(crunch.manifestsInput, voyageManifests)
+
+      var feedSources: Set[FeedSource] = Set[FeedSource]()
+      crunch.liveTestProbe.receiveWhile(5 seconds) {
+        case ps: PortState =>
+          val portStateSources = ps.flights.values.flatMap(_.apiFlight.FeedSources).toSet
+          if (portStateSources.size > feedSources.size)
+          feedSources =portStateSources
+      }
+      feedSources === Set(LiveFeed, ApiFeed)
+    }
+
+    "once a acl and a forecast input arrives for the flight, it will update the arrivals FeedSource so that it has a ACLFeed, LiveFeed and a ForecastFeed" in new Context {
+      val forecastScheduled = "2017-01-01T10:25Z"
+
+      val aclFlight = Flights(List(
+        ArrivalGenerator.apiFlight(flightId = Option(1), actPax = Option(10), schDt = forecastScheduled, iata = "BA0001", feedSources = Set(AclFeed))
+      ))
+
+      offerAndWait(crunch.baseArrivalsInput, ArrivalsFeedSuccess(aclFlight))
+
+      val forecastArrival = apiFlight(schDt = forecastScheduled, iata = "BA0001", terminal = "T1", actPax = Option(21), feedSources = Set(ForecastFeed))
+      val forecastArrivals = ArrivalsFeedSuccess(Flights(List(forecastArrival)))
+
+
+      offerAndWait(crunch.forecastArrivalsInput, forecastArrivals)
+
+      var feedSources: Set[FeedSource] = Set[FeedSource]()
+      crunch.liveTestProbe.receiveWhile(5 seconds) {
+        case ps: PortState =>
+          val portStateSources = ps.flights.values.flatMap(_.apiFlight.FeedSources).toSet
+          println("HERE: "+ portStateSources)
+          if (portStateSources.size > feedSources.size)
+          feedSources =portStateSources
+      }
+      feedSources === Set(LiveFeed, ForecastFeed, AclFeed)
+    }
+
   }
 
 

--- a/server/src/test/scala/services/inputfeeds/AclFeedSpec.scala
+++ b/server/src/test/scala/services/inputfeeds/AclFeedSpec.scala
@@ -2,6 +2,7 @@ package services.inputfeeds
 
 import com.typesafe.config.ConfigFactory
 import controllers.ArrivalGenerator
+import drt.shared
 import drt.shared.CrunchApi.PortState
 import drt.shared.FlightsApi.{Flights, TerminalName}
 import drt.shared.PaxTypesAndQueues._
@@ -46,7 +47,7 @@ class AclFeedSpec extends CrunchTestLike {
       val expected = List(Arrival(Operator = Some("4U"), Status = "ACL Forecast", Estimated = None, Actual = None,
         EstimatedChox = None, ActualChox = None, Gate = None, Stand = None, MaxPax = Some(180), ActPax = Some(149),
         TranPax = None, RunwayID = None, BaggageReclaimId = None, FlightID = Some(-904483842), AirportID = "LHR", Terminal = "T2",
-        rawICAO = "4U0460", rawIATA = "4U0460", Origin = "CGN",
+        rawICAO = "4U0460", rawIATA = "4U0460", Origin = "CGN",FeedSources = Set(shared.AclFeed),
         Scheduled = 1507878600000L, PcpTime = None, LastKnownPax = None))
 
       arrivals === expected
@@ -93,7 +94,7 @@ class AclFeedSpec extends CrunchTestLike {
         Actual = None, EstimatedChox = None, ActualChox = None, Gate = None,
         Stand = None, MaxPax = Some(180), ActPax = Some(149), TranPax = None, RunwayID = None, BaggageReclaimId = None,
         FlightID = Some(-904483842), AirportID = "LHR", Terminal = "S", rawICAO = "4U0460", rawIATA = "4U0460",
-        Origin = "CGN", Scheduled = 1507878600000L, PcpTime = None, LastKnownPax = None))
+        Origin = "CGN", Scheduled = 1507878600000L, PcpTime = None, FeedSources = Set(shared.AclFeed), LastKnownPax = None))
 
       arrivals === expected
     }

--- a/server/src/test/scala/services/inputfeeds/AclFeedSpec.scala
+++ b/server/src/test/scala/services/inputfeeds/AclFeedSpec.scala
@@ -47,7 +47,7 @@ class AclFeedSpec extends CrunchTestLike {
       val expected = List(Arrival(Operator = Some("4U"), Status = "ACL Forecast", Estimated = None, Actual = None,
         EstimatedChox = None, ActualChox = None, Gate = None, Stand = None, MaxPax = Some(180), ActPax = Some(149),
         TranPax = None, RunwayID = None, BaggageReclaimId = None, FlightID = Some(-904483842), AirportID = "LHR", Terminal = "T2",
-        rawICAO = "4U0460", rawIATA = "4U0460", Origin = "CGN",FeedSources = Set(shared.AclFeed),
+        rawICAO = "4U0460", rawIATA = "4U0460", Origin = "CGN",FeedSources = Set(shared.AclFeedSource),
         Scheduled = 1507878600000L, PcpTime = None, LastKnownPax = None))
 
       arrivals === expected
@@ -94,7 +94,7 @@ class AclFeedSpec extends CrunchTestLike {
         Actual = None, EstimatedChox = None, ActualChox = None, Gate = None,
         Stand = None, MaxPax = Some(180), ActPax = Some(149), TranPax = None, RunwayID = None, BaggageReclaimId = None,
         FlightID = Some(-904483842), AirportID = "LHR", Terminal = "S", rawICAO = "4U0460", rawIATA = "4U0460",
-        Origin = "CGN", Scheduled = 1507878600000L, PcpTime = None, FeedSources = Set(shared.AclFeed), LastKnownPax = None))
+        Origin = "CGN", Scheduled = 1507878600000L, PcpTime = None, FeedSources = Set(shared.AclFeedSource), LastKnownPax = None))
 
       arrivals === expected
     }

--- a/server/src/test/scala/services/inputfeeds/LhrForecastSpec.scala
+++ b/server/src/test/scala/services/inputfeeds/LhrForecastSpec.scala
@@ -1,7 +1,7 @@
 package services.inputfeeds
 
 import drt.server.feeds.lhr.forecast.{LhrForecastArrival, LhrForecastArrivals}
-import drt.shared.{Arrival, ForecastFeed}
+import drt.shared.{Arrival, ForecastFeedSource}
 import org.specs2.mutable.Specification
 import services.SDate
 
@@ -25,7 +25,7 @@ class LhrForecastSpec extends Specification {
     val expected = Arrival(Operator = Some("BA"), Status = "Forecast", Estimated = None, Actual = None,
       EstimatedChox = None, ActualChox = None, Gate = None, Stand = None, MaxPax = Some(337),
       ActPax = Some(333), TranPax = Some(142), RunwayID = None, BaggageReclaimId = None, FlightID = None, AirportID = "LHR", Terminal = "T3",
-      rawICAO = "BA0058", rawIATA = "BA0058", Origin = "CPT", FeedSources = Set(ForecastFeed),
+      rawICAO = "BA0058", rawIATA = "BA0058", Origin = "CPT", FeedSources = Set(ForecastFeedSource),
       Scheduled = SDate("2018-02-22T04:45:00").millisSinceEpoch, PcpTime = None, LastKnownPax = None)
 
     arrival === expected

--- a/server/src/test/scala/services/inputfeeds/LhrForecastSpec.scala
+++ b/server/src/test/scala/services/inputfeeds/LhrForecastSpec.scala
@@ -1,7 +1,7 @@
 package services.inputfeeds
 
 import drt.server.feeds.lhr.forecast.{LhrForecastArrival, LhrForecastArrivals}
-import drt.shared.Arrival
+import drt.shared.{Arrival, ForecastFeed}
 import org.specs2.mutable.Specification
 import services.SDate
 
@@ -25,7 +25,7 @@ class LhrForecastSpec extends Specification {
     val expected = Arrival(Operator = Some("BA"), Status = "Forecast", Estimated = None, Actual = None,
       EstimatedChox = None, ActualChox = None, Gate = None, Stand = None, MaxPax = Some(337),
       ActPax = Some(333), TranPax = Some(142), RunwayID = None, BaggageReclaimId = None, FlightID = None, AirportID = "LHR", Terminal = "T3",
-      rawICAO = "BA0058", rawIATA = "BA0058", Origin = "CPT",
+      rawICAO = "BA0058", rawIATA = "BA0058", Origin = "CPT", FeedSources = Set(ForecastFeed),
       Scheduled = SDate("2018-02-22T04:45:00").millisSinceEpoch, PcpTime = None, LastKnownPax = None)
 
     arrival === expected

--- a/shared/src/main/scala/drt/shared/Api.scala
+++ b/shared/src/main/scala/drt/shared/Api.scala
@@ -208,16 +208,16 @@ object Arrival {
 
 sealed trait FeedSource
 
-case object ApiFeed extends FeedSource
+case object ApiFeedSource extends FeedSource
 
-case object AclFeed extends FeedSource
+case object AclFeedSource extends FeedSource
 
-case object ForecastFeed extends FeedSource
+case object ForecastFeedSource extends FeedSource
 
-case object LiveFeed extends FeedSource
+case object LiveFeedSource extends FeedSource
 
 object FeedSource {
-  def feedSources: Set[FeedSource] = Set(ApiFeed, AclFeed, ForecastFeed, LiveFeed)
+  def feedSources: Set[FeedSource] = Set(ApiFeedSource, AclFeedSource, ForecastFeedSource, LiveFeedSource)
   def apply(name: String): Option[FeedSource] = feedSources.find(fs=> fs.toString == name)
 }
 

--- a/shared/src/main/scala/drt/shared/Api.scala
+++ b/shared/src/main/scala/drt/shared/Api.scala
@@ -146,6 +146,7 @@ case class Arrival(
                     Origin: String,
                     Scheduled: MillisSinceEpoch,
                     PcpTime: Option[MillisSinceEpoch],
+                    FeedSources: Set[FeedSource],
                     LastKnownPax: Option[Int] = None) {
   lazy val ICAO: String = Arrival.standardiseFlightCode(rawICAO)
   lazy val IATA: String = Arrival.standardiseFlightCode(rawIATA)
@@ -203,6 +204,21 @@ object Arrival {
       case _ => flightCode
     }
   }
+}
+
+sealed trait FeedSource
+
+case object ApiFeed extends FeedSource
+
+case object AclFeed extends FeedSource
+
+case object ForecastFeed extends FeedSource
+
+case object LiveFeed extends FeedSource
+
+object FeedSource {
+  def feedSources: Set[FeedSource] = Set(ApiFeed, AclFeed, ForecastFeed, LiveFeed)
+  def apply(name: String): Option[FeedSource] = feedSources.find(fs=> fs.toString == name)
 }
 
 case class ArrivalsDiff(toUpdate: Set[Arrival], toRemove: Set[Int])

--- a/shared/src/main/scala/drt/shared/CodeShares.scala
+++ b/shared/src/main/scala/drt/shared/CodeShares.scala
@@ -3,17 +3,22 @@ package drt.shared
 object CodeShares {
   def uniqueArrivalsWithCodeShares[GenFlight](apiFlightFromGenFlight: (GenFlight) => Arrival)
                                              (flights: Seq[GenFlight]): List[(GenFlight, Set[Arrival])] = {
-    val grouped = flights.groupBy(f =>
-      (apiFlightFromGenFlight(f).Scheduled, apiFlightFromGenFlight(f).Terminal, apiFlightFromGenFlight(f).Origin)
-    )
-    grouped.values.map(flights => {
-      val mainFlight: GenFlight = flights.sortBy(f => apiFlightFromGenFlight(f).ActPax).reverse.head
+    val grouped = flights.groupBy(f => {
+      val arrival = apiFlightFromGenFlight(f)
+      (arrival.Scheduled, arrival.Terminal, arrival.Origin)
+    })
+    grouped.values.flatMap(flights => {
+      def mainFlightWithNoApiData: GenFlight = flights.sortBy(f => apiFlightFromGenFlight(f).ActPax).reverse.head
+      val mainFlightsWithApiData = flights.filter(apiFlightFromGenFlight(_).FeedSources.contains(ApiFeed))
+      val mainFlights: Seq[GenFlight] = if (mainFlightsWithApiData.isEmpty) Seq(mainFlightWithNoApiData) else mainFlightsWithApiData
       val shares: Set[Arrival] = flights
-        .filter(_ != mainFlight)
+        .filterNot(mainFlights.contains)
         .toSet
         .map(apiFlightFromGenFlight)
 
-      (mainFlight, shares)
+      mainFlights.zipWithIndex.map { case (mf, i) => (mf, if (i == 0) shares else Set.empty[Arrival])
+
+      }
     }).toList
   }
 }

--- a/shared/src/main/scala/drt/shared/CodeShares.scala
+++ b/shared/src/main/scala/drt/shared/CodeShares.scala
@@ -9,7 +9,7 @@ object CodeShares {
     })
     grouped.values.flatMap(flights => {
       def mainFlightWithNoApiData: GenFlight = flights.sortBy(f => apiFlightFromGenFlight(f).ActPax).reverse.head
-      val mainFlightsWithApiData = flights.filter(apiFlightFromGenFlight(_).FeedSources.contains(ApiFeed))
+      val mainFlightsWithApiData = flights.filter(apiFlightFromGenFlight(_).FeedSources.contains(ApiFeedSource))
       val mainFlights: Seq[GenFlight] = if (mainFlightsWithApiData.isEmpty) Seq(mainFlightWithNoApiData) else mainFlightsWithApiData
       val shares: Set[Arrival] = flights
         .filterNot(mainFlights.contains)


### PR DESCRIPTION
## Improve codeshare matching criteria
- Added FeedSources to each Arrival Input
  - ApiFeed
  - AclFeed
  - ForecastFeed 
  - LiveFeed extends FeedSource
- Improved the codeshare matching criteria so that if it has a API data it is not a codeshare (it is a main flight).
- Unit tests to ensure we are saving the FeedSources

Jira: https://jira.digital.homeoffice.gov.uk/browse/DRT-5148
