### PR TITLE
DRT-5362 - Handle Glacier files in S3 API storage

### DIFF
--- a/server/src/test/scala/drt/server/feeds/api/S3ApiProviderSpec.scala
+++ b/server/src/test/scala/drt/server/feeds/api/S3ApiProviderSpec.scala
@@ -1,0 +1,38 @@
+package drt.server.feeds.api
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Source
+import akka.testkit.TestKit
+import akka.util.ByteString
+import com.amazonaws.auth.AWSCredentials
+import com.amazonaws.services.s3.model.S3ObjectSummary
+import com.mfglabs.commons.aws.s3.AmazonS3Client
+import com.typesafe.config.ConfigFactory
+import org.specs2.mock.Mockito
+import org.specs2.mutable.SpecificationLike
+import org.specs2.specification.Scope
+
+class S3ApiProviderSpec extends TestKit(ActorSystem("testActorSystem", ConfigFactory.empty())) with SpecificationLike with Mockito {
+
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+
+  trait Context extends Scope  {
+    val s3ClientMock: AmazonS3Client = mock[AmazonS3Client]
+    val awsCredentialsMock: AWSCredentials = mock[AWSCredentials]
+    val s3ApiProvider = new S3ApiProvider(awsCredentialsMock, "") {
+      override def s3Client: AmazonS3Client = s3ClientMock
+    }
+  }
+
+  "Can continue if there is an error getting a file from s3" in new Context  {
+    val list = List(ByteString(""), null)
+    val iterator = list.iterator
+    val source: Source[ByteString, NotUsed] = Source.fromIterator(() => iterator)
+    val result = s3ApiProvider.fileNameAndContentFromZip("drt_dq_181108_000233_2957.zip", source)
+
+    result must be_==(("drt_dq_181108_000233_2957.zip", List.empty))
+  }
+
+}


### PR DESCRIPTION
# Handle Glacier files in S3 API storage

When a file has been in S3 long enough to be archived to glacier, but ends up being parsed by our app due to the filename being last alphabetically (often with test files) we get an exception that we need to handle

```
java.io.IOException: com.amazonaws.services.s3.model.AmazonS3Exception: 
  The operation is not valid for the object's storage class 
  (Service: Amazon S3; Status Code: 403; Error Code: InvalidObjectState; Request ID: 
  A5CD4C7BCBCF6E41), 
  S3 Extended Request ID: 
  Q4S0oIlu2GueKe76FRhxNr1MFwtdQ9VTCrb7emz8vd18XSX56DllODGcvlAk4MhvDb06dDuQtW8=
```

I had noticed that the application ran out of memory while processing many zip files in s3, after closing the zipInputStream the app did not run out of memory.
