### PR TITLE
DRT-5349 - Redirect to ACP version of the port when the feature switch is set

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,6 +86,7 @@ lazy val server = (project in file("server"))
   javaOptions in Test += "-Duser.timezone=UTC",
   javaOptions in Runtime += "-Duser.timezone=UTC",
   libraryDependencies ++= Settings.jvmDependencies.value,
+  libraryDependencies += specs2 % Test,
   libraryDependencies += guice,
   dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % "2.8.7",
   dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.7",

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -26,6 +26,8 @@ persistenceBaseDir = ${?PERSISTENCE_BASE_DIR}
 
 
 feature-flags {
+  acp-redirect = false
+  acp-redirect = ${?ACP_REDIRECT}
   nationality-based-processing-times = ${?NATIONALITY_BASED_PROC_TIMES}
   use-v2-staff-input: ${?USE_V2_STAFF_INPUT}
   lhr {

--- a/server/src/main/resources/postgres.conf
+++ b/server/src/main/resources/postgres.conf
@@ -26,6 +26,8 @@ persistenceBaseDir = ${?PERSISTENCE_BASE_DIR}
 
 
 feature-flags {
+  acp-redirect = false
+  acp-redirect = ${?ACP_REDIRECT}
   nationality-based-processing-times = ${?NATIONALITY_BASED_PROC_TIMES}
   use-v2-staff-input: ${?USE_V2_STAFF_INPUT}
   lhr {

--- a/server/src/main/scala/Filters.scala
+++ b/server/src/main/scala/Filters.scala
@@ -1,12 +1,11 @@
 import javax.inject.{Inject, Singleton}
-
-import controllers.{NoCacheFilter, SecurityHeadersFilter}
+import filters.{ACPRedirectFilter, NoCacheFilter, SecurityHeadersFilter}
 import play.api.Environment
 import play.api.http.HttpFilters
 
 @Singleton
 class Filters @Inject()(
                          env: Environment,
-                         noCache: NoCacheFilter, securityHeaders: SecurityHeadersFilter) extends HttpFilters {
-  override val filters = Seq(noCache, securityHeaders)
+                         acpRedirectFilter : ACPRedirectFilter, noCache: NoCacheFilter, securityHeaders: SecurityHeadersFilter) extends HttpFilters {
+  override val filters = Seq(acpRedirectFilter, noCache, securityHeaders)
 }

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -122,37 +122,6 @@ trait ImplicitTimeoutProvider {
   implicit val timeout: Timeout = Timeout(1 second)
 }
 
-@Singleton
-class NoCacheFilter @Inject()(
-                               implicit override val mat: Materializer,
-                               exec: ExecutionContext) extends Filter {
-  val log: Logger = LoggerFactory.getLogger(getClass)
-  val rootRegex: Regex = "/v2/.{3}/live".r
-
-  override def apply(requestHeaderToFutureResult: RequestHeader => Future[Result])
-                    (rh: RequestHeader): Future[Result] = {
-    requestHeaderToFutureResult(rh).map { result =>
-      rh.uri match {
-        case rootRegex() =>
-          result.withHeaders(HeaderNames.CACHE_CONTROL -> "no-cache")
-        case _ =>
-          result
-      }
-    }
-  }
-}
-
-@Singleton
-class SecurityHeadersFilter @Inject()(
-                                       implicit override val mat: Materializer,
-                                       exec: ExecutionContext) extends Filter {
-
-  override def apply(requestHeaderToFutureResult: RequestHeader => Future[Result])
-                    (rh: RequestHeader): Future[Result] = requestHeaderToFutureResult(rh)
-    .map(_.withHeaders("X-Frame-Options" -> "deny"))
-}
-
-
 trait UserRoleProviderLike {
   val log: Logger = LoggerFactory.getLogger(getClass)
 

--- a/server/src/main/scala/filters/ACPRedirectFilter.scala
+++ b/server/src/main/scala/filters/ACPRedirectFilter.scala
@@ -1,0 +1,29 @@
+package filters
+
+import akka.stream.Materializer
+import javax.inject.{Inject, Singleton}
+import org.slf4j.{Logger, LoggerFactory}
+import play.api.Configuration
+import play.api.mvc.{Filter, RequestHeader, Result, Results}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ACPRedirectFilter @Inject()(
+                                   implicit val config: Configuration,
+                                   implicit override val mat: Materializer,
+                                   exec: ExecutionContext) extends Filter {
+  val log: Logger = LoggerFactory.getLogger(getClass)
+  val acpRedirectFlagIsSet: Boolean = config.get[Boolean]("feature-flags.acp-redirect")
+  val portCode: String = config.get[String]("portcode")
+  val redirectUrl = s"https://$portCode.drt.homeoffice.gov.uk/v2/$portCode/live"
+
+  override def apply(next: RequestHeader => Future[Result])
+                    (requestHeader: RequestHeader): Future[Result] = {
+    if (acpRedirectFlagIsSet) {
+      log.info(s"ACPRedirectFilter: Redirecting to $redirectUrl")
+      Future(Results.Redirect(redirectUrl))
+    } else {
+      next(requestHeader)
+    }
+  }
+}

--- a/server/src/main/scala/filters/NoCacheFilter.scala
+++ b/server/src/main/scala/filters/NoCacheFilter.scala
@@ -1,0 +1,33 @@
+package filters
+
+import akka.stream.Materializer
+import javax.inject.{Inject, Singleton}
+import org.slf4j.{Logger, LoggerFactory}
+import play.api.Configuration
+import play.api.http.HeaderNames
+import play.api.mvc.{Filter, RequestHeader, Result}
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.matching.Regex
+
+@Singleton
+class NoCacheFilter @Inject()(
+                               implicit val config: Configuration,
+                               implicit override val mat: Materializer,
+                               exec: ExecutionContext) extends Filter {
+  val log: Logger = LoggerFactory.getLogger(getClass)
+  val rootRegex: Regex = config.get[String]("play.http.context").r
+
+  override def apply(requestHeaderToFutureResult: RequestHeader => Future[Result])
+                    (rh: RequestHeader): Future[Result] = {
+    requestHeaderToFutureResult(rh).map { result =>
+      rh.uri match {
+        case rootRegex() =>
+          log.info(s"NoCacheFilter: no-cache")
+          result.withHeaders(HeaderNames.CACHE_CONTROL -> "no-cache")
+        case _ =>
+          result
+      }
+    }
+  }
+}

--- a/server/src/main/scala/filters/NoCacheFilter.scala
+++ b/server/src/main/scala/filters/NoCacheFilter.scala
@@ -23,7 +23,6 @@ class NoCacheFilter @Inject()(
     requestHeaderToFutureResult(rh).map { result =>
       rh.uri match {
         case rootRegex() =>
-          log.info(s"NoCacheFilter: no-cache")
           result.withHeaders(HeaderNames.CACHE_CONTROL -> "no-cache")
         case _ =>
           result

--- a/server/src/main/scala/filters/SecurityHeadersFilter.scala
+++ b/server/src/main/scala/filters/SecurityHeadersFilter.scala
@@ -1,0 +1,22 @@
+package filters
+
+import akka.stream.Materializer
+import drt.shared.{LoggedInUser, Role, Roles}
+import javax.inject.{Inject, Singleton}
+import org.slf4j.{Logger, LoggerFactory}
+import play.api.Configuration
+import play.api.mvc._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+
+@Singleton
+class SecurityHeadersFilter @Inject()(
+                                       implicit override val mat: Materializer,
+                                       exec: ExecutionContext) extends Filter {
+
+  override def apply(requestHeaderToFutureResult: RequestHeader => Future[Result])
+                    (rh: RequestHeader): Future[Result] = requestHeaderToFutureResult(rh)
+    .map(_.withHeaders("X-Frame-Options" -> "deny"))
+}
+

--- a/server/src/test/scala/filters/ACPRedirectFilterSpec.scala
+++ b/server/src/test/scala/filters/ACPRedirectFilterSpec.scala
@@ -1,0 +1,37 @@
+package filters
+
+import play.api.inject.guice.GuiceApplicationBuilder
+import play.api.mvc._
+import play.api.test._
+import scala.concurrent.ExecutionContext
+
+class ACPRedirectFilterSpec (implicit ec :ExecutionContext) extends PlaySpecification with Results {
+
+  val configWithAcpRedirectNotSet = play.api.Configuration.from(Map("portcode" -> "test", "dq.s3.bucket" -> "bucket", "googleTrackingCode"-> "", "feature-flags.acp-redirect" -> false))
+  val configWithAcpRedirectSet = configWithAcpRedirectNotSet ++ play.api.Configuration.from(Map("feature-flags.acp-redirect" -> true))
+
+  "Passes through the app when the ACP redirect flag is not set" in new WithApplication(GuiceApplicationBuilder(configuration = configWithAcpRedirectNotSet).build()) {
+    val dummyEndpoint: EssentialAction = Action (Ok("hello world"))
+    val request = FakeRequest(GET, "/")
+    implicit val config = configWithAcpRedirectNotSet
+
+    val filter = new ACPRedirectFilter().apply(dummyEndpoint)
+    val result = call(filter, request)
+
+    status(result) mustEqual OK
+    contentAsString(result) mustEqual "hello world"
+  }
+
+  "Redirects to the acp version when the ACP redirect flag is set" in new WithApplication(GuiceApplicationBuilder(configuration = configWithAcpRedirectSet).build()) {
+    val dummyEndpoint: EssentialAction = Action (Ok("hello world"))
+    val request = FakeRequest(GET, "/")
+    implicit val config = configWithAcpRedirectSet
+
+    val filter = new ACPRedirectFilter().apply(dummyEndpoint)
+    val result = call(filter, request)
+
+    status(result) mustEqual SEE_OTHER
+    redirectLocation(result) mustEqual Option("https://test.drt.homeoffice.gov.uk/v2/test/live")
+  }
+
+}


### PR DESCRIPTION
Redirects to ACP version of the port when a feature switch is set.

Moved application filters to a filters package.
Added play's specs2 dependency to unit test for the new filter
By default, the feature flag is set to false, i.e will not redirect to the ACP version of the port.
Assumed the ACP version of the port is;
```
https://<portcode>.drt.homeoffice.gov.uk/v2/<portcode>/live
```