### PR TITLE
DRT-5229 Populate aws credentials from environment vars

### DIFF
--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -160,6 +160,13 @@ acl {
   keypath = ${?ACL_KEYPATH}
 }
 
+aws {
+  credentials {
+    access_key_id = ${?AWS_ACCESS_KEY_ID}
+    secret_key = ${?AWS_SECRET_KEY}
+  }
+}
+
 dq {
   s3 {
     bucket = ${?DQ_S3_BUCKET}

--- a/server/src/main/scala/actors/DrtSystem.scala
+++ b/server/src/main/scala/actors/DrtSystem.scala
@@ -81,7 +81,6 @@ case class DrtSystem(actorSystem: ActorSystem, config: Configuration, airportCon
 
     override def getAWSSecretKey: TerminalName = config.getOptional[String]("aws.credentials.secret_key").getOrElse("")
   }
-  log.info(s"awsCreds: ${awSCredentials.getAWSAccessKeyId}, ${awSCredentials.getAWSSecretKey}")
   val expireAfterMillis: MillisSinceEpoch = 2 * oneDayMillis
 
   val ftpServer: String = ConfigFactory.load.getString("acl.host")

--- a/server/src/main/scala/actors/DrtSystem.scala
+++ b/server/src/main/scala/actors/DrtSystem.scala
@@ -7,6 +7,7 @@ import akka.pattern.AskableActorRef
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import akka.util.Timeout
+import com.amazonaws.auth.AWSCredentials
 import com.typesafe.config.ConfigFactory
 import controllers.{Deskstats, PaxFlow, UserRoleProviderLike}
 import drt.chroma._
@@ -75,6 +76,12 @@ case class DrtSystem(actorSystem: ActorSystem, config: Configuration, airportCon
   val snapshotMegaBytesFcstPortState: Int = (config.getOptional[Double]("persistence.snapshot-megabytes.forecast-portstate").getOrElse(10d) * oneMegaByte).toInt
   val snapshotMegaBytesLivePortState: Int = (config.getOptional[Double]("persistence.snapshot-megabytes.live-portstate").getOrElse(25d) * oneMegaByte).toInt
   val snapshotMegaBytesVoyageManifests: Int = (config.getOptional[Double]("persistence.snapshot-megabytes.voyage-manifest").getOrElse(100d) * oneMegaByte).toInt
+  val awSCredentials: AWSCredentials = new AWSCredentials {
+    override def getAWSAccessKeyId: TerminalName = config.getOptional[String]("aws.credentials.access_key_id").getOrElse("")
+
+    override def getAWSSecretKey: TerminalName = config.getOptional[String]("aws.credentials.secret_key").getOrElse("")
+  }
+  log.info(s"awsCreds: ${awSCredentials.getAWSAccessKeyId}, ${awSCredentials.getAWSSecretKey}")
   val expireAfterMillis: MillisSinceEpoch = 2 * oneDayMillis
 
   val ftpServer: String = ConfigFactory.load.getString("acl.host")
@@ -120,7 +127,7 @@ case class DrtSystem(actorSystem: ActorSystem, config: Configuration, airportCon
 
   val dqZipBucketName: String = config.getOptional[String]("dq.s3.bucket").getOrElse(throw new Exception("You must set DQ_S3_BUCKET for us to poll for AdvPaxInfo"))
   val apiS3PollFrequencyMillis: MillisSinceEpoch = config.getOptional[Int]("dq.s3.poll_frequency_seconds").getOrElse(60) * 1000L
-  val s3ApiProvider = S3ApiProvider(dqZipBucketName)
+  val s3ApiProvider = S3ApiProvider(awSCredentials, dqZipBucketName)
   val initialManifestsState: Option[VoyageManifestState] = manifestsState
   val maybeLatestZipFileName: String = initialManifestsState.map(_.latestZipFilename).getOrElse("")
 


### PR DESCRIPTION
Rather than a profile name which relies on a credentials file existing on the server