### PR TITLE
DRT-5260 - Add Google Analytics Data

### DIFF
--- a/client/src/main/scala/drt/client/components/AlertsPage.scala
+++ b/client/src/main/scala/drt/client/components/AlertsPage.scala
@@ -4,6 +4,7 @@ import diode.data.Pot
 import diode.react.ModelProxy
 import drt.client.actions.Actions.{DeleteAllAlerts, SaveAlert}
 import drt.client.logger.{Logger, LoggerFactory}
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.JSDateConversions.SDate
 import drt.client.services.SPACircuit
 import drt.shared.CrunchApi.MillisSinceEpoch
@@ -26,6 +27,7 @@ object AlertsPage {
       val modelRCP = SPACircuit.connect(m => m.alerts)
 
       def deleteAllAlerts = (_: ReactEventFromInput) => {
+        GoogleEventTracker.sendEvent("alerts", "Delete All Alerts", "")
         SPACircuit.dispatch(DeleteAllAlerts)
         scope.setState(State())
       }
@@ -48,7 +50,9 @@ object AlertsPage {
           message <- state.message
           expiryDateTime <- state.expiryDateTime
         } yield {
-          SPACircuit.dispatch(SaveAlert(Alert(title, message, expiryDateTime, SDate.now().millisSinceEpoch)))
+          val alert = Alert(title, message, expiryDateTime, SDate.now().millisSinceEpoch)
+          GoogleEventTracker.sendEvent("alerts", "Add Alert", alert.toString)
+          SPACircuit.dispatch(SaveAlert(alert))
         }
         scope.setState(State())
       }
@@ -134,6 +138,7 @@ object AlertsPage {
         )
       )
     })
+    .componentDidMount(p => Callback(GoogleEventTracker.sendPageView("alerts")))
     .build
 
   def apply(): VdomElement = component()

--- a/client/src/main/scala/drt/client/components/DatePickerComponent.scala
+++ b/client/src/main/scala/drt/client/components/DatePickerComponent.scala
@@ -2,6 +2,7 @@ package drt.client.components
 
 import drt.client.SPAMain.{Loc, TerminalPageTabLoc}
 import drt.client.logger.{Logger, LoggerFactory}
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.JSDateConversions.SDate
 import drt.client.services.LoadingState
 import drt.shared.SDateLike
@@ -77,20 +78,26 @@ object DatePickerComponent {
       }
 
       def selectPointInTime = (_: ReactEventFromInput) => {
+        GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "Point In time", state.selectedDateTime.toISODateOnly)
         updateUrlWithDateCallback(Option(state.selectedDateTime))
       }
 
       def selectYesterday = (_: ReactEventFromInput) => {
         val yesterday = SDate.midnightThisMorning().addMinutes(-1)
+        GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "Yesterday", yesterday.toISODateOnly)
         updateUrlWithDateCallback(Option(yesterday))
       }
 
       def selectTomorrow = (_: ReactEventFromInput) => {
         val tomorrow = SDate.midnightThisMorning().addDays(2).addMinutes(-1)
+        GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "Tomorrow", tomorrow.toISODateOnly)
         updateUrlWithDateCallback(Option(tomorrow))
       }
 
-      def selectToday = (_: ReactEventFromInput) => updateUrlWithDateCallback(None)
+      def selectToday = (_: ReactEventFromInput) => {
+        GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "Today", "Today")
+        updateUrlWithDateCallback(None)
+      }
 
       def isDataAvailableForDate = SnapshotSelector.isLaterThanEarliest(state.selectedDateTime)
 

--- a/client/src/main/scala/drt/client/components/ListKeyCloakUsers.scala
+++ b/client/src/main/scala/drt/client/components/ListKeyCloakUsers.scala
@@ -2,6 +2,7 @@ package drt.client.components
 
 import diode.data.Pot
 import drt.client.actions.Actions.AddUserToGroup
+import drt.client.modules.GoogleEventTracker
 import drt.client.services._
 import drt.shared.KeyCloakApi.KeyCloakUser
 import japgolly.scalajs.react.vdom.html_<^._
@@ -34,7 +35,9 @@ object ListKeyCloakUsers {
         )
       })
     }
-    ).build
+    )
+    .componentDidMount(p => Callback(GoogleEventTracker.sendPageView("users")))
+    .build
 
   def apply(): VdomElement = component(Props())
 }

--- a/client/src/main/scala/drt/client/components/MultiDayExportComponent.scala
+++ b/client/src/main/scala/drt/client/components/MultiDayExportComponent.scala
@@ -1,9 +1,10 @@
 package drt.client.components
 
 import drt.client.logger.{Logger, LoggerFactory}
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.JSDateConversions.SDate
 import drt.shared.SDateLike
-import japgolly.scalajs.react.ScalaComponent
+import japgolly.scalajs.react.{Callback, ScalaComponent}
 import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.vdom.html_<^._
 import org.scalajs.dom
@@ -77,11 +78,15 @@ object MultiDayExportComponent {
                     <.a("Export Arrivals",
                       ^.className := "btn btn-default",
                       ^.href := s"${dom.window.location.pathname}/export/arrivals/${state.startMillis}/${state.endMillis}/${props.terminal}",
-                      ^.target := "_blank"),
+                      ^.target := "_blank",
+                      ^.onClick -->{Callback(GoogleEventTracker.sendEvent(props.terminal, "click", "Export Arrivals", f"${state.startYear}-${state.startMonth}%02d-${state.startDay}%02d - ${state.endYear}-${state.endMonth}%02d-${state.endDay}%02d"))}
+                    ),
                     <.a("Export Desks",
                       ^.className := "btn btn-default",
                       ^.href := s"${dom.window.location.pathname}/export/desks/${state.startMillis}/${state.endMillis}/${props.terminal}",
-                      ^.target := "_blank")
+                      ^.target := "_blank",
+                      ^.onClick -->{Callback(GoogleEventTracker.sendEvent(props.terminal, "click", "Export Desks", f"${state.startYear}-${state.startMonth}%02d-${state.startDay}%02d - ${state.endYear}-${state.endMonth}%02d-${state.endDay}%02d"))}
+                    )
                   )
                 )
               ),

--- a/client/src/main/scala/drt/client/components/Navbar.scala
+++ b/client/src/main/scala/drt/client/components/Navbar.scala
@@ -1,7 +1,9 @@
 package drt.client.components
 
 import drt.client.SPAMain.Loc
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.SPACircuit
+import japgolly.scalajs.react.Callback
 import japgolly.scalajs.react.extra.router.{BaseUrl, RouterCtl}
 import japgolly.scalajs.react.vdom.html_<^._
 import org.scalajs.dom.html
@@ -20,17 +22,23 @@ object Navbar {
             }).getOrElse(TagMod(""))
 
             <.div(^.className := "navbar-drt",
+              <.input.hidden(^.id:="port-code", ^.value:=airportConfig.portCode),
               <.span(^.className := "navbar-brand", s"DRT ${airportConfig.portCode}"),
               loggedInUserPot.renderReady(loggedInUser =>
 
               <.div(^.className := "collapse navbar-collapse", MainMenu(ctl, page, feedStatusesPot.getOrElse(Seq()), airportConfig, loggedInUser.roles),
                 <.ul(^.className := "nav navbar-nav navbar-right",
                   <.li(contactLink),
-                  <.li(<.a(Icon.signOut, "Log Out", ^.href := "/oauth/logout?redirect=" + BaseUrl.until_#.value))
+                  <.li(<.a(Icon.signOut, "Log Out", ^.href := "/oauth/logout?redirect=" + BaseUrl.until_#.value,
+                    ^.onClick --> Callback(GoogleEventTracker.sendEvent(airportConfig.portCode, "Log Out", loggedInUser.id))))
                 )
               ))
             )
-          }))
+          }),
+          loggedInUserPot.render(loggedInUser => <.input.hidden(^.id:="user-id", ^.value:=loggedInUser.id)),
+          loggedInUserPot.renderEmpty(<.input.hidden(^.id:="user-id")),
+          airportConfigPot.renderEmpty(<.input.hidden(^.id:="port-code"))
+          )
       })
     )
   }

--- a/client/src/main/scala/drt/client/components/Navbar.scala
+++ b/client/src/main/scala/drt/client/components/Navbar.scala
@@ -22,7 +22,6 @@ object Navbar {
             }).getOrElse(TagMod(""))
 
             <.div(^.className := "navbar-drt",
-              <.input.hidden(^.id:="port-code", ^.value:=airportConfig.portCode),
               <.span(^.className := "navbar-brand", s"DRT ${airportConfig.portCode}"),
               loggedInUserPot.renderReady(loggedInUser =>
 
@@ -36,8 +35,7 @@ object Navbar {
             )
           }),
           loggedInUserPot.render(loggedInUser => <.input.hidden(^.id:="user-id", ^.value:=loggedInUser.id)),
-          loggedInUserPot.renderEmpty(<.input.hidden(^.id:="user-id")),
-          airportConfigPot.renderEmpty(<.input.hidden(^.id:="port-code"))
+          loggedInUserPot.renderEmpty(<.input.hidden(^.id:="user-id"))
           )
       })
     )

--- a/client/src/main/scala/drt/client/components/SnapshotSelector.scala
+++ b/client/src/main/scala/drt/client/components/SnapshotSelector.scala
@@ -2,6 +2,7 @@ package drt.client.components
 
 import drt.client.SPAMain.{Loc, TerminalPageTabLoc}
 import drt.client.logger.{Logger, LoggerFactory}
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.JSDateConversions.SDate
 import drt.client.services.LoadingState
 import drt.shared.SDateLike
@@ -97,9 +98,11 @@ object SnapshotSelector {
 
       def selectPointInTime = (_: ReactEventFromInput) => {
         if (isValidSnapshotDate) {
+          GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "Snapshot", state.snapshotDateTime.toLocalDateTimeString())
           log.info(s"state.snapshotDateTime: ${state.snapshotDateTime.toLocalDateTimeString()}")
           props.router.set(props.terminalPageTab.copy(date = Option(state.snapshotDateTime.toLocalDateTimeString())))
         } else {
+          GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "Snapshot", "Invalid Date")
           scope.modState(_.copy(showDatePicker = true))
         }
       }

--- a/client/src/main/scala/drt/client/components/StaffDeploymentsAdjustmentPopover.scala
+++ b/client/src/main/scala/drt/client/components/StaffDeploymentsAdjustmentPopover.scala
@@ -1,6 +1,7 @@
 package drt.client.components
 
 import drt.client.actions.Actions.{AddStaffMovement, SaveStaffMovements}
+import drt.client.modules.GoogleEventTracker
 import drt.client.services._
 import drt.shared.FlightsApi.TerminalName
 import drt.shared.{LoggedInUser, SDateLike, StaffAssignment}
@@ -70,6 +71,7 @@ object StaffDeploymentsAdjustmentPopover {
           for (movement <- StaffMovements.assignmentsToMovements(Seq(shift))) yield {
             SPACircuit.dispatch(AddStaffMovement(movement))
           }
+          GoogleEventTracker.sendEvent(state.terminalName, "Save Staff Assignment", shift.toString)
           SPACircuit.dispatch(SaveStaffMovements(shift.terminalName))
           scope.modState(_.copy(active = false))
         case Failure(_) =>

--- a/client/src/main/scala/drt/client/components/StatusPage.scala
+++ b/client/src/main/scala/drt/client/components/StatusPage.scala
@@ -1,11 +1,12 @@
 package drt.client.components
 
 import drt.client.logger.{Logger, LoggerFactory}
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.JSDateConversions.SDate
 import drt.client.services.SPACircuit
 import drt.shared.CrunchApi.MillisSinceEpoch
 import drt.shared.{FeedStatusFailure, FeedStatusSuccess, FeedStatuses}
-import japgolly.scalajs.react.ScalaComponent
+import japgolly.scalajs.react.{Callback, ScalaComponent}
 import japgolly.scalajs.react.vdom.html_<^._
 
 object StatusPage {
@@ -56,6 +57,7 @@ object StatusPage {
         )
       }
     })
+    .componentDidMount(p => Callback(GoogleEventTracker.sendPageView("feed-status")))
     .build
 
   private def displayTime(date: MillisSinceEpoch): String = {

--- a/client/src/main/scala/drt/client/components/TerminalComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalComponent.scala
@@ -87,13 +87,11 @@ object TerminalComponent {
 
           val subMode = if (props.terminalPageTab.mode == "staffing") "desksAndQueues" else props.terminalPageTab.subMode
 
-          val gaPage = s"${airportConfig.portCode}-${props.terminalPageTab.terminal}"
-
           <.div(
             <.ul(^.className := "nav nav-tabs",
               <.li(^.className := currentClass,
                 <.a(^.id := "currentTab", VdomAttr("data-toggle") := "tab", "Current"), ^.onClick --> {
-                  GoogleEventTracker.sendPageView(s"$gaPage-current")
+                  GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "click", "Current")
                   props.router.set(props.terminalPageTab.copy(
                     mode = "current",
                     subMode = subMode,
@@ -102,7 +100,7 @@ object TerminalComponent {
               }),
               <.li(^.className := snapshotDataClass,
                 <.a(^.id := "snapshotTab", VdomAttr("data-toggle") := "tab", "Snapshot"), ^.onClick --> {
-                  GoogleEventTracker.sendPageView(s"$gaPage-snapshot")
+                  GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "click", "Snapshot")
                   props.router.set(props.terminalPageTab.copy(
                     mode = "snapshot",
                     subMode = subMode,
@@ -112,7 +110,7 @@ object TerminalComponent {
               ),
               <.li(^.className := planningClass,
                 <.a(^.id := "planningTab", VdomAttr("data-toggle") := "tab", "Planning"), ^.onClick --> {
-                  GoogleEventTracker.sendPageView(s"$gaPage-planning")
+                  GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "click", "Planning")
                   props.router.set(props.terminalPageTab.copy(mode = "planning", subMode = subMode, date = None))
                 }
               ),
@@ -120,7 +118,7 @@ object TerminalComponent {
                 loggedInUser => if (loggedInUser.roles.contains(StaffEdit))
                   <.li(^.className := staffingClass,
                     <.a(^.id := "monthlyStaffingTab", VdomAttr("data-toggle") := "tab", "Monthly Staffing"), ^.onClick --> {
-                      GoogleEventTracker.sendPageView(s"$gaPage-monthly-staffing")
+                      GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "click", "Monthly Staffing")
                       props.router.set(props.terminalPageTab.copy(mode = "staffing", subMode = "15", date = None))
                     }
                   ) else ""

--- a/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
@@ -6,6 +6,7 @@ import drt.client.SPAMain.{Loc, TerminalPageTabLoc}
 import drt.client.components.FlightComponents.SplitsGraph.splitsGraphComponentColoured
 import drt.client.components.FlightComponents.paxComp
 import drt.client.logger.log
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.JSDateConversions.SDate
 import drt.client.services.{SPACircuit, ViewMode}
 import drt.shared.CrunchApi.CrunchState
@@ -110,14 +111,17 @@ object TerminalContentComponent {
               <.ul(^.className := "nav nav-tabs",
                 <.li(^.className := desksAndQueuesActive,
                   <.a(^.id := "desksAndQueuesTab", VdomAttr("data-toggle") := "tab", "Desks & Queues"), ^.onClick --> {
+                    GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "Desks & Queues", props.terminalPageTab.dateFromUrlOrNow.toISODateOnly)
                     props.router.set(props.terminalPageTab.copy(subMode = "desksAndQueues"))
                   }),
                 <.li(^.className := arrivalsActive,
                   <.a(^.id := "arrivalsTab", VdomAttr("data-toggle") := "tab", "Arrivals"), ^.onClick --> {
+                    GoogleEventTracker.sendEvent(props.terminalPageTab.terminal,  "Arrivals", props.terminalPageTab.dateFromUrlOrNow.toISODateOnly)
                     props.router.set(props.terminalPageTab.copy(subMode = "arrivals"))
                   }),
                 <.li(^.className := staffingActive,
                   <.a(^.id := "staffMovementsTab", VdomAttr("data-toggle") := "tab", "Staff Movements"), ^.onClick --> {
+                    GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "Staff Movements", props.terminalPageTab.dateFromUrlOrNow.toISODateOnly)
                     props.router.set(props.terminalPageTab.copy(subMode = "staffing"))
                   })
               ),
@@ -125,13 +129,15 @@ object TerminalContentComponent {
                 <.a("Export Arrivals",
                   ^.className := "btn btn-default",
                   ^.href := s"${dom.window.location.pathname}/export/arrivals/${props.terminalPageTab.viewMode.millis}/${props.terminalPageTab.terminal}?startHour=${timeRangeHours.start}&endHour=${timeRangeHours.end}",
-                  ^.target := "_blank"
+                  ^.target := "_blank",
+                  ^.onClick -->{Callback(GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "Export Arrivals", props.terminalPageTab.dateFromUrlOrNow.toISODateOnly))}
                 ),
                 <.a(
                   "Export Desks",
                   ^.className := "btn btn-default",
                   ^.href := s"${dom.window.location.pathname}/export/desks/${props.terminalPageTab.viewMode.millis}/${props.terminalPageTab.terminal}?startHour=${timeRangeHours.start}&endHour=${timeRangeHours.end}",
-                  ^.target := "_blank"
+                  ^.target := "_blank",
+                  ^.onClick -->{Callback(GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "Export Desks", props.terminalPageTab.dateFromUrlOrNow.toISODateOnly))}
                 ),
                 MultiDayExportComponent(props.terminalPageTab.terminal, props.terminalPageTab.dateFromUrlOrNow)
               )
@@ -194,7 +200,15 @@ object TerminalContentComponent {
   val component = ScalaComponent.builder[Props]("TerminalContentComponent")
     .initialStateFromProps(p => State(p.terminalPageTab.subMode))
     .renderBackend[TerminalContentComponent.Backend]
-    .componentDidMount(_ => Callback.log(s"terminal component didMount"))
+    .componentDidMount(p =>
+      Callback{
+        val page = s"${p.props.terminalPageTab.terminal}/${p.props.terminalPageTab.mode}/${p.props.terminalPageTab.subMode}"
+        val pageWithTime = s"$page/${timeRange(p.props).start}/${timeRange(p.props).end}"
+        val pageWithDate = p.props.terminalPageTab.date.map(s=> s"$page/${p.props.terminalPageTab.parseDateString(s)}/${timeRange(p.props).start}/${timeRange(p.props).end}").getOrElse(pageWithTime)
+        GoogleEventTracker.sendPageView(pageWithDate)
+        log.info("terminal component didMount")
+      }
+    )
     .build
 
   def apply(props: Props): VdomElement = component(props)

--- a/client/src/main/scala/drt/client/components/TerminalDesksAndQueues.scala
+++ b/client/src/main/scala/drt/client/components/TerminalDesksAndQueues.scala
@@ -3,6 +3,7 @@ package drt.client.components
 import drt.client.actions.Actions.UpdateShowActualDesksAndQueues
 import drt.client.components.TerminalDesksAndQueues.{NodeListSeq, ViewDeps, ViewRecs, ViewType, documentScrollHeight, documentScrollTop, queueActualsColour, queueColour}
 import drt.client.logger.{Logger, LoggerFactory}
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.JSDateConversions._
 import drt.client.services.{SPACircuit, ViewMode}
 import drt.shared.CrunchApi.{CrunchMinute, CrunchState, MillisSinceEpoch, StaffMinute}
@@ -223,6 +224,7 @@ object TerminalDesksAndQueues {
       }
 
       def toggleViewType(newViewType: ViewType) = (e: ReactEventFromInput) => {
+        GoogleEventTracker.sendEvent(s"${props.terminalName}", "Desks & Queues", newViewType.toString)
         scope.modState(_.copy(viewType = newViewType))
       }
 

--- a/client/src/main/scala/drt/client/components/TerminalPlanningComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalPlanningComponent.scala
@@ -1,13 +1,14 @@
 package drt.client.components
 
 import drt.client.SPAMain.{Loc, TerminalPageTabLoc}
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.JSDateConversions.SDate
 import drt.shared.CrunchApi.{ForecastPeriodWithHeadlines, ForecastTimeSlot}
 import drt.shared.{MilliDate, Queues, SDateLike}
 import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.extra.router.RouterCtl
 import japgolly.scalajs.react.vdom.html_<^.{<, _}
-import japgolly.scalajs.react.{ReactEventFromInput, ScalaComponent}
+import japgolly.scalajs.react.{Callback, ReactEventFromInput, ScalaComponent}
 import org.scalajs.dom
 
 import scala.collection.immutable.Seq
@@ -121,6 +122,9 @@ object TerminalPlanningComponent {
       )
     })
     .configure(Reusability.shouldComponentUpdate)
+    .componentDidMount(p => Callback{
+      GoogleEventTracker.sendPageView(s"${p.props.page.terminal}/planning/${defaultStartDate(p.props.page.dateFromUrlOrNow).toISODateOnly}")
+    })
     .build
 
   def defaultStartDate(date: SDateLike) = getLastSunday(date)

--- a/client/src/main/scala/drt/client/components/TerminalStaffing.scala
+++ b/client/src/main/scala/drt/client/components/TerminalStaffing.scala
@@ -4,6 +4,7 @@ import diode.data.Pot
 import drt.client.actions.Actions._
 import drt.client.components.FixedPoints._
 import drt.client.logger.{Logger, LoggerFactory}
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.JSDateConversions._
 import drt.client.services._
 import drt.shared.CrunchApi.MillisSinceEpoch
@@ -13,7 +14,6 @@ import japgolly.scalajs.react._
 import japgolly.scalajs.react.component.Scala.Unmounted
 import japgolly.scalajs.react.vdom.html_<^._
 import org.scalajs.dom.html.{Div, Table}
-
 import scala.collection.immutable.NumericRange
 import scala.scalajs.js.Date
 import scala.util.{Success, Try}
@@ -126,11 +126,19 @@ object TerminalStaffing {
               case (_, movementPair) =>
                 movementPair.toList.sortBy(_.time) match {
                   case first :: second :: Nil =>
-                    val remove = <.a(Icon.remove, ^.key := first.uUID.toString, ^.onClick ==> ((_: ReactEventFromInput) => Callback(SPACircuit.dispatch(RemoveStaffMovement(0, first.uUID)))))
+                    val remove = <.a(Icon.remove, ^.key := first.uUID.toString, ^.onClick ==> ((_: ReactEventFromInput) =>
+                      Callback{
+                        GoogleEventTracker.sendEvent(terminalName, "Remove Staff Movement", first.toString)
+                        SPACircuit.dispatch(RemoveStaffMovement(0, first.uUID))
+                      }))
                     val span = <.span(^.`class` := "movement-display", MovementDisplay.displayPair(first, second))
                     <.li(remove, " ", span)
                   case mm :: Nil =>
-                    val remove = <.a(Icon.remove, ^.key := mm.uUID.toString, ^.onClick ==> ((_: ReactEventFromInput) => Callback(SPACircuit.dispatch(RemoveStaffMovement(0, mm.uUID)))))
+                    val remove = <.a(Icon.remove, ^.key := mm.uUID.toString, ^.onClick ==> ((_: ReactEventFromInput) =>
+                      Callback{
+                        GoogleEventTracker.sendEvent(terminalName, "Remove Staff Movement", mm.toString)
+                        SPACircuit.dispatch(RemoveStaffMovement(0, mm.uUID))
+                      }))
                     val span = <.span(^.`class` := "movement-display", MovementDisplay.displaySingle(mm))
                     <.li(remove, " ", span)
                   case x =>
@@ -179,6 +187,7 @@ object TerminalStaffing {
                   <.button("Save", ^.onClick ==> ((e: ReactEventFromInput) => {
                     val withTerminalName = addTerminalNameAndDate(state.rawFixedPoints, props.terminalName)
                     val newAssignments = StaffAssignments(StaffAssignmentParser(withTerminalName).parsedAssignments.toList.collect { case Success(sa) => sa })
+                    GoogleEventTracker.sendEvent(withTerminalName, "Save Fixed Points", newAssignments.toString)
                     Callback(SPACircuit.dispatch(SaveFixedPoints(newAssignments, props.terminalName)))
                   }))
                 )

--- a/client/src/main/scala/drt/client/components/TerminalsDashboardPage.scala
+++ b/client/src/main/scala/drt/client/components/TerminalsDashboardPage.scala
@@ -6,8 +6,9 @@ import drt.client.services.JSDateConversions.SDate
 import drt.client.services.SPACircuit
 import drt.shared.{ApiFlightWithSplits, SDateLike}
 import japgolly.scalajs.react.extra.router.RouterCtl
+import drt.client.logger.log
 import japgolly.scalajs.react.vdom.html_<^._
-import japgolly.scalajs.react.{ReactEventFromInput, ScalaComponent}
+import japgolly.scalajs.react.{Callback, ReactEventFromInput, ScalaComponent}
 
 object TerminalsDashboardPage {
 
@@ -46,7 +47,10 @@ object TerminalsDashboardPage {
               def flightWithinPeriod(flight: ApiFlightWithSplits) = DashboardTerminalSummary.flightPcpInPeriod(flight, displayPeriod.start, displayPeriod.end)
 
 
-              def switchDashboardPeriod(period: Int) = (_: ReactEventFromInput) => p.router.set(p.dashboardPage.copy(period = Option(period)))
+              def switchDashboardPeriod(period: Int) = (_: ReactEventFromInput) => {
+                GoogleEventTracker.sendEvent("dashboard", "Switch Period", period.toString)
+                p.router.set(p.dashboardPage.copy(period = Option(period)))
+              }
 
               <.div(
                 <.div(^.className := "form-group row",
@@ -91,6 +95,14 @@ object TerminalsDashboardPage {
           }
           ))
       }
+    })
+    .componentWillReceiveProps(p=> Callback{
+      GoogleEventTracker.sendPageView(s"dashboard${p.nextProps.dashboardPage.period.map(period=>s"/$period").getOrElse("")}")
+      log.info("Terminal dashboard got new props")
+    })
+    .componentDidMount(p=> Callback {
+      GoogleEventTracker.sendPageView(s"dashboard${p.props.dashboardPage.period.map(period=>s"/$period").getOrElse("")}")
+      log.info("Terminal dashboard page did mount")
     })
     .build
 

--- a/client/src/main/scala/drt/client/components/TimeRangeFilter.scala
+++ b/client/src/main/scala/drt/client/components/TimeRangeFilter.scala
@@ -2,6 +2,7 @@ package drt.client.components
 
 import drt.client.SPAMain.{Loc, TerminalPageTabLoc}
 import drt.client.logger.{Logger, LoggerFactory}
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.JSDateConversions.SDate
 import japgolly.scalajs.react.extra.Reusability
 import japgolly.scalajs.react.extra.router.RouterCtl
@@ -80,9 +81,11 @@ object TimeRangeFilter {
           <.div(^.className := "btn-group no-gutters", VdomAttr("data-toggle") := "buttons",
             if (props.showNow)
               <.div(^.id := "now", ^.className := s"btn btn-primary $nowActive", "Now", ^.onClick ==> ((_: ReactEventFromInput) => {
+                GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "Time Range", "now")
                 props.router.set(props.terminalPageTab.copy(timeRangeStartString = None, timeRangeEndString = None))
               })) else "",
             <.div(^.id := "hours24", ^.className := s"btn btn-primary $dayActive", "24 hours", ^.onClick ==> ((_: ReactEventFromInput) => {
+              GoogleEventTracker.sendEvent(props.terminalPageTab.terminal, "Time Range", "24 hours")
               props.router.set(props.terminalPageTab.copy(
                 timeRangeStartString = Option(wholeDayWindow.start.toString), timeRangeEndString = Option(wholeDayWindow.end.toString)
               ))

--- a/client/src/main/scala/drt/client/components/VersionUpdateNotice.scala
+++ b/client/src/main/scala/drt/client/components/VersionUpdateNotice.scala
@@ -1,6 +1,7 @@
 package drt.client.components
 
 import diode.data.Ready
+import drt.client.modules.GoogleEventTracker
 import drt.client.services.{ClientServerVersions, SPACircuit}
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.{Callback, ScalaComponent}
@@ -18,7 +19,9 @@ object VersionUpdateNotice {
           case Ready(ClientServerVersions(client, server)) if client != server =>
             <.div(^.className := "notice-box alert alert-info", s"Newer version available ($client -> $server). ",
               <.br(),
-              <.a("Click here to update", ^.onClick --> Callback(dom.document.location.reload(true))))
+              <.a("Click here to update", ^.onClick --> Callback{
+                GoogleEventTracker.sendEvent("VersionUpdateNotice", "click", "Version Update Notice")
+                dom.document.location.reload(true)}))
           case _ => <.div()
         }
       })

--- a/client/src/main/scala/drt/client/modules/GoogleAnalytics.scala
+++ b/client/src/main/scala/drt/client/modules/GoogleAnalytics.scala
@@ -1,26 +1,82 @@
 package drt.client.modules
 
-
+import org.scalajs.dom
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSGlobalScope
 
 object GoogleEventTracker {
-  def isScriptLoaded: Boolean =js.Dynamic.global.analytics.isInstanceOf[js.Function]
-  def sendPageView(page:String):Unit={
-    if (isScriptLoaded) GoogleAnalytics.analytics("send","event","pageView", page)
+  val trackingCode: GoogleTrackingCode = GoogleTrackingCode.getTrackingCode(dom.document.location.href)
+  def port: String = dom.document.getElementById("port-code").getAttribute("value")
+  def userId: String = dom.document.getElementById("user-id").getAttribute("value")
+  def isScriptLoaded: Boolean = js.Dynamic.global.analytics.isInstanceOf[js.Function]
+  private var hasCreateTrackerRun = false
+
+  private def runCreateTracker(): Unit = {
+    if (!hasCreateTrackerRun && !userId.isEmpty && !port.isEmpty) {
+      GoogleAnalytics.analytics("create", trackingCode.code, "auto", js.Dictionary("userId"->userId))
+      hasCreateTrackerRun = true
+    }
   }
-  def sendEvent(category:String,action:String,label:String):Unit={
-    if (isScriptLoaded) GoogleAnalytics.analytics("send","event",category,action,label)
+
+  def sendPageView(page: String): Unit = {
+    if (isScriptLoaded) {
+      runCreateTracker()
+      if (hasCreateTrackerRun) {
+        GoogleAnalytics.analytics("set", "page", s"/$port/$page")
+        GoogleAnalytics.analytics("send", "pageView")
+      }
+    }
   }
-  def sendEvent(category:String,action:String,label:String,value:String):Unit={
-    if (isScriptLoaded) GoogleAnalytics.analytics("send","event",category,action,label,value)
+
+  def sendEvent(category: String, action: String, label: String): Unit = {
+    if (isScriptLoaded && hasCreateTrackerRun) GoogleAnalytics.analytics("send", "event", s"$port-$category", action, label)
+  }
+
+  def sendEvent(category: String, action: String, label: String, value: String): Unit = {
+    if (isScriptLoaded && hasCreateTrackerRun) GoogleAnalytics.analytics("send", "event", s"$port-$category", action, label, value)
+  }
+
+  def sendError(description: String, fatal: Boolean): Unit = {
+    if (isScriptLoaded && hasCreateTrackerRun) GoogleAnalytics.analytics("send", "exception", js.Dictionary("exDescription" -> description, "exFatal" -> fatal))
+  }
+}
+
+trait GoogleTrackingCode {
+  val code: String
+}
+
+case object ProductionTrackingCode extends GoogleTrackingCode {
+  val code = "UA-125317287-1"
+}
+case object TestTrackingCode extends GoogleTrackingCode {
+  val code = "UA-125317287-2"
+}
+
+object GoogleTrackingCode {
+  def getTrackingCode(location: String): GoogleTrackingCode = {
+    if (location.contains("demand.bf.drt") || location.contains("prod") && !location.contains("notprod")) {
+      ProductionTrackingCode
+    }
+    else {
+      TestTrackingCode
+    }
   }
 }
 
 @js.native
 @JSGlobalScope
 object GoogleAnalytics extends js.Any {
-  def analytics(send:String,event:String,category:String,action:String): Unit = js.native
-  def analytics(send:String,event:String,category:String,action:String,label:String ): Unit = js.native
-  def analytics(send:String,event:String,category:String,action:String,label:String,value:js.Any ): Unit = js.native
+  def analytics(send: String, event: String): Unit = js.native
+
+  def analytics(send: String, event: String, category: String): Unit = js.native
+
+  def analytics(send: String, event: String, fieldObjs: js.Any): Unit = js.native
+
+  def analytics(send: String, event: String, category: String, action: String): Unit = js.native
+
+  def analytics(send: String, event: String, category: String, fieldObjs: js.Any): Unit = js.native
+
+  def analytics(send: String, event: String, category: String, action: String, label: String): Unit = js.native
+
+  def analytics(send: String, event: String, category: String, action: String, label: String, value: js.Any): Unit = js.native
 }

--- a/client/src/main/scala/drt/client/modules/GoogleAnalytics.scala
+++ b/client/src/main/scala/drt/client/modules/GoogleAnalytics.scala
@@ -5,15 +5,15 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation.JSGlobalScope
 
 object GoogleEventTracker {
-  val trackingCode: GoogleTrackingCode = GoogleTrackingCode.getTrackingCode(dom.document.location.href)
+  def trackingCode: String = dom.document.getElementById("ga-code").getAttribute("value")
   def port: String = dom.document.getElementById("port-code").getAttribute("value")
   def userId: String = dom.document.getElementById("user-id").getAttribute("value")
   def isScriptLoaded: Boolean = js.Dynamic.global.analytics.isInstanceOf[js.Function]
   private var hasCreateTrackerRun = false
 
   private def runCreateTracker(): Unit = {
-    if (!hasCreateTrackerRun && !userId.isEmpty && !port.isEmpty) {
-      GoogleAnalytics.analytics("create", trackingCode.code, "auto", js.Dictionary("userId"->userId))
+    if (!hasCreateTrackerRun && !userId.isEmpty && !port.isEmpty && !trackingCode.isEmpty) {
+      GoogleAnalytics.analytics("create", trackingCode, "auto", js.Dictionary("userId"->userId))
       hasCreateTrackerRun = true
     }
   }
@@ -38,28 +38,6 @@ object GoogleEventTracker {
 
   def sendError(description: String, fatal: Boolean): Unit = {
     if (isScriptLoaded && hasCreateTrackerRun) GoogleAnalytics.analytics("send", "exception", js.Dictionary("exDescription" -> description, "exFatal" -> fatal))
-  }
-}
-
-trait GoogleTrackingCode {
-  val code: String
-}
-
-case object ProductionTrackingCode extends GoogleTrackingCode {
-  val code = "UA-125317287-1"
-}
-case object TestTrackingCode extends GoogleTrackingCode {
-  val code = "UA-125317287-2"
-}
-
-object GoogleTrackingCode {
-  def getTrackingCode(location: String): GoogleTrackingCode = {
-    if (location.contains("demand.bf.drt") || location.contains("prod") && !location.contains("notprod")) {
-      ProductionTrackingCode
-    }
-    else {
-      TestTrackingCode
-    }
   }
 }
 

--- a/client/src/main/scala/drt/client/services/ErrorHandler.scala
+++ b/client/src/main/scala/drt/client/services/ErrorHandler.scala
@@ -1,6 +1,7 @@
 package drt.client.services
 
 import drt.client.logger.LoggerFactory
+import drt.client.modules.GoogleEventTracker
 import org.scalajs.dom
 import org.scalajs.dom.Event
 
@@ -11,6 +12,8 @@ object ErrorHandler {
       val serverLogger = LoggerFactory.getXHRLogger("error")
 
       val message = s"Event: $ev, Url: $url, Line: $line, Col: $col, Error: $error, Browser: ${dom.window.navigator.appVersion}"
+      GoogleEventTracker.sendError(message, fatal = true)
+
       error match {
         case e: Exception =>
           serverLogger.error(message, e)

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -9,6 +9,9 @@ play.http.parser.maxMemoryBuffer = 100m
 portcode = "xxx"
 portcode = ${?PORT_CODE}
 
+googleTrackingCode = ""
+googleTrackingCode =  ${?GOOGLE_TRACKING_CODE}
+
 env = ${?ENV}
 
 contact-email = ${?CONTACT_EMAIL}

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -168,6 +168,8 @@ class Application @Inject()(implicit val config: Configuration,
     with ProdPassengerSplitProviders
     with ImplicitTimeoutProvider {
 
+  val googleTrackingCode: String = config.get[String]("googleTrackingCode")
+
   val ctrl: DrtSystemInterface = config.getOptional[String]("env") match {
     case Some("test") =>
       new TestDrtSystem(system, config, getPortConfFromEnvVar)
@@ -380,7 +382,7 @@ class Application @Inject()(implicit val config: Configuration,
   }
 
   def index = Action {
-    Ok(views.html.index("DRT - BorderForce"))
+    Ok(views.html.index("DRT - BorderForce", portCode, googleTrackingCode))
   }
 
 

--- a/server/src/main/twirl/views/index.scala.html
+++ b/server/src/main/twirl/views/index.scala.html
@@ -1,4 +1,4 @@
-@(title: String)(implicit config: play.api.Configuration, env: play.api.Environment)
+@(title: String, port: String, googleTrackingCode: String)(implicit config: play.api.Configuration, env: play.api.Environment)
 @import views.html.tags._
 
 <!DOCTYPE html>
@@ -11,18 +11,22 @@
         <link rel="stylesheet" media="screen" href=@_asset("stylesheets/main.min.css") >
         <link href="//cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
         <link rel="shortcut icon" type="image/png" href=@_asset("images/favicon.png") >
-        <script>
-                (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-                    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                })(window,document,'script','https://www.google-analytics.com/analytics.js','analytics');
+        @if(!googleTrackingCode.isEmpty){
+            <script>
+                    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+                        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+                    })(window,document,'script','https://www.google-analytics.com/analytics.js','analytics');
 
-        </script>
+            </script>
+        }
     </head>
 
     <body>
         <div id="root">
         </div>
+        <input type="hidden" id="port-code" value="@{port}"/>
+        <input type="hidden" id="ga-code" value="@{googleTrackingCode}"/>
     </body>
     @*<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">*@
 

--- a/server/src/main/twirl/views/index.scala.html
+++ b/server/src/main/twirl/views/index.scala.html
@@ -15,9 +15,8 @@
                 (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
                     (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
                         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-                })(window,document,'script','//www.google-analytics.com/analytics.js','analytics');
+                })(window,document,'script','https://www.google-analytics.com/analytics.js','analytics');
 
-                analytics('create', 'UA-83931001-1', 'auto');
         </script>
     </head>
 


### PR DESCRIPTION
## Add Google Analytics Data

- Given access to google analytics to drtdevteam@digital.homeoffice.gov.uk
  - Any new members will need to have a google account for their existing email (https://support.google.com/accounts/answer/176347)
- Got two trackers for DRT-Prod and DRT-NotProd
- Creates a tracker with an associated `userId`, so a view (User Enabled View) _can_ _report_ on User Activity
- Added events and pageViews on the app
- Prefixes pageViews and events with the current port to enable Reporting per port.