### PR TITLE
DRT-5260 - Google Analytics anonymizeIp

### DIFF
--- a/client/src/main/scala/drt/client/modules/GoogleAnalytics.scala
+++ b/client/src/main/scala/drt/client/modules/GoogleAnalytics.scala
@@ -18,6 +18,7 @@ object GoogleEventTracker {
     if (!hasCreateTrackerRun && !userId.isEmpty && !port.isEmpty && !trackingCode.isEmpty) {
       val userUUID = if (userId.contains("@")) UUID.randomUUID else userId
       GoogleAnalytics.analytics("create", trackingCode, "auto", js.Dictionary("userId"->userUUID))
+      GoogleAnalytics.analytics("set", "anonymizeIp", true)
       hasCreateTrackerRun = true
     }
   }


### PR DESCRIPTION
# Google Analytics anonymizeIp

When you annoimise the IP it impacts the geolocation tracking data at city level (not at continent/country level).


To test on the network tab in your browser the url to google should have `aip=1` as a parameter

e.g. 
<img width="1401" alt="screen shot 2018-09-20 at 09 27 13" src="https://user-images.githubusercontent.com/369407/45805817-6e473e80-bcb7-11e8-9869-3fa5c9577cfc.png">
