### PR TITLE
DRT-5290 - Close sftp connection - correction

### DIFF
--- a/server/src/main/scala/drt/server/feeds/acl/AclFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/acl/AclFeed.scala
@@ -30,12 +30,13 @@ case class AclFeed(ftpServer: String, username: String, path: String, portCode: 
     val feedResponseTry = (for {
       sshClient <- Try(ssh)
       sftpClient <- Try(sftp(sshClient))
+      responseTry = Try{
+        Flights(arrivalsFromCsvContent(contentFromFileName(sftpClient, latestFileForPort(sftpClient, portCode)), terminalMapping))
+      }
     } yield {
       sshClient.disconnect()
       sftpClient.close()
-      Try{
-        Flights(arrivalsFromCsvContent(contentFromFileName(sftpClient, latestFileForPort(sftpClient, portCode)), terminalMapping))
-      }
+      responseTry
     }).flatten
 
     feedResponseTry match {


### PR DESCRIPTION
This is to correct the last PR.

Obviously we don't want to close the sftp connection before we fetch the data.