### PR TITLE
DRT-5348 - Create API to expose Adv Pax Info Splits to port operators

### DIFF
--- a/e2e/cypress/integration/alerts.js
+++ b/e2e/cypress/integration/alerts.js
@@ -6,7 +6,7 @@ describe('Alerts system', function () {
 
 
   beforeEach(function () {
-    setRoles(["test"]);
+    cy.setRoles(["test"]);
     deleteAlerts();
   });
 
@@ -14,12 +14,9 @@ describe('Alerts system', function () {
     deleteAlerts();
   });
 
-  function setRoles(roles) {
-    cy.request("POST", 'v2/test/live/test/mock-roles', {"roles": roles})
-  }
 
   function deleteAlerts() {
-    setRoles(["test"]);
+    cy.setRoles(["test"]);
     cy.request('DELETE', '/v2/test/live/data/alert');
 
   }
@@ -34,7 +31,7 @@ describe('Alerts system', function () {
   }
 
   function navigateToHome() {
-    setRoles(["test"]);
+    cy.setRoles(["test"]);
     cy.visit('/v2/test/live').then(() => {
       cy.wait(1000);
       cy.get('.navbar-drt').contains('DRT TEST').end();
@@ -42,7 +39,7 @@ describe('Alerts system', function () {
 
   }
   function shouldHaveAlerts(num) {
-    setRoles(["test"]);
+    cy.setRoles(["test"]);
     cy.get('#has-alerts .alert').should('have.length', num);
   }
 

--- a/e2e/cypress/integration/api-splits-for-port-operators.js
+++ b/e2e/cypress/integration/api-splits-for-port-operators.js
@@ -1,0 +1,66 @@
+let moment = require('moment-timezone');
+require('moment/locale/en-gb');
+moment.locale("en-gb");
+
+describe('Advanced Passenger Information Splits exposed to Port Operators', function () {
+  const now = moment();
+  const schDateString = now.format("YYYY-MM-DD");
+  const day = now.date();
+  const month = now.month() + 1;
+  const year = now.year();
+  const header = "IATA,ICAO,Origin,Gate/Stand,Status,Scheduled Date,Scheduled Time,Est Arrival,Act Arrival,Est Chox,Act Chox,Est PCP,Total Pax,PCP Pax,API e-Gates,API EEA,API Non-EEA,API Fast Track,Historical e-Gates,Historical EEA,Historical Non-EEA,Historical Fast Track,Terminal Average e-Gates,Terminal Average EEA,Terminal Average Non-EEA,Terminal Average Fast Track";
+
+  beforeEach(function () {
+    cy.deleteData();
+    cy.setRoles(["test"]);
+  });
+
+  function downloadCsv(day, month, year, terminalName) {
+    return cy.request({url: '/v2/test/live/export/api/'+day+'/'+month+'/'+year+'/'+terminalName, failOnStatusCode: false})
+  }
+
+  function waitForArrivalToAppearInTheSystem() {
+    cy.visit('/v2/test/live#terminal/T1/current/arrivals/?timeRangeStart=0&timeRangeEnd=24');
+    cy.get("#arrivals").contains("TS0123");
+  }
+
+  it("Forbidden when user does not have the role `ApiViewPortCsv`", function () {
+    downloadCsv(day, month, year, "T1").then((response) => {
+      expect(response.status).to.eq(401)
+    });
+  });
+
+  it("Bad Request when the date is invalid", function () {
+    cy.setRoles(["test", "api:view-port-csv"]);
+    downloadCsv(40, month, year, "T1").then((response) => {
+      expect(response.status).to.eq(400)
+    });
+  });
+
+  it("Bad Request when the terminal is invalid", function () {
+    cy.setRoles(["test", "api:view-port-csv"]);
+    downloadCsv(40, month, year, "InvalidTerminalName").then((response) => {
+      expect(response.status).to.eq(400)
+    });
+  });
+
+  it("Not Found when there is no arrivals on the date", function () {
+    cy.setRoles(["test", "api:view-port-csv"]);
+    downloadCsv(day, month, year, "T1").then((response) => {
+      expect(response.status).to.eq(404)
+    });
+  });
+
+  it("Ok when there are arrivals on the date and user has the correct role", function () {
+    cy.addFlight(schDateString + "T00:55:00Z", schDateString + "T00:55:00Z", schDateString + "T01:01:00Z", schDateString + "T01:05:00Z", schDateString + "T00:15:00Z");
+    cy.setRoles(["test", "api:view-port-csv"]);
+    waitForArrivalToAppearInTheSystem();
+    downloadCsv(day, month, year, "T1").then((response) => {
+      expect(response.status).to.eq(200);
+      expect(response.body).to.contain(header);
+      expect(response.body).to.contain(schDateString + ',' + '00:15');
+      expect(response.headers['content-disposition']).to.eq("attachment; filename='export-splits-TEST-T1-" + year + "-" + month + "-" + day + ".csv'")
+    });
+  })
+
+});

--- a/e2e/cypress/integration/arrival.js
+++ b/e2e/cypress/integration/arrival.js
@@ -5,11 +5,11 @@ moment.locale("en-gb");
 describe('Arrivals page', () => {
   const schDateString = moment().format("YYYY-MM-DD");
 
-  const schTimeString = "00:55:00"
-  const estTimeString = "01:05:00"
-  const actTimeString = "01:07:00"
-  const estChoxTimeString = "01:11:00"
-  const actChoxTimeString = "01:12:00"
+  const schTimeString = "00:55:00";
+  const estTimeString = "01:05:00";
+  const actTimeString = "01:07:00";
+  const estChoxTimeString = "01:11:00";
+  const actChoxTimeString = "01:12:00";
 
   const schString = schDateString + "T" + schTimeString + "Z";
   const estString = schDateString + "T" + estTimeString + "Z";
@@ -19,53 +19,27 @@ describe('Arrivals page', () => {
 
   const millis = moment(schString).unix() * 1000;
 
-  const flightPayload = {
-    "Operator": "TestAir",
-    "Status": "On Chocks",
-    "EstDT": estString,
-    "ActDT": actString,
-    "EstChoxDT": estChoxString,
-    "ActChoxDT": actChoxString,
-    "Gate": "46",
-    "Stand": "44R",
-    "MaxPax": 78,
-    "ActPax": 51,
-    "TranPax": 0,
-    "RunwayID": "05L",
-    "BaggageReclaimId": "05",
-    "FlightID": 14710007,
-    "AirportID": "MAN",
-    "Terminal": "T1",
-    "ICAO": "TS123",
-    "IATA": "TS123",
-    "Origin": "AMS",
-    "SchDT": schString
-  }
-
   function addFlight() {
-    setRoles(["test"]);
-    cy.request('POST', '/v2/test/live/test/arrival', flightPayload);
+    cy.setRoles(["test"]);
+    cy.addFlight(estString, actString, estChoxString, actChoxString, schString);
   }
 
   function loadManifestFixture() {
-    setRoles(["test"]);
+    cy.setRoles(["test"]);
     cy.request('POST', '/v2/test/live/test/manifest', manifest);
     cy.request('GET', '/v2/test/live/export/arrivals/' + millis + '/T1?startHour=0&endHour=24');
     cy.get('.pax-api');
   }
 
-  function setRoles(roles) {
-    cy.request("POST", 'v2/test/live/test/mock-roles', { "roles": roles});
-  }
 
   before(() => {
-    setRoles(["test"]);
-    cy.request('DELETE', '/v2/test/live/test/data');
+    cy.setRoles(["test"]);
+    cy.deleteData();
   });
 
   after(() => {
-    setRoles(["test"]);
-    cy.request('DELETE', '/v2/test/live/test/data');
+    cy.setRoles(["test"]);
+    cy.deleteData();
   });
 
   const manifest = {
@@ -157,7 +131,7 @@ describe('Arrivals page', () => {
 
   it('Does not show API splits in the flights export for regular users', () => {
     loadManifestFixture();
-    setRoles(["test"]);
+    cy.setRoles(["test"]);
     cy.request('POST', '/v2/test/live/test/manifest', manifest);
     cy.request('GET', '/v2/test/live/export/arrivals/' + millis + '/T1?startHour=0&endHour=24').then((resp) => {
       expect(resp.body).to.equal(csvWithNoApiSplits);
@@ -166,7 +140,7 @@ describe('Arrivals page', () => {
 
   it('Allows you to view API splits in the flights export for users with api:view permission', () => {
     loadManifestFixture();
-    setRoles(["test", "api:view"]);
+    cy.setRoles(["test", "api:view"]);
     cy.request({
       method: 'GET',
       url: '/v2/test/live/export/arrivals/' + millis + '/T1?startHour=0&endHour=24',

--- a/e2e/cypress/integration/monthly-staffing.js
+++ b/e2e/cypress/integration/monthly-staffing.js
@@ -4,10 +4,6 @@ moment.locale("en-gb");
 
 describe('Monthly Staffing', function () {
 
-  function setRoles(roles) {
-    cy.request("POST", 'v2/test/live/test/mock-roles', {"roles": roles})
-  }
-
   function firstMidnightOfThisMonth() {
     return moment().tz('Europe/London').startOf('month');
   }
@@ -47,7 +43,7 @@ describe('Monthly Staffing', function () {
     it("If I enter staff for the current month those staff should still be visible if I change months and change back", function () {
       saveShifts();
 
-      setRoles(["staff:edit", "test"]);
+      cy.setRoles(["staff:edit", "test"]);
 
       cy.visit('/v2/test/live#terminal/T1/staffing/15/');
       cy.get(cellToTest).contains("1");

--- a/e2e/cypress/integration/restrict-access-by-port.js
+++ b/e2e/cypress/integration/restrict-access-by-port.js
@@ -1,10 +1,5 @@
 describe('Restrict access by port', function () {
 
-
-  function setRoles(roles) {
-    cy.request("POST", 'v2/test/live/test/mock-roles', {"roles": roles})
-  }
-
   function navigateToHome() {
     cy.visit('/v2/test/live').then(() => {
       cy.contains('.navbar-drt', 'DRT TEST').end();
@@ -21,18 +16,18 @@ describe('Restrict access by port', function () {
   describe('Restrict access by port', function () {
 
     it("When I have the correct permission to view the port I see the app", function () {
-      setRoles(["test"]);
+      cy.setRoles(["test"]);
       navigateToHome();
     });
 
     it("When I do not have any permission to view any ports I see access restricted page", function () {
-      setRoles(["bogus"]);
+      cy.setRoles(["bogus"]);
       navigateToHomeAccessRestricted();
       cy.get('#alternate-ports').should('not.exist');
     });
 
     it("When I only have permission to view LHR I see access restricted page with a link to LHR only", function () {
-      setRoles(["LHR"]);
+      cy.setRoles(["LHR"]);
       navigateToHomeAccessRestricted();
       cy.get('#alternate-ports').should('exist');
       cy.contains('#LHR-link', 'LHR');
@@ -40,7 +35,7 @@ describe('Restrict access by port', function () {
     });
 
     it("When I have permission to view LHR and LGW I see access restricted page with a link to both ports", function () {
-      setRoles(["LHR", "LGW"]);
+      cy.setRoles(["LHR", "LGW"]);
       navigateToHomeAccessRestricted();
       cy.get('#alternate-ports').should('exist');
       cy.contains('#LHR-link', 'LHR');

--- a/e2e/cypress/integration/staff-movements.js
+++ b/e2e/cypress/integration/staff-movements.js
@@ -4,39 +4,12 @@ describe('Staff movements', function () {
   beforeEach(function () {
     deleteTestData();
     var schDT = new Date().toISOString().split("T")[0];
-    setRoles(["test"]);
-    cy.request('POST',
-      '/v2/test/live/test/arrival',
-      {
-        "Operator": "Flybe",
-        "Status": "On Chocks",
-        "EstDT": schDT + "T00:55:00Z",
-        "ActDT": schDT + "T00:55:00Z",
-        "EstChoxDT": schDT + "T01:01:00Z",
-        "ActChoxDT": schDT + "T01:05:00Z",
-        "Gate": "46",
-        "Stand": "44R",
-        "MaxPax": 78,
-        "ActPax": 51,
-        "TranPax": 0,
-        "RunwayID": "05L",
-        "BaggageReclaimId": "05",
-        "FlightID": 14710007,
-        "AirportID": "MAN",
-        "Terminal": "T1",
-        "ICAO": "SA123",
-        "IATA": "SA123",
-        "Origin": "AMS",
-        "SchDT": schDT + "T00:15:00Z"
-      });
+    cy.setRoles(["test"]);
+    cy.addFlight(schDT + "T00:55:00Z", schDT + "T00:55:00Z", schDT + "T01:01:00Z", schDT + "T01:05:00Z", schDT + "T00:15:00Z");
   });
 
-  function setRoles(roles) {
-    cy.request("POST", 'v2/test/live/test/mock-roles', {"roles": roles})
-  }
-
   function deleteTestData() {
-    cy.request('DELETE', '/v2/test/live/test/data');
+    cy.deleteData();
   }
 
   function addMovementFor1HourAt(numStaff, hour) {

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -23,3 +23,37 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+Cypress.Commands.add('setRoles', (roles = []) => {
+  cy.request("POST", 'v2/test/live/test/mock-roles', { "roles": roles});
+});
+
+Cypress.Commands.add('addFlight', (estString, actString, estChoxString, actChoxString, schString) => {
+  const flightPayload = {
+    "Operator": "TestAir",
+    "Status": "On Chocks",
+    "EstDT": estString,
+    "ActDT": actString,
+    "EstChoxDT": estChoxString,
+    "ActChoxDT": actChoxString,
+    "Gate": "46",
+    "Stand": "44R",
+    "MaxPax": 78,
+    "ActPax": 51,
+    "TranPax": 0,
+    "RunwayID": "05L",
+    "BaggageReclaimId": "05",
+    "FlightID": 14710007,
+    "AirportID": "MAN",
+    "Terminal": "T1",
+    "ICAO": "TS123",
+    "IATA": "TS123",
+    "Origin": "AMS",
+    "SchDT": schString
+  };
+
+  cy.request('POST', '/v2/test/live/test/arrival', flightPayload);
+});
+
+Cypress.Commands.add('deleteData', () => {
+  cy.request("DELETE", '/v2/test/live/test/data');
+});

--- a/server/src/main/resources/routes
+++ b/server/src/main/resources/routes
@@ -5,6 +5,7 @@
 # Home page
 GET           /                                                    controllers.Application.index
 
+GET           /export/api/:day/:month/:year/:terminalName          controllers.Application.exportApi(day: Int, month: Int, year: Int, terminalName: String)
 GET           /export/desks/:pointInTime/:terminalName             controllers.Application.exportDesksAndQueuesAtPointInTimeCSV(pointInTime, terminalName, startHour: Int ?= 0, endHour: Int ?= 24)
 GET           /export/arrivals/:pointInTime/:terminalName          controllers.Application.exportFlightsWithSplitsAtPointInTimeCSV(pointInTime, terminalName, startHour: Int ?= 0, endHour: Int ?= 24)
 GET           /export/desks/:start/:end/:terminalName              controllers.Application.exportDesksAndQueuesBetweenTimeStampsCSV(start, end, terminalName)

--- a/server/src/main/resources/routes
+++ b/server/src/main/resources/routes
@@ -5,7 +5,7 @@
 # Home page
 GET           /                                                    controllers.Application.index
 
-GET           /export/api/:day/:month/:year/:terminalName          controllers.Application.exportApi(day: Int, month: Int, year: Int, terminalName: String)
+GET           /export/api/:terminalName/:year/:month/:day          controllers.Application.exportApi(day: Int, month: Int, year: Int, terminalName: String)
 GET           /export/desks/:pointInTime/:terminalName             controllers.Application.exportDesksAndQueuesAtPointInTimeCSV(pointInTime, terminalName, startHour: Int ?= 0, endHour: Int ?= 24)
 GET           /export/arrivals/:pointInTime/:terminalName          controllers.Application.exportFlightsWithSplitsAtPointInTimeCSV(pointInTime, terminalName, startHour: Int ?= 0, endHour: Int ?= 24)
 GET           /export/desks/:start/:end/:terminalName              controllers.Application.exportDesksAndQueuesBetweenTimeStampsCSV(start, end, terminalName)

--- a/shared/src/main/scala/drt/shared/LoggedInUser.scala
+++ b/shared/src/main/scala/drt/shared/LoggedInUser.scala
@@ -26,7 +26,8 @@ object Roles {
     StaffEdit,
     ApiView,
     ManageUsers,
-    CreateAlerts
+    CreateAlerts,
+    ApiViewPortCsv
   ) ++ portRoles
   def parse(roleName: String): Option[Role] = availableRoles.find(role=> role.name == roleName)
 }
@@ -37,6 +38,10 @@ case object StaffEdit extends Role {
 
 case object ApiView extends Role {
   override val name: String = "api:view"
+}
+
+case object ApiViewPortCsv extends Role {
+  override val name: String = "api:view-port-csv"
 }
 
 case object TestAccess extends Role {

--- a/shared/src/main/scala/drt/shared/LoggedInUser.scala
+++ b/shared/src/main/scala/drt/shared/LoggedInUser.scala
@@ -41,7 +41,7 @@ case object ApiView extends Role {
 }
 
 case object ApiViewPortCsv extends Role {
-  override val name: String = "api:view-port-csv"
+  override val name: String = "api:view-port-arrivals"
 }
 
 case object TestAccess extends Role {


### PR DESCRIPTION
# Create API to expose Adv Pax Info Splits to port operators
Initially we can reproduce the CSV export as an API endpoint 

This will require:

- restricting access to only the endpoint that it requires
- E2E tests to ensure this role doesn't accidentally gain access to things it shouldn't
