### PR TITLE
Drt 5319 improve handling of adding and removing movements

### DIFF
--- a/client/src/main/scala/drt/client/actions/Actions.scala
+++ b/client/src/main/scala/drt/client/actions/Actions.scala
@@ -69,11 +69,9 @@ object Actions {
 
   case class SaveMonthTimeSlotsToShifts(staffTimeSlots: StaffTimeSlotsForTerminalMonth) extends Action
 
-  case class AddStaffMovement(staffMovement: StaffMovement) extends Action
+  case class AddStaffMovements(staffMovements: Seq[StaffMovement]) extends Action
 
-  case class RemoveStaffMovement(idx: Int, uUID: UUID) extends Action
-
-  case class SaveStaffMovements(terminalName: TerminalName) extends Action
+  case class RemoveStaffMovements(uUID: UUID) extends Action
 
   case class SetStaffMovements(staffMovements: Seq[StaffMovement]) extends Action
 

--- a/client/src/main/scala/drt/client/components/StaffDeploymentsAdjustmentPopover.scala
+++ b/client/src/main/scala/drt/client/components/StaffDeploymentsAdjustmentPopover.scala
@@ -1,14 +1,14 @@
 package drt.client.components
 
-import drt.client.actions.Actions.{AddStaffMovement, SaveStaffMovements}
+import drt.client.actions.Actions.AddStaffMovements
 import drt.client.modules.GoogleEventTracker
 import drt.client.services._
 import drt.shared.FlightsApi.TerminalName
-import drt.shared.{LoggedInUser, SDateLike, StaffAssignment}
+import drt.shared.{LoggedInUser, SDateLike}
 import japgolly.scalajs.react._
 import japgolly.scalajs.react.vdom.html_<^._
 import org.scalajs.dom.html
-import org.scalajs.dom.html.Div
+import org.scalajs.dom.html.{Div, Select}
 
 import scala.util.{Failure, Success}
 
@@ -31,14 +31,24 @@ object StaffDeploymentsAdjustmentPopover {
     (x.toDouble / nearest).round.toInt * nearest
   }
 
-  def selectTerminal(defaultValue: String, callback: (ReactEventFromInput) => Callback, terminalNames: Seq[String]) = {
+  def selectTerminal(defaultValue: String,
+                     callback: ReactEventFromInput => Callback,
+                     terminalNames: Seq[String]): VdomTagOf[Select] = {
     <.select(
       ^.defaultValue := defaultValue,
       ^.onChange ==> callback,
       terminalNames.map(x => <.option(^.value := x, x)).toTagMod)
   }
 
-  def apply(terminalNames: Seq[TerminalName], terminal: Option[TerminalName], trigger: String, reasonPlaceholder: String, startDate: SDateLike, endDate: SDateLike, popoverPosition: String, action: String = "-", loggedInUser: LoggedInUser) = ScalaComponent.builder[Unit]("staffMovementPopover")
+  def apply(terminalNames: Seq[TerminalName],
+            terminal: Option[TerminalName],
+            trigger: String,
+            reasonPlaceholder: String,
+            startDate: SDateLike,
+            endDate: SDateLike,
+            popoverPosition: String,
+            action: String = "-",
+            loggedInUser: LoggedInUser) = ScalaComponent.builder[Unit]("staffMovementPopover")
     .initialState(
       StaffDeploymentAdjustmentPopoverState(
         reason = "",
@@ -50,97 +60,102 @@ object StaffDeploymentsAdjustmentPopover {
         endTimeMinutes = roundToNearest(5)(endDate.getMinutes()),
         loggedInUser = loggedInUser
       )
-    ).renderS((scope, state) => {
-
-
-    def selectFromRange(range: Range, defaultValue: Int, callback: (String) => (StaffDeploymentAdjustmentPopoverState) => StaffDeploymentAdjustmentPopoverState, applyRounding: Int => Int) = {
-      <.select(
-        ^.defaultValue := applyRounding(defaultValue),
-        ^.onChange ==> ((e: ReactEventFromInput) => scope.modState(callback(e.target.value))
-          ),
-        range.map(x => <.option(^.value := x, f"$x%02d")).toTagMod)
-    }
-
-    def trySaveMovement = (e: ReactEventFromInput) => {
-      val startTime: String = f"${state.startTimeHours}%02d:${state.startTimeMinutes}%02d"
-      val endTime: String = f"${state.endTimeHours}%02d:${state.endTimeMinutes}%02d"
-      val numberOfStaff: String = s"$action${state.numberOfStaff.toString}"
-      val shiftTry = StaffAssignmentHelper.tryStaffAssignment(state.reason, state.terminalName, state.date, startTime, endTime, numberOfStaff, createdBy = Some(loggedInUser.email))
-      shiftTry match {
-        case Success(shift) =>
-          for (movement <- StaffMovements.assignmentsToMovements(Seq(shift))) yield {
-            SPACircuit.dispatch(AddStaffMovement(movement))
-          }
-          GoogleEventTracker.sendEvent(state.terminalName, "Save Staff Assignment", shift.copy(createdBy = None).toString)
-          SPACircuit.dispatch(SaveStaffMovements(shift.terminalName))
-          scope.modState(_.copy(active = false))
-        case Failure(_) =>
-          scope.modState(_.copy(active = true))
+    )
+    .renderS(r = (scope, state) => {
+      def selectFromRange(range: Range,
+                          defaultValue: Int,
+                          callback: String => StaffDeploymentAdjustmentPopoverState => StaffDeploymentAdjustmentPopoverState,
+                          applyRounding: Int => Int) = {
+        <.select(
+          ^.defaultValue := applyRounding(defaultValue),
+          ^.onChange ==> ((e: ReactEventFromInput) => scope.modState(callback(e.target.value))
+            ),
+          range.map(x => <.option(^.value := x, f"$x%02d")).toTagMod)
       }
-    }
 
-    def labelledInput(labelText: String, value: String, callback: (String) => (StaffDeploymentAdjustmentPopoverState) => StaffDeploymentAdjustmentPopoverState, placeHolder: String = ""): VdomTagOf[html.Div] = {
-      popoverFormRow(labelText, <.input.text(^.value := value, ^.placeholder := reasonPlaceholder, ^.onChange ==> ((e: ReactEventFromInput) => {
-        val newValue: String = e.target.value
-        scope.modState(callback(newValue))
-      })))
-    }
+      def trySaveMovement = (e: ReactEventFromInput) => {
+        val startTime: String = f"${state.startTimeHours}%02d:${state.startTimeMinutes}%02d"
+        val endTime: String = f"${state.endTimeHours}%02d:${state.endTimeMinutes}%02d"
+        val numberOfStaff: String = s"$action${state.numberOfStaff.toString}"
 
-    def popoverFormRow(label: String, xs: TagMod*) = {
-      <.div(^.className := "form-group row",
-        <.label(label, ^.className := "col-sm-4 col-form-label"),
-        <.div(^.className := "col-sm-4", xs.toTagMod))
-    }
+        StaffAssignmentHelper
+          .tryStaffAssignment(state.reason, state.terminalName, state.date, startTime, endTime, numberOfStaff, createdBy = Some(loggedInUser.email)) match {
+          case Success(movement) =>
+            val movementsToAdd = for (movement <- StaffMovements.assignmentsToMovements(Seq(movement))) yield movement
+            SPACircuit.dispatch(AddStaffMovements(movementsToAdd))
+            GoogleEventTracker.sendEvent(state.terminalName, "Save Staff Assignment", movement.copy(createdBy = None).toString)
+            scope.modState(_.copy(active = false))
+          case Failure(_) =>
+            scope.modState(_.copy(active = true))
+        }
+      }
 
-    def timeSelector(label: String,
-                     hourDefault: Int,
-                     minuteDefault: Int,
-                     hourCallback: (String) => (StaffDeploymentAdjustmentPopoverState) => StaffDeploymentAdjustmentPopoverState,
-                     minuteCallback: (String) => (StaffDeploymentAdjustmentPopoverState) => StaffDeploymentAdjustmentPopoverState
-                    ): VdomTagOf[Div] = {
-      popoverFormRow(label,
-        selectFromRange(
-          0 to 23, hourDefault, hourCallback, (x) => x
-        ), ":",
-        selectFromRange(
-          0 to 59 by 5, minuteDefault, minuteCallback, roundToNearest(5)
+      def labelledInput(labelText: String,
+                        value: String,
+                        callback: String => StaffDeploymentAdjustmentPopoverState => StaffDeploymentAdjustmentPopoverState,
+                        placeHolder: String = ""): VdomTagOf[html.Div] = {
+        popoverFormRow(labelText, <.input.text(^.value := value, ^.placeholder := reasonPlaceholder, ^.onChange ==> ((e: ReactEventFromInput) => {
+          val newValue: String = e.target.value
+          scope.modState(callback(newValue))
+        })))
+      }
+
+      def popoverFormRow(label: String, xs: TagMod*) = {
+        <.div(^.className := "form-group row",
+          <.label(label, ^.className := "col-sm-4 col-form-label"),
+          <.div(^.className := "col-sm-4", xs.toTagMod))
+      }
+
+      def timeSelector(label: String,
+                       hourDefault: Int,
+                       minuteDefault: Int,
+                       hourCallback: String => StaffDeploymentAdjustmentPopoverState => StaffDeploymentAdjustmentPopoverState,
+                       minuteCallback: String => StaffDeploymentAdjustmentPopoverState => StaffDeploymentAdjustmentPopoverState
+                      ): VdomTagOf[Div] = {
+        popoverFormRow(label,
+          selectFromRange(
+            0 to 23, hourDefault, hourCallback, x => x
+          ), ":",
+          selectFromRange(
+            0 to 59 by 5, minuteDefault, minuteCallback, roundToNearest(5)
+          )
         )
-      )
-    }
+      }
 
-    def hoveredComponent: TagMod = if (state.active) {
-      val popoverChildren = <.div(<.div(^.className:="popover-overlay", ^.onClick ==> showPopover(false)),
-        <.div(^.className := "container", ^.onClick ==> ((e: ReactEvent) => Callback(e.stopPropagation())), ^.key := "StaffAdjustments",
-        labelledInput("Reason", state.reason, (v: String) => (s: StaffDeploymentAdjustmentPopoverState) => s.copy(reason = v)),
-        terminal match {
-          case None => popoverFormRow ("Terminal", selectTerminal (state.terminalName, (e: ReactEventFromInput) =>
-        scope.modState (_.copy (terminalName = e.target.value) ), terminalNames) )
-          case _ => ""
-        },
-        timeSelector("Start time", state.startTimeHours, state.startTimeMinutes,
-          (v: String) => (s: StaffDeploymentAdjustmentPopoverState) => s.copy(startTimeHours = v.toInt),
-          (v: String) => (s: StaffDeploymentAdjustmentPopoverState) => s.copy(startTimeMinutes = v.toInt)),
-        timeSelector("End time", state.endTimeHours, state.endTimeMinutes,
-          (v: String) => (s: StaffDeploymentAdjustmentPopoverState) => s.copy(endTimeHours = v.toInt),
-          (v: String) => (s: StaffDeploymentAdjustmentPopoverState) => s.copy(endTimeMinutes = v.toInt)),
-        popoverFormRow("Number of staff", <.input.text(^.value := state.numberOfStaff.toString, ^.onChange ==> ((e: ReactEventFromInput) => {
-          val newValue = e.target.value
-          scope.modState((s: StaffDeploymentAdjustmentPopoverState) => s.copy(numberOfStaff = newValue))
-        }))),
-        <.div(^.className := "form-group-row",
-          <.div(^.className := "col-sm-4"),
-          <.div(^.className := "col-sm-6 btn-toolbar",
-            <.button("Save", ^.className := "btn btn-primary", ^.onClick ==> trySaveMovement),
-            <.button("Cancel", ^.className := "btn btn-default", ^.onClick ==> showPopover(false))))))
+      def hoveredComponent: TagMod = if (state.active) {
+        val popoverChildren = <.div(<.div(^.className := "popover-overlay", ^.onClick ==> showPopover(false)),
+          <.div(^.className := "container", ^.onClick ==> ((e: ReactEvent) => Callback(e.stopPropagation())), ^.key := "StaffAdjustments",
+            labelledInput("Reason", state.reason, (v: String) => (s: StaffDeploymentAdjustmentPopoverState) => s.copy(reason = v)),
+            terminal match {
+              case None => popoverFormRow("Terminal", selectTerminal(state.terminalName, (e: ReactEventFromInput) =>
+                scope.modState(_.copy(terminalName = e.target.value)), terminalNames))
+              case _ => ""
+            },
+            timeSelector("Start time", state.startTimeHours, state.startTimeMinutes,
+              (v: String) => (s: StaffDeploymentAdjustmentPopoverState) => s.copy(startTimeHours = v.toInt),
+              (v: String) => (s: StaffDeploymentAdjustmentPopoverState) => s.copy(startTimeMinutes = v.toInt)),
+            timeSelector("End time", state.endTimeHours, state.endTimeMinutes,
+              (v: String) => (s: StaffDeploymentAdjustmentPopoverState) => s.copy(endTimeHours = v.toInt),
+              (v: String) => (s: StaffDeploymentAdjustmentPopoverState) => s.copy(endTimeMinutes = v.toInt)),
+            popoverFormRow("Number of staff", <.input.text(^.value := state.numberOfStaff.toString, ^.onChange ==> ((e: ReactEventFromInput) => {
+              val newValue = e.target.value
+              scope.modState((s: StaffDeploymentAdjustmentPopoverState) => s.copy(numberOfStaff = newValue))
+            }))),
+            <.div(^.className := "form-group-row",
+              <.div(^.className := "col-sm-4"),
+              <.div(^.className := "col-sm-6 btn-toolbar",
+                <.button("Save", ^.className := "btn btn-primary", ^.onClick ==> trySaveMovement),
+                <.button("Cancel", ^.className := "btn btn-default", ^.onClick ==> showPopover(false))))))
 
-      popoverChildren
-    } else {
-      ""
-    }
-    def showPopover(show: Boolean) = (e: ReactEventFromInput) => scope.modState(_.copy(active = show))
+        popoverChildren
+      } else {
+        ""
+      }
 
-    val popover = <.div(hoveredComponent, ^.className := "staff-deployment-adjustment-container",
-      <.div(^.className := "popover-trigger", ^.onClick ==> showPopover(true), trigger))
-    popover
-  }).build
+      def showPopover(show: Boolean) = (e: ReactEventFromInput) => scope.modState(_.copy(active = show))
+
+      val popover = <.div(hoveredComponent, ^.className := "staff-deployment-adjustment-container",
+        <.div(^.className := "popover-trigger", ^.onClick ==> showPopover(true), trigger))
+      popover
+    }).build
 }

--- a/client/src/main/scala/drt/client/components/StaffDeploymentsAdjustmentPopover.scala
+++ b/client/src/main/scala/drt/client/components/StaffDeploymentsAdjustmentPopover.scala
@@ -83,7 +83,7 @@ object StaffDeploymentsAdjustmentPopover {
           case Success(movement) =>
             val movementsToAdd = for (movement <- StaffMovements.assignmentsToMovements(Seq(movement))) yield movement
             SPACircuit.dispatch(AddStaffMovements(movementsToAdd))
-            GoogleEventTracker.sendEvent(state.terminalName, "Save Staff Assignment", movement.copy(createdBy = None).toString)
+            GoogleEventTracker.sendEvent(state.terminalName, "Add StaffMovement", movement.copy(createdBy = None).toString)
             scope.modState(_.copy(active = false))
           case Failure(_) =>
             scope.modState(_.copy(active = true))

--- a/server/src/main/protobuf/StaffMovementMessages.proto
+++ b/server/src/main/protobuf/StaffMovementMessages.proto
@@ -24,4 +24,5 @@ message StaffMovementMessage {
 
 message RemoveStaffMovementMessage {
     optional string uUID = 1;
+    optional int64 createdAt = 2;
 }

--- a/server/src/main/protobuf/StaffMovementMessages.proto
+++ b/server/src/main/protobuf/StaffMovementMessages.proto
@@ -21,3 +21,7 @@ message StaffMovementMessage {
     optional int64 createdAt = 7;
     optional string createdBy = 8;
 }
+
+message RemoveStaffMovementMessage {
+    optional string uUID = 1;
+}

--- a/server/src/main/scala/actors/StaffMovementsActorBase.scala
+++ b/server/src/main/scala/actors/StaffMovementsActorBase.scala
@@ -32,7 +32,11 @@ case class StaffMovementsState(staffMovements: StaffMovements) {
 
 case class AddStaffMovements(movementsToAdd: Seq[StaffMovement])
 
+case class AddStaffMovementsAck(movementsToAdd: Seq[StaffMovement])
+
 case class RemoveStaffMovements(movementUuidsToRemove: UUID)
+
+case class RemoveStaffMovementsAck(movementUuidsToRemove: UUID)
 
 case class AddStaffMovementsSubscribers(subscribers: List[SourceQueueWithComplete[Seq[StaffMovement]]])
 
@@ -111,6 +115,8 @@ class StaffMovementsActorBase extends RecoveryActorLike with PersistentDrtActor[
       val messagesToPersist = StaffMovementsMessage(staffMovementsToStaffMovementMessages(movements))
       persistAndMaybeSnapshot(messagesToPersist)
 
+      sender() ! AddStaffMovementsAck(movementsToAdd)
+
     case RemoveStaffMovements(uuidToRemove) =>
       val updatedStaffMovements = state.staffMovements - Seq(uuidToRemove)
       updateState(updatedStaffMovements)
@@ -119,6 +125,8 @@ class StaffMovementsActorBase extends RecoveryActorLike with PersistentDrtActor[
       log.info(s"Staff movements removed ($uuidToRemove)")
       val messagesToPersist: RemoveStaffMovementMessage = RemoveStaffMovementMessage(Option(uuidToRemove.toString))
       persistAndMaybeSnapshot(messagesToPersist)
+
+      sender() ! RemoveStaffMovementsAck(uuidToRemove)
 
     case SaveSnapshotSuccess(md) =>
       log.info(s"Save snapshot success: $md")

--- a/server/src/main/scala/actors/StaffMovementsActorBase.scala
+++ b/server/src/main/scala/actors/StaffMovementsActorBase.scala
@@ -80,19 +80,20 @@ class StaffMovementsActorBase extends RecoveryActorLike with PersistentDrtActor[
 
   def updateState(data: StaffMovements): Unit = state = state.updated(data)
 
-  def staffMovementMessagesToStaffMovements(messages: List[StaffMovementMessage]): StaffMovements = StaffMovements(messages.map(staffMovementMessageToStaffMovement))
+  def staffMovementMessagesToStaffMovements(messages: Seq[StaffMovementMessage]): StaffMovements = StaffMovements(messages.map(staffMovementMessageToStaffMovement))
 
   def processSnapshotMessage: PartialFunction[Any, Unit] = {
     case snapshot: StaffMovementsStateSnapshotMessage => state = StaffMovementsState(staffMovementMessagesToStaffMovements(snapshot.staffMovements.toList))
   }
 
   def processRecoveryMessage: PartialFunction[Any, Unit] = {
-    case smm: StaffMovementsMessage =>
-      val sm = staffMovementMessagesToStaffMovements(smm.staffMovements.toList)
-      updateState(sm)
+    case StaffMovementsMessage(movements, _) =>
+      val updatedStaffMovements = staffMovementMessagesToStaffMovements(movements.toList)
+      updateState(updatedStaffMovements)
 
-    case RemoveStaffMovementMessage(Some(uuidToRemove)) =>
+    case RemoveStaffMovementMessage(Some(uuidToRemove), _) =>
       val updatedStaffMovements = state.staffMovements - Seq(UUID.fromString(uuidToRemove))
+      updateState(updatedStaffMovements)
   }
 
   def receiveCommand: Receive = {

--- a/server/src/main/scala/actors/pointInTime/StaffMovementsReadActor.scala
+++ b/server/src/main/scala/actors/pointInTime/StaffMovementsReadActor.scala
@@ -1,9 +1,11 @@
 package actors.pointInTime
 
+import java.util.UUID
+
 import actors.{StaffMovementsActorBase, StaffMovementsState}
 import akka.persistence.{Recovery, SnapshotSelectionCriteria}
 import drt.shared.SDateLike
-import server.protobuf.messages.StaffMovementMessages.{StaffMovementsMessage, StaffMovementsStateSnapshotMessage}
+import server.protobuf.messages.StaffMovementMessages.{RemoveStaffMovementMessage, StaffMovementsMessage, StaffMovementsStateSnapshotMessage}
 
 class StaffMovementsReadActor(pointInTime: SDateLike) extends StaffMovementsActorBase {
   override def processSnapshotMessage: PartialFunction[Any, Unit] = {
@@ -11,7 +13,13 @@ class StaffMovementsReadActor(pointInTime: SDateLike) extends StaffMovementsActo
   }
 
   override def processRecoveryMessage: PartialFunction[Any, Unit] = {
-    case smm: StaffMovementsMessage => updateState(staffMovementMessagesToStaffMovements(smm.staffMovements.toList))
+    case StaffMovementsMessage(movements, Some(createdAt)) if createdAt <= pointInTime.millisSinceEpoch =>
+      val updatedStaffMovements = staffMovementMessagesToStaffMovements(movements.toList)
+      updateState(updatedStaffMovements)
+
+    case RemoveStaffMovementMessage(Some(uuidToRemove), Some(createdAt)) if createdAt <= pointInTime.millisSinceEpoch  =>
+      val updatedStaffMovements = state.staffMovements - Seq(UUID.fromString(uuidToRemove))
+      updateState(updatedStaffMovements)
   }
 
   override def postRecoveryComplete(): Unit = logPointInTimeCompleted(pointInTime)

--- a/server/src/main/scala/controllers/StaffMovementsPersistence.scala
+++ b/server/src/main/scala/controllers/StaffMovementsPersistence.scala
@@ -3,7 +3,7 @@ package controllers
 import java.util.UUID
 
 import actors.pointInTime.StaffMovementsReadActor
-import actors.{GetState, StaffMovements}
+import actors.{AddStaffMovements, GetState, RemoveStaffMovements, StaffMovements}
 import akka.actor.{ActorRef, ActorSystem, PoisonPill, Props}
 import akka.pattern._
 import akka.util.Timeout
@@ -27,9 +27,14 @@ trait StaffMovementsPersistence {
 
   def staffMovementsActor: ActorRef
 
-  def saveStaffMovements(staffMovements: Seq[StaffMovement]) = {
+  def addStaffMovements(movementsToAdd: Seq[StaffMovement]): Unit = {
     actorSystem.log.info(s"Sending StaffMovements to staffMovementsActor")
-    staffMovementsActor ! StaffMovements(staffMovements)
+    staffMovementsActor ! AddStaffMovements(movementsToAdd)
+  }
+
+  def removeStaffMovements(movementsToRemove: UUID): Unit = {
+    actorSystem.log.info(s"Sending StaffMovements to staffMovementsActor")
+    staffMovementsActor ! RemoveStaffMovements(movementsToRemove)
   }
 
   def getStaffMovements(pointInTime: MillisSinceEpoch): Future[Seq[StaffMovement]] = {

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -2,4 +2,3 @@
 # https://www.playframework.com/documentation/latest/Configuration
 
 portcode = "test"
-

--- a/server/src/test/scala/actors/AkkaTestkitSpecs2SupportForPersistence.scala
+++ b/server/src/test/scala/actors/AkkaTestkitSpecs2SupportForPersistence.scala
@@ -6,6 +6,7 @@ import akka.actor.{ActorSystem, Terminated}
 import akka.testkit.{ImplicitSender, TestKit}
 import com.typesafe.config.ConfigFactory
 import org.specs2.mutable.After
+import org.specs2.specification.{AfterAll, BeforeEach}
 
 import scala.collection.JavaConversions._
 import scala.concurrent.duration._

--- a/server/src/test/scala/actors/AkkaTestkitSpecs2SupportForPersistence.scala
+++ b/server/src/test/scala/actors/AkkaTestkitSpecs2SupportForPersistence.scala
@@ -6,7 +6,6 @@ import akka.actor.{ActorSystem, Terminated}
 import akka.testkit.{ImplicitSender, TestKit}
 import com.typesafe.config.ConfigFactory
 import org.specs2.mutable.After
-import org.specs2.specification.{AfterAll, BeforeEach}
 
 import scala.collection.JavaConversions._
 import scala.concurrent.duration._

--- a/server/src/test/scala/actors/StaffMovementsActorSpec.scala
+++ b/server/src/test/scala/actors/StaffMovementsActorSpec.scala
@@ -3,97 +3,63 @@ package actors
 
 import java.util.UUID
 
-import akka.actor.{ActorRef, ActorSystem, PoisonPill, Props, Terminated}
-import akka.pattern._
+import akka.actor.{ActorSystem, PoisonPill, Props}
 import akka.testkit.{ImplicitSender, TestKit}
-import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import drt.shared.{MilliDate, StaffMovement}
-import org.specs2.matcher.Scope
-import org.specs2.mutable.{After, Specification, SpecificationLike}
+import org.specs2.mutable.SpecificationLike
+import org.specs2.specification.AfterEach
 import services.SDate
-import akka.testkit.{ImplicitSender, TestKit}
-import com.typesafe.config.ConfigFactory
 
 import scala.collection.JavaConversions._
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.{Await, Future}
 import scala.language.reflectiveCalls
-import scala.util.Success
 
-object PersistenceTestHelper {
+
+object PersistenceHelper {
   val dbLocation = "target/test"
 }
 
-abstract class AkkaTestkitSpecs2SupportForPersistence2(val dbLocation: String) extends TestKit(ActorSystem("testActorSystem", ConfigFactory.parseMap(Map(
+class StaffMovementsActorSpec extends TestKit(ActorSystem("StaffMovementsActorSpec", ConfigFactory.parseMap(Map(
   "akka.persistence.journal.plugin" -> "akka.persistence.journal.leveldb",
-  "akka.persistence.no-snapshot-store.class" -> "akka.persistence.snapshot.NoSnapshotStore",
-  "akka.persistence.journal.leveldb.dir" -> dbLocation,
+  "akka.persistence.journal.leveldb.dir" -> PersistenceHelper.dbLocation,
   "akka.persistence.snapshot-store.plugin" -> "akka.persistence.snapshot-store.local",
-  "akka.persistence.snapshot-store.local.dir" -> s"$dbLocation/snapshot"
+  "akka.persistence.snapshot-store.local.dir" -> s"${PersistenceHelper.dbLocation}/snapshot"
 ))))
-  //  with After
+  with SpecificationLike
+  with AfterEach
   with ImplicitSender {
-
-  //  def after: Unit = {
-  //    shutDownActorSystem
-  //    PersistenceCleanup.deleteJournal(s"$dbLocation/snapshot")
-  //    PersistenceCleanup.deleteJournal(dbLocation)
-  //  }
-
-  def shutDownActorSystem: Future[Terminated] = {
-    //TODO figure out how to wait for the actor to finish saving rather than this nasty timer.
-    Thread.sleep(200)
-    import scala.language.postfixOps
-    Await.ready(system.terminate(), 2 second)
-    Await.ready(system.whenTerminated, 2 second)
-  }
-}
-
-class StaffMovementsActorSpec extends AkkaTestkitSpecs2SupportForPersistence2(PersistenceTestHelper.dbLocation) with SpecificationLike {
   sequential
   isolated
 
-  private def staffMovementsActor(system: ActorSystem) = {
-    val actor = system.actorOf(Props(classOf[StaffMovementsActorBase]), "staffMovementsActor")
-    actor
-  }
-
-  implicit val timeout: Timeout = Timeout(5 seconds)
-
-  def getActor: ActorRef = staffMovementsActor(system)
-
-  def getState(actor: ActorRef) = {
-    Await.result(actor ? GetState, 1 second)
-  }
-
-  def getStateAndShutdown(actor: ActorRef): Any = {
-    val s = getState(actor)
-    shutDownActorSystem
-    s
+  override def after: Unit = {
+    TestKit.shutdownActorSystem(system)
+    PersistenceCleanup.deleteJournal(PersistenceHelper.dbLocation)
   }
 
   "StaffMovementsActor" should {
-    "return the movements that were added after a shutdown" >> {
-
-      PersistenceCleanup.deleteJournal(dbLocation)
+    "return the movements that were added after a shutdown" in {
 
       val movementUuid1: UUID = UUID.randomUUID()
       val staffMovements = StaffMovements(Seq(StaffMovement("T1", "lunch start", MilliDate(SDate(s"2017-01-01T00:00").millisSinceEpoch), -1, movementUuid1, createdBy = Some("batman"))))
 
-      val actor = getActor
+      val actor = system.actorOf(Props(classOf[StaffMovementsActorBase]), "movementsActor")
 
       actor ! AddStaffMovements(staffMovements.movements)
+      expectMsg(AddStaffMovementsAck(staffMovements.movements))
+      actor ! PoisonPill
 
-      val result = getStateAndShutdown(actor)
+      Thread.sleep(100)
 
-      result mustEqual staffMovements
+      val newActor = system.actorOf(Props(classOf[StaffMovementsActorBase]), "movementsActor")
+
+      newActor ! GetState
+
+      expectMsg(staffMovements)
+
+      true
     }
 
     "return no movements if the movements were removed after a restart" in {
-
-      PersistenceCleanup.deleteJournal(dbLocation)
 
       val movementUuid1: UUID = UUID.randomUUID()
       val movementUuid2: UUID = UUID.randomUUID()
@@ -102,23 +68,23 @@ class StaffMovementsActorSpec extends AkkaTestkitSpecs2SupportForPersistence2(Pe
       val movement2 = StaffMovement("T1", "coffee start", MilliDate(SDate(s"2017-01-01T01:15").millisSinceEpoch), -1, movementUuid2, createdBy = Some("robin"))
       val staffMovements = StaffMovements(Seq(movement1, movement2))
 
-      val actor = getActor
+      val actor = system.actorOf(Props(classOf[StaffMovementsActorBase]), "movementsActor1")
 
       actor ! AddStaffMovements(staffMovements.movements)
-
-      Thread.sleep(100)
+      expectMsg(AddStaffMovementsAck(staffMovements.movements))
 
       actor ! RemoveStaffMovements(movementUuid1)
+      expectMsg(RemoveStaffMovementsAck(movementUuid1))
       actor ! PoisonPill
 
-      Thread.sleep(100)
+      val newActor = system.actorOf(Props(classOf[StaffMovementsActorBase]), "movementsActor2")
 
-      val newActor = getActor
-
-      val result = Await.result(newActor ? GetState, 1 second)
+      newActor ! GetState
       val expected = StaffMovements(Seq(movement2))
 
-      result mustEqual expected
+      expectMsg(expected)
+
+      true
     }
   }
 

--- a/server/src/test/scala/actors/StaffMovementsActorSpec.scala
+++ b/server/src/test/scala/actors/StaffMovementsActorSpec.scala
@@ -3,19 +3,55 @@ package actors
 
 import java.util.UUID
 
-import akka.actor.{ActorRef, ActorSystem, Props}
+import akka.actor.{ActorRef, ActorSystem, PoisonPill, Props, Terminated}
 import akka.pattern._
+import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
 import drt.shared.{MilliDate, StaffMovement}
 import org.specs2.matcher.Scope
-import org.specs2.mutable.Specification
+import org.specs2.mutable.{After, Specification, SpecificationLike}
 import services.SDate
+import akka.testkit.{ImplicitSender, TestKit}
+import com.typesafe.config.ConfigFactory
 
-import scala.concurrent.Await
+import scala.collection.JavaConversions._
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{Await, Future}
 import scala.language.reflectiveCalls
+import scala.util.Success
 
-class StaffMovementsActorSpec extends Specification {
+object PersistenceTestHelper {
+  val dbLocation = "target/test"
+}
+
+abstract class AkkaTestkitSpecs2SupportForPersistence2(val dbLocation: String) extends TestKit(ActorSystem("testActorSystem", ConfigFactory.parseMap(Map(
+  "akka.persistence.journal.plugin" -> "akka.persistence.journal.leveldb",
+  "akka.persistence.no-snapshot-store.class" -> "akka.persistence.snapshot.NoSnapshotStore",
+  "akka.persistence.journal.leveldb.dir" -> dbLocation,
+  "akka.persistence.snapshot-store.plugin" -> "akka.persistence.snapshot-store.local",
+  "akka.persistence.snapshot-store.local.dir" -> s"$dbLocation/snapshot"
+))))
+  //  with After
+  with ImplicitSender {
+
+  //  def after: Unit = {
+  //    shutDownActorSystem
+  //    PersistenceCleanup.deleteJournal(s"$dbLocation/snapshot")
+  //    PersistenceCleanup.deleteJournal(dbLocation)
+  //  }
+
+  def shutDownActorSystem: Future[Terminated] = {
+    //TODO figure out how to wait for the actor to finish saving rather than this nasty timer.
+    Thread.sleep(200)
+    import scala.language.postfixOps
+    Await.ready(system.terminate(), 2 second)
+    Await.ready(system.whenTerminated, 2 second)
+  }
+}
+
+class StaffMovementsActorSpec extends AkkaTestkitSpecs2SupportForPersistence2(PersistenceTestHelper.dbLocation) with SpecificationLike {
   sequential
   isolated
 
@@ -26,60 +62,63 @@ class StaffMovementsActorSpec extends Specification {
 
   implicit val timeout: Timeout = Timeout(5 seconds)
 
-  val dbLocation = "target/test"
+  def getActor: ActorRef = staffMovementsActor(system)
 
-  def getTestKit = {
-    new AkkaTestkitSpecs2SupportForPersistence(dbLocation) {
-      def getActor: ActorRef = staffMovementsActor(system)
-
-      def getState(actor: ActorRef) = {
-        Await.result(actor ? GetState, 1 second)
-      }
-
-      def getStateAndShutdown(actor: ActorRef): Any = {
-        val s = getState(actor)
-        shutDownActorSystem
-        s
-      }
-    }
+  def getState(actor: ActorRef) = {
+    Await.result(actor ? GetState, 1 second)
   }
 
-  trait Context extends Scope {
-    val testKit2 = getTestKit
-    val actor: ActorRef = testKit2.getActor
-    val date = "2017-01-01"
-    val movementUuid: UUID = UUID.randomUUID()
+  def getStateAndShutdown(actor: ActorRef): Any = {
+    val s = getState(actor)
+    shutDownActorSystem
+    s
   }
 
   "StaffMovementsActor" should {
-    "return the movements that were added after a shutdown" in new Context {
+    "return the movements that were added after a shutdown" >> {
 
       PersistenceCleanup.deleteJournal(dbLocation)
 
-      val staffMovements = StaffMovements(Seq(StaffMovement("T1", "lunch start", MilliDate(SDate(s"${date}T00:00").millisSinceEpoch), -1, movementUuid, createdBy = Some("batman"))))
+      val movementUuid1: UUID = UUID.randomUUID()
+      val staffMovements = StaffMovements(Seq(StaffMovement("T1", "lunch start", MilliDate(SDate(s"2017-01-01T00:00").millisSinceEpoch), -1, movementUuid1, createdBy = Some("batman"))))
+
+      val actor = getActor
 
       actor ! AddStaffMovements(staffMovements.movements)
 
-      val result = testKit2.getStateAndShutdown(actor)
+      val result = getStateAndShutdown(actor)
 
       result mustEqual staffMovements
     }
 
-    "return no movements if the movements were removed after a restart" in new Context {
+    "return no movements if the movements were removed after a restart" in {
 
       PersistenceCleanup.deleteJournal(dbLocation)
 
-      val staffMovements = StaffMovements(Seq(StaffMovement("T1", "lunch start", MilliDate(SDate(s"${date}T00:00").millisSinceEpoch), -1, movementUuid, createdBy = Some("batman"))))
+      val movementUuid1: UUID = UUID.randomUUID()
+      val movementUuid2: UUID = UUID.randomUUID()
+
+      val movement1 = StaffMovement("T1", "lunch start", MilliDate(SDate(s"2017-01-01T00:00").millisSinceEpoch), -1, movementUuid1, createdBy = Some("batman"))
+      val movement2 = StaffMovement("T1", "coffee start", MilliDate(SDate(s"2017-01-01T01:15").millisSinceEpoch), -1, movementUuid2, createdBy = Some("robin"))
+      val staffMovements = StaffMovements(Seq(movement1, movement2))
+
+      val actor = getActor
 
       actor ! AddStaffMovements(staffMovements.movements)
 
-      Thread.sleep(250)
+      Thread.sleep(100)
 
-      actor ! RemoveStaffMovements(movementUuid)
+      actor ! RemoveStaffMovements(movementUuid1)
+      actor ! PoisonPill
 
-      val result = testKit2.getStateAndShutdown(actor)
+      Thread.sleep(100)
 
-      result mustEqual StaffMovements(Seq())
+      val newActor = getActor
+
+      val result = Await.result(newActor ? GetState, 1 second)
+      val expected = StaffMovements(Seq(movement2))
+
+      result mustEqual expected
     }
   }
 

--- a/shared/src/main/scala/drt/shared/Api.scala
+++ b/shared/src/main/scala/drt/shared/Api.scala
@@ -630,7 +630,9 @@ trait Api {
 
   def getFixedPoints(pointIntTime: MillisSinceEpoch): Future[FixedPointAssignments]
 
-  def saveStaffMovements(staffMovements: Seq[StaffMovement]): Unit
+  def addStaffMovements(movementsToAdd: Seq[StaffMovement]): Unit
+
+  def removeStaffMovements(movementsToRemove: UUID): Unit
 
   def getStaffMovements(pointIntTime: MillisSinceEpoch): Future[Seq[StaffMovement]]
 


### PR DESCRIPTION
Send additions & removals to the backend when movements are added and removed rather than all of the known movements

Start persisting additions and removals rather than exclusively snapshotting 