### PR TITLE
DRT-5205 - put missing image back using a relative path in the css

### DIFF
--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -129,7 +129,7 @@
   height: 70px;
   width: 220px;
   float:left;
-  background-image: url(/v2/stn/live/assets/images/logo_colour.png);
+  background-image: url(../images/logo_colour.png);
   background-repeat: no-repeat;
   background-position: 0px 15px;
 }


### PR DESCRIPTION
Have the image show up so that css doesn't point to a path of an image that will not exist in ACP, or in UKCloud if the port Stansted goes down.

Used a relative path. Relative to the stylesheet path rather than the URL. This is probably not ideal, but better than an alternative I can think of.

The image show up:

<img width="249" alt="screen shot 2018-10-19 at 10 06 07" src="https://user-images.githubusercontent.com/369407/47208883-f12aea00-d386-11e8-9ca3-ba9056b359b5.png">


