### PR TITLE
Drt 5454 investigate high memory churn

### DIFF
--- a/server/src/main/scala/services/graphstages/ArrivalsGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/ArrivalsGraphStage.scala
@@ -81,8 +81,10 @@ class ArrivalsGraphStage(name: String = "",
       grab(arrivalsInlet) match {
         case ArrivalsFeedSuccess(Flights(flights), connectedAt) =>
           log.info(s"Grabbed ${flights.length} arrivals from connection at ${connectedAt.toISOString()}")
-          handleIncomingArrivals(sourceType, flights)
-          mergeAllSourcesAndPush(baseArrivals, forecastArrivals, liveArrivals)
+          if (flights.nonEmpty || sourceType == BaseArrivals) {
+            handleIncomingArrivals(sourceType, flights)
+            mergeAllSourcesAndPush(baseArrivals, forecastArrivals, liveArrivals)
+          }
         case ArrivalsFeedFailure(message, failedAt) =>
           log.warn(s"$arrivalsInlet failed at ${failedAt.toISOString()}: $message")
       }

--- a/server/src/main/scala/services/graphstages/PortStateGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/PortStateGraphStage.scala
@@ -85,10 +85,12 @@ class PortStateGraphStage(name: String = "",
 
     setHandler(outPortState, new OutHandler {
       override def onPull(): Unit = {
+        val start = SDate.now()
         log.info(s"onPull() called")
         pushIfAppropriate(mayBePortState)
 
         pullAllInlets()
+        log.info(s"outPortState Took ${SDate.now().millisSinceEpoch - start.millisSinceEpoch}ms")
       }
     })
 

--- a/server/src/main/scala/services/graphstages/SplitsPredictorStage.scala
+++ b/server/src/main/scala/services/graphstages/SplitsPredictorStage.scala
@@ -5,6 +5,7 @@ import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 import drt.shared.FlightsApi.TerminalName
 import drt.shared._
 import org.slf4j.{Logger, LoggerFactory}
+import services.SDate
 import services.prediction.{SparkSplitsPredictor, SplitsPredictorFactoryLike}
 
 
@@ -24,6 +25,7 @@ class DummySplitsPredictor() extends SplitsPredictorBase {
 
       setHandler(in, new InHandler {
         override def onPush(): Unit = {
+          val start = SDate.now()
           log.info(s"Dummy predictor onPush() - grabbing arrivals")
           grab(in)
           haveGrabbed = true
@@ -31,11 +33,13 @@ class DummySplitsPredictor() extends SplitsPredictorBase {
             log.info(s"Dummy predictor pull(in)")
             pull(in)
           }
+          log.info(s"in Took ${SDate.now().millisSinceEpoch - start.millisSinceEpoch}ms")
         }
       })
 
       setHandler(out, new OutHandler {
         override def onPull(): Unit = {
+          val start = SDate.now()
           log.info(s"Dummy predictor onPull()")
           if (haveGrabbed && isAvailable(out)) {
             log.info(s"Dummy predictor pushing empty results")
@@ -46,6 +50,7 @@ class DummySplitsPredictor() extends SplitsPredictorBase {
             log.info(s"Dummy predictor pull(in)")
             pull(in)
           }
+          log.info(s"out Took ${SDate.now().millisSinceEpoch - start.millisSinceEpoch}ms")
         }
       })
     }

--- a/server/src/main/scala/services/graphstages/VoyageManifestsGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/VoyageManifestsGraphStage.scala
@@ -53,8 +53,10 @@ class VoyageManifestsGraphStage(portCode: String,
     new GraphStageLogic(shape) {
       setHandler(out, new OutHandler {
         override def onPull(): Unit = {
+          val start = SDate.now()
           fetchAndUpdateState()
           pushManifests()
+          log.info(s"out Took ${SDate.now().millisSinceEpoch - start.millisSinceEpoch}ms")
         }
       })
 

--- a/server/src/main/scala/services/graphstages/WorkloadGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/WorkloadGraphStage.scala
@@ -81,20 +81,13 @@ class WorkloadGraphStage(name: String = "",
         val incomingFlights = grab(inFlightsWithSplits)
         log.info(s"Received ${incomingFlights.flights.size} arrivals")
 
-        val used = Memory.used
         val updatedWorkloads: Map[Int, Set[FlightSplitMinute]] = mergeWorkloadByFlightId(incomingFlights, workloadByFlightId)
-        Memory.printMemUsedSince(used, "WL After merge")
         workloadByFlightId = purgeExpired(updatedWorkloads, (fsms: Set[FlightSplitMinute]) => if (fsms.nonEmpty) fsms.map(_.minute).min else 0, now, expireAfterMillis)
-        Memory.printMemUsedSince(used, "WL After purging expired wl by flight id")
         val updatedLoads = flightSplitMinutesToQueueLoadMinutes(updatedWorkloads)
-        Memory.printMemUsedSince(used, "WL After updatedLoads")
         val latestDiff = loadDiff(updatedLoads, loadMinutes)
-        Memory.printMemUsedSince(used, "WL After diff")
         loadMinutes = purgeExpired(updatedLoads, (lm: LoadMinute) => lm.minute, now, expireAfterMillis)
-        Memory.printMemUsedSince(used, "WL After purging loads")
 
         updatedLoadsToPush = purgeExpired(mergeLoadMinutes(latestDiff, updatedLoadsToPush), (lm: LoadMinute) => lm.minute, now, expireAfterMillis)
-        Memory.printMemUsedSince(used, "WL After merging & purging loads to push")
         log.info(s"${updatedLoadsToPush.size} load minutes to push (${updatedLoadsToPush.values.count(_.paxLoad == 0d)} zero pax minutes)")
 
         pushStateIfReady()

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -3,6 +3,39 @@
 
 portcode = "test"
 
+akka {
+  log-dead-letters = 0,
+  warn-about-java-serializer-usage = false
+  jvm-exit-on-fatal-error = true
+  actor {
+    serializers {
+      protobuf = "actors.serializers.ProtoBufSerializer"
+    }
+    serialization-bindings {
+      "server.protobuf.messages.CrunchState.CrunchDiffMessage" = protobuf
+      "server.protobuf.messages.FlightsMessage.FlightsDiffMessage" = protobuf
+      "server.protobuf.messages.CrunchState.CrunchStateSnapshotMessage" = protobuf
+      "server.protobuf.messages.ShiftMessage.ShiftStateSnapshotMessage" = protobuf
+      "server.protobuf.messages.FixedPointMessage.FixedPointsStateSnapshotMessage" = protobuf
+      "server.protobuf.messages.StaffMovementMessages.StaffMovementsStateSnapshotMessage" = protobuf
+      "server.protobuf.messages.FlightsMessage.FlightStateSnapshotMessage" = protobuf
+      "server.protobuf.messages.FlightsMessage.FeedStatusMessage" = protobuf
+      "server.protobuf.messages.FlightsMessage.FeedStatusesMessage" = protobuf
+      "server.protobuf.messages.VoyageManifest.VoyageManifestStateSnapshotMessage" = protobuf
+      "server.protobuf.messages.VoyageManifest.VoyageManifestLatestFileNameMessage" = protobuf
+      "server.protobuf.messages.VoyageManifest.VoyageManifestsMessage" = protobuf
+      "server.protobuf.messages.VoyageManifest.VoyageManifestMessage" = protobuf
+      "server.protobuf.messages.Alert.AlertSnapshotMessage" = protobuf
+      "server.protobuf.messages.Alert.Alert" = protobuf
+    }
+  }
+  stream.materializer {
+    initial-input-buffer-size = 1
+    max-input-buffer-size = 1
+  }
+  extensions = [akka.persistence.Persistence]
+}
+
 aggregated-db {
   connectionPool = disabled
   driver = "org.h2.Driver"

--- a/server/src/test/scala/MemorySpec.scala
+++ b/server/src/test/scala/MemorySpec.scala
@@ -15,6 +15,8 @@ class MemorySpec extends Specification {
   "Given a Map of stuff " +
     "When I transform it to a Set " +
     "How much memory allocation is triggered" >> {
+    skipped("exploratory")
+    
     val terminals = Seq("T2", "T3", "T4", "T5")
     val queues = Seq("EEA", "NonEEA", "EGates", "FastTrack")
     val sixMonthsInMinutes = 180 * 24 * 60 * 60

--- a/server/src/test/scala/MemorySpec.scala
+++ b/server/src/test/scala/MemorySpec.scala
@@ -1,0 +1,49 @@
+import drt.shared.TQM
+import org.slf4j.{Logger, LoggerFactory}
+import org.specs2.mutable.Specification
+import services.graphstages.Crunch.LoadMinute
+
+import scala.collection.immutable
+import scala.collection.immutable.Map
+
+
+class MemorySpec extends Specification {
+  val runtime = Runtime.getRuntime
+  val kb = 1024
+  val mb = 1024 * 1024
+
+  "Given a Map of stuff " +
+    "When I transform it to a Set " +
+    "How much memory allocation is triggered" >> {
+    val terminals = Seq("T2", "T3", "T4", "T5")
+    val queues = Seq("EEA", "NonEEA", "EGates", "FastTrack")
+    val sixMonthsInMinutes = 180 * 24 * 60 * 60
+    val minutesRange = 1548674630957L to (1548674630957L + (sixMonthsInMinutes * 1000L)) by 60000L
+    val minutes: Seq[Long] = minutesRange.take(sixMonthsInMinutes)
+
+    logMemoryUsage("before seq creation")
+
+    val stuff = for {
+      t <- terminals
+      q <- queues
+      m <- minutes
+    } yield { TQM(t, q, m) -> LoadMinute(t, q, Math.random(), Math.random(), m) }
+
+    println(s"generated a ${stuff.length} element Seq")
+
+    logMemoryUsage("before toMap")
+    val minuteMap = stuff.toMap
+    logMemoryUsage("after toMap")
+    val minuteKeys = minuteMap.keys
+    logMemoryUsage("after keys")
+    val minuteValues = minuteMap.values.toSet
+    logMemoryUsage("after values.toSet")
+
+    true
+  }
+
+  def logMemoryUsage(msg: String): Unit = {
+    println(s"** $msg")
+    println("** Used Memory:  " + (runtime.totalMemory - runtime.freeMemory) / mb) + "Mb"
+  }
+}

--- a/server/src/test/scala/actors/AkkaTestkitSpecs2SupportForPersistence.scala
+++ b/server/src/test/scala/actors/AkkaTestkitSpecs2SupportForPersistence.scala
@@ -24,6 +24,7 @@ object PersistenceCleanup {
 }
 
 abstract class AkkaTestkitSpecs2SupportForPersistence(val dbLocation: String) extends TestKit(ActorSystem("testActorSystem", ConfigFactory.parseMap(Map(
+  "akka.actor.warn-about-java-serializer-usage" -> false,
   "akka.persistence.journal.plugin" -> "akka.persistence.journal.leveldb",
   "akka.persistence.no-snapshot-store.class" -> "akka.persistence.snapshot.NoSnapshotStore",
   "akka.persistence.journal.leveldb.dir" -> dbLocation,

--- a/server/src/test/scala/actors/FixedPointsActorSpec.scala
+++ b/server/src/test/scala/actors/FixedPointsActorSpec.scala
@@ -16,6 +16,8 @@ import scala.language.reflectiveCalls
 
 
 class FixedPointsActorSpec extends TestKit(ActorSystem("FixedPointsActorSpec", ConfigFactory.parseMap(Map(
+  "akka.log-dead-letters" -> 0,
+  "akka.actor.warn-about-java-serializer-usage" -> false,
   "akka.persistence.journal.plugin" -> "akka.persistence.journal.leveldb",
   "akka.persistence.journal.leveldb.dir" -> PersistenceHelper.dbLocation,
   "akka.persistence.snapshot-store.plugin" -> "akka.persistence.snapshot-store.local",
@@ -31,7 +33,7 @@ class FixedPointsActorSpec extends TestKit(ActorSystem("FixedPointsActorSpec", C
     TestKit.shutdownActorSystem(system)
     PersistenceCleanup.deleteJournal(PersistenceHelper.dbLocation)
   }
-  
+
   import StaffAssignmentGenerator._
 
   "FixedPoints actor" should {

--- a/server/src/test/scala/actors/ShiftsActorSpec.scala
+++ b/server/src/test/scala/actors/ShiftsActorSpec.scala
@@ -24,6 +24,8 @@ object StaffAssignmentGenerator {
 }
 
 class ShiftsActorSpec extends TestKit(ActorSystem("ShiftsActorSpec", ConfigFactory.parseMap(Map(
+  "akka.log-dead-letters" -> 0,
+  "akka.actor.warn-about-java-serializer-usage" -> false,
   "akka.persistence.journal.plugin" -> "akka.persistence.journal.leveldb",
   "akka.persistence.journal.leveldb.dir" -> PersistenceHelper.dbLocation,
   "akka.persistence.snapshot-store.plugin" -> "akka.persistence.snapshot-store.local",
@@ -41,7 +43,7 @@ class ShiftsActorSpec extends TestKit(ActorSystem("ShiftsActorSpec", ConfigFacto
   }
 
   import StaffAssignmentGenerator._
-  
+
   "Shifts actor" should {
     "remember a shift staff assignment added before a shutdown" in {
       val startTime = MilliDate(SDate(s"2017-01-01T07:00").millisSinceEpoch)

--- a/server/src/test/scala/actors/StaffMovementsActorSpec.scala
+++ b/server/src/test/scala/actors/StaffMovementsActorSpec.scala
@@ -22,6 +22,8 @@ object PersistenceHelper {
 }
 
 class StaffMovementsActorSpec extends TestKit(ActorSystem("StaffMovementsActorSpec", ConfigFactory.parseMap(Map(
+  "akka.log-dead-letters" -> 0,
+  "akka.actor.warn-about-java-serializer-usage" -> false,
   "akka.persistence.journal.plugin" -> "akka.persistence.journal.leveldb",
   "akka.persistence.journal.leveldb.dir" -> PersistenceHelper.dbLocation,
   "akka.persistence.snapshot-store.plugin" -> "akka.persistence.snapshot-store.local",

--- a/server/src/test/scala/passengersplits/InMemoryPersistence.scala
+++ b/server/src/test/scala/passengersplits/InMemoryPersistence.scala
@@ -8,6 +8,8 @@ import scala.collection.JavaConversions._
 object InMemoryPersistence {
 
   val akkaAndAggregateDbConfig = ConfigFactory.parseMap(Map(
+    "akka.actor.warn-about-java-serializer-usage" -> false,
+
     "akka.persistence.journal.plugin" -> "inmemory-journal",
     "akka.persistence.no-snapshot-store.class" -> "akka.persistence.snapshot.NoSnapshotStore",
     "akka.persistence.snapshot-store.plugin" -> "inmemory-snapshot-store",
@@ -18,8 +20,3 @@ object InMemoryPersistence {
     "aggregated-db.keepAliveConnection" -> "true"
   ))
 }
-
-
-
-
-

--- a/server/src/test/scala/services/AirportToCountryTests.scala
+++ b/server/src/test/scala/services/AirportToCountryTests.scala
@@ -16,10 +16,8 @@ object AirportToCountryTests extends TestSuite {
       val airportInfo = AirportToCountry.airportInfoByAirportCode("LGW")
       airportInfo.onSuccess {
         case Some(ai) =>
-          println(s"i'm asserting ${ai}")
           assert(ai == AirportInfo("Gatwick", "London",  "United Kingdom", "LGW"))
         case f =>
-          println(f)
           assert(false)
       }
     }

--- a/server/src/test/scala/services/advpaxinfo/SplitsExportSpec.scala
+++ b/server/src/test/scala/services/advpaxinfo/SplitsExportSpec.scala
@@ -136,11 +136,7 @@ class SplitsExportSpec extends Specification {
           .map(p => p.copy(nationalities = None))
 
         val scheduledDateString = s"${vm.ScheduledDateOfArrival}T${vm.ScheduledTimeOfArrival}"
-        Try {
-          MilliDate(SDate(scheduledDateString).millisSinceEpoch)
-        }
-        match {
-          case Failure(_) => println(s"Couldn't parse scheduled date string: $scheduledDateString")
+        Try(MilliDate(SDate(scheduledDateString).millisSinceEpoch)) match {
           case Success(scheduled) =>
             val year = SDate(scheduled).getFullYear()
             val month = SDate(scheduled).getMonth()
@@ -157,6 +153,7 @@ class SplitsExportSpec extends Specification {
 
             val row = s"${vm.flightCode},${SDate(scheduled).toISOString()},${vm.DeparturePortCode},${vm.ArrivalPortCode},$year,$month,$dayOfWeek,${percentages.mkString(",")}\n"
             outputFile.write(row)
+          case Failure(_) =>
         }
 
       case _ =>

--- a/server/src/test/scala/services/crunch/AggregatedArrivalsSpec.scala
+++ b/server/src/test/scala/services/crunch/AggregatedArrivalsSpec.scala
@@ -49,29 +49,24 @@ class TestAggregatedArrivalsActor(portCode: String, arrivalTable: ArrivalTableLi
 
 class AggregatedArrivalsSpec extends CrunchTestLike with BeforeEach {
   override def before: Any = {
-    println(s"before()")
     clearDatabase()
   }
 
   val table = ArrivalTable(airportConfig.portCode, H2Tables)
 
   def clearDatabase(): Unit = {
-    println(s"clearDatabase")
     Try(dropTables())
     createTables()
   }
 
   def createTables(): Unit = {
-    println(s"attempting to create db")
     H2Tables.schema.createStatements.toList.foreach { query =>
-      println(s"query: $query")
       Await.ready(table.db.run(SQLActionBuilder(List(query), SetUnit).asUpdate), 10 seconds)
     }
   }
 
   def dropTables(): Unit = {
     H2Tables.schema.dropStatements.toList.reverse.foreach { query =>
-      println(s"query: $query")
       Await.ready(table.db.run(SQLActionBuilder(List(query), SetUnit).asUpdate), 10 seconds)
     }
   }

--- a/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
+++ b/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
@@ -105,7 +105,6 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
       crunch.liveTestProbe.receiveWhile(5 seconds) {
         case ps: PortState =>
           val portStateSources = ps.flights.values.flatMap(_.apiFlight.FeedSources).toSet
-          println("HERE: "+ portStateSources)
           if (portStateSources.size > feedSources.size)
           feedSources =portStateSources
       }

--- a/server/src/test/scala/services/crunch/CrunchCodeSharesSpec.scala
+++ b/server/src/test/scala/services/crunch/CrunchCodeSharesSpec.scala
@@ -80,7 +80,6 @@ class CrunchCodeSharesSpec extends CrunchTestLike {
       crunch.liveTestProbe.fishForMessage(10 seconds) {
         case ps: PortState =>
           val resultSummary = paxLoadsFromPortState(ps, 30)
-          println(s"result: $resultSummary")
           resultSummary == expected
       }
 

--- a/server/src/test/scala/services/crunch/CrunchFlightExclusionsSpec.scala
+++ b/server/src/test/scala/services/crunch/CrunchFlightExclusionsSpec.scala
@@ -82,7 +82,6 @@ class CrunchFlightExclusionsSpec extends CrunchTestLike {
     crunch.liveTestProbe.fishForMessage(10 seconds) {
       case ps: PortState =>
         val resultSummary = paxLoadsFromPortState(ps, 30)
-        println(s"results: $resultSummary")
         resultSummary == expected
     }
 

--- a/server/src/test/scala/services/crunch/CrunchLoadStageSpec.scala
+++ b/server/src/test/scala/services/crunch/CrunchLoadStageSpec.scala
@@ -83,9 +83,7 @@ class CrunchLoadStageSpec extends CrunchTestLike {
 
     val result = probe.receiveOne(5 seconds) match {
       case DeskRecMinutes(drms) => drms
-      case unexpected =>
-        println(s"Got unexpected: $unexpected")
-        Set()
+      case unexpected => Set()
     }
 
     val interestingMinutes = result.filter(cm => {
@@ -128,7 +126,6 @@ class CrunchLoadStageSpec extends CrunchTestLike {
         val minutes = drms.filter(cm => {
           expectedMillis.contains(cm.minute)
         })
-        println(s"minutes: $minutes")
         minutes == expected && drms.size == expectedSize
     }
 

--- a/server/src/test/scala/services/crunch/CrunchSplitsToLoadAndDeskRecsSpec.scala
+++ b/server/src/test/scala/services/crunch/CrunchSplitsToLoadAndDeskRecsSpec.scala
@@ -37,6 +37,7 @@ class CrunchSplitsToLoadAndDeskRecsSpec extends CrunchTestLike {
         now = () => SDate(scheduled),
         airportConfig = airportConfig.copy(
           queues = Map("T1" -> Seq(Queues.EeaDesk, Queues.EGate)),
+          terminalNames = Seq("T1"),
           defaultPaxSplits = SplitRatios(
             SplitSources.TerminalAverage,
             SplitRatio(eeaMachineReadableToDesk, edSplit),
@@ -261,6 +262,7 @@ class CrunchSplitsToLoadAndDeskRecsSpec extends CrunchTestLike {
         val crunch = runCrunchGraph(
           now = () => SDate(scheduled),
           airportConfig = airportConfig.copy(
+            terminalNames = Seq("T1"),
             queues = Map("T1" -> Seq(Queues.EeaDesk, Queues.EGate)),
             defaultProcessingTimes = Map("T1" -> Map(
               eeaMachineReadableToDesk -> 20d / 60,

--- a/server/src/test/scala/services/crunch/SimulationSpec.scala
+++ b/server/src/test/scala/services/crunch/SimulationSpec.scala
@@ -20,7 +20,9 @@ class SimulationSpec extends Specification {
   def randomDesks: Seq[Int] = 1 to 1440 map (_ => (Math.random() * 30).toInt)
   def zeroDesks: Seq[Int] = 1 to 1440 map (_ => 0)
 
-  "Something here" >> {
+  "Given some a simulation of random loads and desks, and one of random load and zero desks " +
+    "I want to see what the memory usage difference is" >> {
+    skipped("exploratory")
 
     println(s"$randomWorkload")
     println(s"$randomDesks")

--- a/server/src/test/scala/services/crunch/SimulationSpec.scala
+++ b/server/src/test/scala/services/crunch/SimulationSpec.scala
@@ -1,0 +1,41 @@
+package services.crunch
+
+import org.specs2.mutable.Specification
+import services.{OptimizerConfig, TryRenjin}
+
+object Memory {
+  val runtime: Runtime = Runtime.getRuntime
+  val mb: Int = 1024 * 1024
+
+  def used: Long = runtime.totalMemory - runtime.freeMemory
+
+  def printUsedSince(lastUsed: Long): Unit = println(s"${(used - lastUsed) / mb}MB")
+}
+
+class SimulationSpec extends Specification {
+  val simService: (Seq[Double], Seq[Int], OptimizerConfig) => Seq[Int] = TryRenjin.runSimulationOfWork
+  val optimizerConfig = OptimizerConfig(25)
+
+  def randomWorkload: Seq[Double] = 1 to 1440 map (_ => Math.random() * 25)
+  def randomDesks: Seq[Int] = 1 to 1440 map (_ => (Math.random() * 30).toInt)
+  def zeroDesks: Seq[Int] = 1 to 1440 map (_ => 0)
+
+  "Something here" >> {
+
+    println(s"$randomWorkload")
+    println(s"$randomDesks")
+
+    memUsage(randomWorkload, randomDesks)
+    memUsage(randomWorkload, zeroDesks)
+
+    true
+  }
+
+  private def memUsage(workload: Seq[Double], desks: Seq[Int]): Unit = {
+    val used = Memory.used
+
+    simService(workload, desks, optimizerConfig)
+
+    Memory.printUsedSince(used)
+  }
+}

--- a/server/src/test/scala/services/crunch/StaffMinutesSpec.scala
+++ b/server/src/test/scala/services/crunch/StaffMinutesSpec.scala
@@ -156,10 +156,12 @@ class StaffMinutesSpec extends CrunchTestLike {
     val endDate1 = MilliDate(SDate("2017-01-01T00:14").millisSinceEpoch)
     val assignment1 = StaffAssignment("shift a", "T1", startDate1, endDate1, 10, None)
     val initialShifts = ShiftAssignments(Seq(assignment1))
+
     val startDate2 = MilliDate(SDate("2017-01-01T00:00").millisSinceEpoch)
     val endDate2 = MilliDate(SDate("2017-01-01T00:14").millisSinceEpoch)
     val assignment2 = StaffAssignment("egate monitor", "T1", startDate2, endDate2, 2, None)
     val initialFixedPoints = FixedPointAssignments(Seq(assignment2))
+
     val flight = ArrivalGenerator.apiFlight(iata = "BA0001", schDt = scheduled, actPax = Option(100))
 
     val crunch = runCrunchGraph(
@@ -309,7 +311,6 @@ class StaffMinutesSpec extends CrunchTestLike {
         val minutesInOrder = ps.crunchMinutes.values.toList.sortBy(cm => (cm.minute, cm.queueName)).take(10)
         val deployments = minutesInOrder.map(cm => (cm.queueName, SDate(cm.minute), cm.deployedDesks.getOrElse(0))).toSet
 
-        println(s"deployments: $deployments")
         deployments == expectedCrunchDeployments
     }
 

--- a/server/src/test/scala/services/crunch/WorkloadGraphStageSpec.scala
+++ b/server/src/test/scala/services/crunch/WorkloadGraphStageSpec.scala
@@ -13,6 +13,7 @@ import services.SDate
 import services.graphstages.Crunch.{LoadMinute, Loads}
 import services.graphstages.{Crunch, WorkloadGraphStage}
 
+import scala.collection.immutable.Seq
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -107,6 +108,7 @@ class WorkloadGraphStageSpec extends CrunchTestLike {
     val workloadWindow = (_: Set[ApiFlightWithSplits], _: Set[ApiFlightWithSplits]) => Option((workloadStart(SDate(scheduled)), workloadEnd(SDate(scheduled))))
     val procTimes = Map("T1" -> Map(eeaMachineReadableToDesk -> 30d / 60, visaNationalToDesk -> 60d / 60))
     val testAirportConfig = airportConfig.copy(
+      terminalNames = Seq("T1"),
       queues = Map("T1" -> Seq(Queues.EeaDesk, Queues.NonEeaDesk, Queues.Transfer)),
       defaultProcessingTimes = procTimes
     )

--- a/server/src/test/scala/services/inputfeeds/AclFeedSpec.scala
+++ b/server/src/test/scala/services/inputfeeds/AclFeedSpec.scala
@@ -184,7 +184,6 @@ class AclFeedSpec extends CrunchTestLike {
       crunch.liveTestProbe.fishForMessage(5 seconds) {
         case ps: PortState =>
           val flightsResult = ps.flights.values.map(_.apiFlight).toSet
-          println(s"flights: $flightsResult")
           flightsResult == expected
       }
 

--- a/server/src/test/scala/services/inputfeeds/StreamFlightCrunchTests.scala
+++ b/server/src/test/scala/services/inputfeeds/StreamFlightCrunchTests.scala
@@ -92,6 +92,7 @@ object TestCrunchConfig {
   def levelDbJournalDir(tn: String) = s"target/test/journal/$tn"
 
   def levelDbTestActorSystem(tn: String) = ActorSystem("testActorSystem", ConfigFactory.parseMap(Map(
+    "akka.actor.warn-about-java-serializer-usage" -> false,
     "akka.persistence.journal.plugin" -> "akka.persistence.journal.leveldb",
     "akka.persistence.no-snapshot-store.class" -> "akka.persistence.snapshot.NoSnapshotStore",
     "akka.persistence.journal.leveldb.dir" -> levelDbJournalDir(tn),


### PR DESCRIPTION
Add timing logging of all inlets and outlets
Don't merge arrivals sources on empty incoming arrivals set
Add config to test application.conf to stop unnecessary warnings:
 - use correct akka serialiser 
 - don't log dead letters
Remove some printlns from tests