### PR TITLE
DRT-5283 - Move alert message to be inline with the logo

### DIFF
--- a/client/src/main/scala/drt/client/components/AlertsComponent.scala
+++ b/client/src/main/scala/drt/client/components/AlertsComponent.scala
@@ -6,6 +6,8 @@ import drt.shared.Alert
 import japgolly.scalajs.react.vdom.html_<^._
 import japgolly.scalajs.react.ScalaComponent
 
+import scala.scalajs.js
+
 object AlertsComponent {
 
   val log: Logger = LoggerFactory.getLogger(getClass.getName)
@@ -24,7 +26,7 @@ object AlertsComponent {
           alertsPot.render((alerts: Seq[Alert]) => {
           <.span(^.id:= "has-alerts",
             alerts.map(alert => {
-              <.span(^.key := alert.createdAt, ^.`class`:="alert alert-danger col-md-12", ^.role:="alert",
+              <.span(^.key := alert.createdAt, ^.`class`:="alert alert-danger the-alert", ^.role:="alert",
               <.strong(alert.title),s" ${alert.message}"
               )
             }).toVdomArray

--- a/client/src/main/scala/drt/client/components/AlertsComponent.scala
+++ b/client/src/main/scala/drt/client/components/AlertsComponent.scala
@@ -27,7 +27,7 @@ object AlertsComponent {
           <.span(^.id:= "has-alerts",
             alerts.map(alert => {
               <.span(^.key := alert.createdAt, ^.`class`:="alert alert-danger the-alert", ^.role:="alert",
-              <.strong(alert.title),s" ${alert.message}"
+              <.strong(alert.title),s" - ${alert.message}"
               )
             }).toVdomArray
             )

--- a/client/src/main/scala/drt/client/components/Layout.scala
+++ b/client/src/main/scala/drt/client/components/Layout.scala
@@ -14,8 +14,10 @@ object Layout {
   val component = ScalaComponent.builder[Props]("Layout")
     .renderP((_, props: Props) => {
       <.div(
-        <.div(^.className := "main-logo"),
-        AlertsComponent(),
+        <.div( ^.className:= "topbar",
+          <.div(^.className := "main-logo"),
+          <.div(^.className := "alerts", AlertsComponent())
+        ),
         <.div(
           // here we use plain Bootstrap class names as these are specific to the top level layout defined here
           Navbar(props.ctl, props.currentLoc.page),

--- a/client/src/main/scala/drt/client/components/MainMenu.scala
+++ b/client/src/main/scala/drt/client/components/MainMenu.scala
@@ -38,7 +38,7 @@ object MainMenu {
 
   val restrictedMenuItems = List(
     (ManageUsers, usersMenuItem _),
-    (ManageUsers, alertsMenuItem _)
+    (CreateAlerts, alertsMenuItem _)
   )
 
   def menuItems(airportConfig: AirportConfig, currentLoc: Loc, userRoles: Seq[Role], feeds: Seq[FeedStatuses]): List[MenuItem] = {

--- a/client/src/main/scala/drt/client/components/TerminalsDashboardPage.scala
+++ b/client/src/main/scala/drt/client/components/TerminalsDashboardPage.scala
@@ -53,7 +53,7 @@ object TerminalsDashboardPage {
               }
 
               <.div(
-                <.div(^.className := "form-group row",
+                <.div(
                   <.div(^.className := "btn-group no-gutters", VdomAttr("data-toggle") := "buttons",
                     periods.zipWithIndex.map {
                       case (p, index) => <.div(

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -112,9 +112,10 @@
 
 .main-logo {
   height: 70px;
-  width: 96%;
+  width: 210px;
   padding: 15px;
   margin: auto;
+  float:left;
   background-image: url(/v2/stn/live/assets/images/logo_colour.png);
   background-repeat: no-repeat;
   background-position: 16px 15px;
@@ -1648,10 +1649,19 @@ a i.fa.fa-remove {
   padding: 10px;
 }
 
+.topbar {
+  width: 100%;
+  overflow: hidden;
+}
+
+.alerts {
+  float: left;
+  width: calc(~"100% - 210px");
+}
+
 #has-alerts {
     font-size: 12px;
     font-family: tahoma;
-    border: 3px double #ccc;
     color: #555;
     display: block;
     padding: 10px 5px 0 5px;
@@ -1660,6 +1670,7 @@ a i.fa.fa-remove {
     overflow: auto;
 }
 
-#has-alerts:hover {
-  box-shadow: 2px -5px 5px 0px rgba(0,0,0,.2);
+.the-alert {
+  display: block;
+  margin-bottom: 1px;
 }

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -34,6 +34,9 @@
 .navbar-default {
   background-color: @bgDefault;
   border-color: @bgHighlight;
+  border-radius: 0px;
+  border-left: 0px;
+  border-right: 0px;
   .navbar-brand {
     color: @colDefault;
     &:hover, &:focus {
@@ -91,6 +94,18 @@
   }
 }
 
+.navbar-nav li.red .fa-bar-chart {
+    color: #f55;
+}
+
+.navbar-nav li.amber .fa-bar-chart  {
+    color: #F7901E;
+}
+
+.navbar-nav li.green .fa-bar-chart  {
+    color: #008000;
+}
+
 @media (max-width: 767px) {
   .navbar-default .navbar-nav .open .dropdown-menu {
     > li > a {
@@ -113,12 +128,10 @@
 .main-logo {
   height: 70px;
   width: 220px;
-  padding: 15px;
-  margin: auto;
   float:left;
   background-image: url(/v2/stn/live/assets/images/logo_colour.png);
   background-repeat: no-repeat;
-  background-position: center;
+  background-position: 0px 15px;
 }
 
 .popover.flights-popover .popover__content > tr td {
@@ -1633,27 +1646,16 @@ a i.fa.fa-remove {
   vertical-align: middle;
 }
 
-.navbar-nav li.red .fa-bar-chart {
-    color: #f55;
-}
-
-.navbar-nav li.amber .fa-bar-chart  {
-    color: #F7901E;
-}
-
-.navbar-nav li.green .fa-bar-chart  {
-    color: #008000;
-}
-
 .key-cloak-users td {
   padding: 10px;
 }
 
 .topbar {
-  width: 100%;
+  height: 70px;
+  width: 96%;
   overflow: hidden;
-  margin-left: auto;
-  padding-left: 25px;
+  margin: auto;
+  padding-left: 15px;
   box-sizing: border-box;
   display: block;
 }

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -112,7 +112,7 @@
 
 .main-logo {
   height: 70px;
-  width: 210px;
+  width: 220px;
   padding: 15px;
   margin: auto;
   float:left;
@@ -1651,12 +1651,13 @@ a i.fa.fa-remove {
 
 .topbar {
   width: 100%;
+  padding-left: 20px;
   overflow: hidden;
 }
 
 .alerts {
   float: left;
-  width: calc(~"100% - 210px");
+  width: calc(~"100% - 220px");
 }
 
 #has-alerts {

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -118,7 +118,7 @@
   float:left;
   background-image: url(/v2/stn/live/assets/images/logo_colour.png);
   background-repeat: no-repeat;
-  background-position: 16px 15px;
+  background-position: center;
 }
 
 .popover.flights-popover .popover__content > tr td {
@@ -1651,8 +1651,11 @@ a i.fa.fa-remove {
 
 .topbar {
   width: 100%;
-  padding-left: 20px;
   overflow: hidden;
+  margin-left: auto;
+  padding-left: 25px;
+  box-sizing: border-box;
+  display: block;
 }
 
 .alerts {

--- a/server/src/test/scala/services/crunch/CrunchTestLike.scala
+++ b/server/src/test/scala/services/crunch/CrunchTestLike.scala
@@ -334,7 +334,7 @@ class CrunchTestLike
   }
 
   def offerAndWait[T](sourceQueue: SourceQueueWithComplete[T], offering: T): QueueOfferResult = {
-    Await.result(sourceQueue.offer(offering), 5 seconds) match {
+    Await.result(sourceQueue.offer(offering), 3 seconds) match {
       case offerResult if offerResult != Enqueued =>
         throw new Exception(s"Queue offering (${offering.getClass}) was not enqueued: ${offerResult.getClass}")
       case offerResult =>

--- a/shared/src/main/scala/drt/shared/LoggedInUser.scala
+++ b/shared/src/main/scala/drt/shared/LoggedInUser.scala
@@ -7,7 +7,7 @@ sealed trait Role{
 }
 
 object Roles {
-  val availableRoles = List(StaffEdit, ApiView, ManageUsers)
+  val availableRoles = List(StaffEdit, ApiView, ManageUsers, CreateAlerts)
   def parse(roleName: String): Option[Role] = availableRoles.find(role=> role.name == roleName)
 }
 
@@ -21,4 +21,8 @@ case object ApiView extends Role {
 
 case object ManageUsers extends Role {
   override val name: String = "manage-users"
+}
+
+case object CreateAlerts extends Role {
+  override val name: String = "create-alerts"
 }


### PR DESCRIPTION
Moved the Alert message to be inline with the logo.
Added a `create-alerts` role, for users who can create alerts.

Edit:
I've had to escape the calc css in less as it does not calculate the value correctly otherwise.
It's 100% minus the logo width in px. Consequently I could not find a way of putting this width as a variable as it's escaped in quotes.

<img width="1283" alt="screen shot 2018-09-13 at 13 55 42" src="https://user-images.githubusercontent.com/369407/45489674-c41e6280-b75c-11e8-873a-a1fb05ead492.png">
