### PR TITLE
DRT 5833 Fix uniqueness of arrival keys

### DIFF
--- a/server/src/main/scala/actors/AggregatedArrivalsActor.scala
+++ b/server/src/main/scala/actors/AggregatedArrivalsActor.scala
@@ -24,7 +24,7 @@ class AggregatedArrivalsActor(portCode: String, arrivalTable: ArrivalTableLike) 
 
   def handleRemovals(flightRemovals: Set[RemoveFlight]): Unit = {
     flightRemovals.foreach {
-      case RemoveFlight(UniqueArrival(number, terminalName, scheduled, _)) =>
+      case RemoveFlight(UniqueArrival(number, terminalName, scheduled)) =>
         val scheduledIso = SDate(scheduled).toISOString()
         val scheduledTs = new Timestamp(scheduled)
         log.info(s"Removing $portCode / $terminalName / $number / $scheduledIso")

--- a/server/src/main/scala/actors/ArrivalsActor.scala
+++ b/server/src/main/scala/actors/ArrivalsActor.scala
@@ -136,7 +136,7 @@ abstract class ArrivalsActor(now: () => SDateLike,
     logRecoveryMessage(s"Consuming ${diffsMessage.removals.length} removals")
     restorer.removeLegacies(diffsMessage.removalsOLD)
     restorer.remove(diffsMessage.removals.map(uam =>
-      UniqueArrival(uam.getNumber, uam.getTerminalName, uam.getScheduled, 0L)
+      UniqueArrival(uam.getNumber, uam.getTerminalName, uam.getScheduled)
     ))
   }
 
@@ -188,7 +188,7 @@ abstract class ArrivalsActor(now: () => SDateLike,
     persistFeedStatus(FeedStatusSuccess(createdAt.millisSinceEpoch, updatedArrivals.size))
     if (updatedArrivals.nonEmpty) persistArrivalUpdates(mutable.Set(), mutable.Set[Arrival]() ++ updatedArrivals)
   }
-  
+
   def persistArrivalUpdates(removals: mutable.Set[UniqueArrival], updatedArrivals: mutable.Set[Arrival]): Unit = {
     val updateMessages = updatedArrivals.map(apiFlightToFlightMessage).toSeq
     val removalMessages = removals.map(ua => UniqueArrivalMessage(Option(ua.number), Option(ua.terminalName), Option(ua.scheduled))).toSeq

--- a/server/src/main/scala/actors/CrunchStateActor.scala
+++ b/server/src/main/scala/actors/CrunchStateActor.scala
@@ -158,7 +158,7 @@ class CrunchStateActor(initialMaybeSnapshotInterval: Option[Int],
   }
 
   private def uniqueArrivalFromMessage(uam: UniqueArrivalMessage) = {
-    UniqueArrival(uam.getNumber, uam.getTerminalName, uam.getScheduled, uam.getScheduled)
+    UniqueArrival(uam.getNumber, uam.getTerminalName, uam.getScheduled)
   }
 
   def applyDiff(cdm: CrunchDiffMessage): Unit = {

--- a/server/src/test/scala/services/crunch/ArrivalUpdatesCorrectlyAffectLoads.scala
+++ b/server/src/test/scala/services/crunch/ArrivalUpdatesCorrectlyAffectLoads.scala
@@ -146,7 +146,7 @@ class ArrivalUpdatesCorrectlyAffectLoads extends CrunchTestLike {
     val flights = ps.flights
     val crunchMins = ps.crunchMinutes
 
-    val arrivalsExist = arrivals.foldLeft(true) { case (soFar, a) => soFar && flights.contains(a.uniqueId) }
+    val arrivalsExist = arrivals.foldLeft(true) { case (soFar, a) => soFar && flights.contains(a.unique) }
 
     val arrivalsPaxTotal = arrivals.map {
       _.ActPax.getOrElse(-1)


### PR DESCRIPTION
Remove pcp time field to prevent multiple keys being stored for the same arrival