### PR TITLE
DRT-5381 Increase snapshot intervals to enable later point in time re…

### DIFF
--- a/server/src/main/scala/actors/ShiftsActorBase.scala
+++ b/server/src/main/scala/actors/ShiftsActorBase.scala
@@ -75,7 +75,7 @@ class ShiftsActorBase(val now: () => SDateLike,
 
   def initialState: ShiftAssignments = ShiftAssignments.empty
 
-  val snapshotInterval = 250
+  val snapshotInterval = 5000
   override val snapshotBytesThreshold: Int = oneMegaByte
 
   import ShiftsMessageParser._

--- a/server/src/main/scala/actors/StaffMovementsActorBase.scala
+++ b/server/src/main/scala/actors/StaffMovementsActorBase.scala
@@ -93,7 +93,7 @@ class StaffMovementsActorBase(val now: () => SDateLike,
 
   def initialState = StaffMovementsState(StaffMovements(List()))
 
-  val snapshotInterval = 250
+  val snapshotInterval = 5000
   override val snapshotBytesThreshold: Int = oneMegaByte
 
   override def stateToMessage: GeneratedMessage = StaffMovementsStateSnapshotMessage(staffMovementsToStaffMovementMessages(state.staffMovements))


### PR DESCRIPTION
…coveries

Movements were suffering from the same bug as the crunch state at EMA. Because snapshots hadn't been triggered at the snapshot intervals, not enough messages were being loaded to replay up to the dates being requested. Increasing the snapshot interval to 5000 resolves this and doesn't impact performance, so seems a sensible point to take a snapshot anyway