### PR TITLE
Drt 5864 missing data in multi day export

### DIFF
--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -740,11 +740,11 @@ class Application @Inject()(implicit val config: Configuration,
         val startMillis = dayStartMillisWithHourOffset(startHour, pit)
         val endMillis = dayStartMillisWithHourOffset(endHour, pit)
         val portStateForPointInTime = loadBestPortStateForPointInTime(pit.millisSinceEpoch, terminalName, startMillis, endMillis)
-        exportDesksToCSV(terminalName, pit, startHour, endHour, portStateForPointInTime, true).map {
+        exportDesksToCSV(terminalName, pit, startHour, endHour, portStateForPointInTime, includeHeader = true).map {
           case Some(csvData) =>
-            Result(
-              ResponseHeader(200, Map("Content-Disposition" -> s"attachment; filename=$fileName.csv")),
-              HttpEntity.Strict(ByteString(csvData), Option("application/csv")))
+            val header = ResponseHeader(200, Map("Content-Disposition" -> s"attachment; filename=$fileName.csv"))
+            val entity = HttpEntity.Strict(ByteString(csvData), Option("application/csv"))
+            Result(header, entity)
           case None =>
             NotFound("Could not find desks and queues for this date.")
         }

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -5,11 +5,12 @@ import java.util.{Calendar, TimeZone, UUID}
 
 import actors._
 import actors.pointInTime.{CrunchStateReadActor, FixedPointsReadActor}
+import akka.NotUsed
 import akka.actor._
 import akka.event.{Logging, LoggingAdapter}
 import akka.pattern.{AskableActorRef, _}
 import akka.stream._
-import akka.stream.scaladsl.{Sink, Source}
+import akka.stream.scaladsl.{Sink, Source, StreamConverters}
 import akka.util.{ByteString, Timeout}
 import api.{KeyCloakAuth, KeyCloakAuthError, KeyCloakAuthResponse, KeyCloakAuthToken}
 import boopickle.CompositePickler
@@ -28,7 +29,7 @@ import drt.users.{KeyCloakClient, KeyCloakGroups}
 import javax.inject.{Inject, Singleton}
 import org.joda.time.chrono.ISOChronology
 import org.slf4j.{Logger, LoggerFactory}
-import play.api.http.{HeaderNames, HttpEntity}
+import play.api.http.{HeaderNames, HttpChunk, HttpEntity, Writeable}
 import play.api.libs.json._
 import play.api.mvc.{Action, _}
 import play.api.{Configuration, Environment}
@@ -739,12 +740,11 @@ class Application @Inject()(implicit val config: Configuration,
         val startMillis = dayStartMillisWithHourOffset(startHour, pit)
         val endMillis = dayStartMillisWithHourOffset(endHour, pit)
         val portStateForPointInTime = loadBestPortStateForPointInTime(pit.millisSinceEpoch, terminalName, startMillis, endMillis)
-        exportDesksToCSV(terminalName, pit, startHour, endHour, portStateForPointInTime).map {
+        exportDesksToCSV(terminalName, pit, startHour, endHour, portStateForPointInTime, true).map {
           case Some(csvData) =>
-            val columnHeadings = CSVData.terminalCrunchMinutesToCsvDataHeadings(airportConfig.queues(terminalName))
             Result(
               ResponseHeader(200, Map("Content-Disposition" -> s"attachment; filename=$fileName.csv")),
-              HttpEntity.Strict(ByteString(columnHeadings + CSVData.lineEnding + csvData), Option("application/csv")))
+              HttpEntity.Strict(ByteString(csvData), Option("application/csv")))
           case None =>
             NotFound("Could not find desks and queues for this date.")
         }
@@ -759,7 +759,8 @@ class Application @Inject()(implicit val config: Configuration,
                        pointInTime: SDateLike,
                        startHour: Int,
                        endHour: Int,
-                       portStateFuture: Future[Either[PortStateError, Option[PortState]]]
+                       portStateFuture: Future[Either[PortStateError, Option[PortState]]],
+                       includeHeader: Boolean
                       ): Future[Option[String]] = {
 
     val startDateTime = getLocalLastMidnight(pointInTime).addHours(startHour)
@@ -769,8 +770,12 @@ class Application @Inject()(implicit val config: Configuration,
     portStateFuture.map {
       case Right(Some(ps: PortState)) =>
         val wps = ps.windowWithTerminalFilter(startDateTime, endDateTime, airportConfig.queues.filterKeys(_ == terminalName))
-        log.debug(s"Exports: ${localTime.toISOString()} filtered to ${wps.crunchMinutes.size} CMs and ${wps.staffMinutes.size} SMs ")
-        Option(CSVData.terminalMinutesToCsvData(wps.crunchMinutes, wps.staffMinutes, airportConfig.queues(terminalName), startDateTime, endDateTime, 15))
+        val dataLines = CSVData.terminalMinutesToCsvData(wps.crunchMinutes, wps.staffMinutes, airportConfig.nonTransferQueues(terminalName), startDateTime, endDateTime, 15)
+        val fullData = if (includeHeader) {
+          val headerLines = CSVData.terminalCrunchMinutesToCsvDataHeadings(airportConfig.queues(terminalName))
+          headerLines + CSVData.lineEnding + dataLines
+        } else dataLines
+        Option(fullData)
 
       case unexpected =>
         log.error(s"Exports: Got the wrong thing $unexpected for Point In time: ${localTime.toISOString()}")
@@ -956,7 +961,7 @@ class Application @Inject()(implicit val config: Configuration,
   def exportDesksAndQueuesBetweenTimeStampsCSV(start: String,
                                                end: String,
                                                terminalName: TerminalName): Action[AnyContent] = authByRole(DesksAndQueuesView) {
-    Action.async {
+    Action {
       val startPit = getLocalLastMidnight(SDate(start.toLong, europeLondonTimeZone))
       val endPit = SDate(end.toLong, europeLondonTimeZone)
 
@@ -964,28 +969,31 @@ class Application @Inject()(implicit val config: Configuration,
       val fileName = makeFileName("desks-and-queues", terminalName, startPit, endPit, portCode)
 
       val dayRangeMillis = startPit.millisSinceEpoch to endPit.millisSinceEpoch by oneDayMillis
-      val daysMillisSource: Future[Seq[Option[String]]] = Source(dayRangeMillis)
+      val daysMillisSource: Source[String, NotUsed] = Source(dayRangeMillis)
         .mapAsync(config.get[Int]("multi-day-parallelism")) { millis =>
           val startHour = 0
           val endHour = 24
           val day = SDate(millis)
           val startMillis = dayStartMillisWithHourOffset(startHour, day)
           val endMillis = dayStartMillisWithHourOffset(endHour, day)
+          val includeHeader = millis == startPit.millisSinceEpoch
           exportDesksToCSV(
             terminalName = terminalName,
             pointInTime = day,
             startHour = startHour,
             endHour = endHour,
-            portStateFuture = loadBestPortStateForPointInTime(millis, terminalName, startMillis, endMillis)
+            portStateFuture = loadBestPortStateForPointInTime(millis, terminalName, startMillis, endMillis),
+            includeHeader
           )
-        }.runWith(Sink.seq)
+        }
+          .collect { case Some(dayData) => dayData + CSVData.lineEnding }
 
-      CSVData.multiDayToSingleExport(daysMillisSource).map(csvData => {
-        Result(ResponseHeader(200, Map("Content-Disposition" -> s"attachment; filename=$fileName.csv")),
-          HttpEntity.Strict(ByteString(
-            CSVData.terminalCrunchMinutesToCsvDataHeadings(airportConfig.queues(terminalName)) + CSVData.lineEnding + csvData
-          ), Option("application/csv")))
-      })
+      implicit val writeable = Writeable((str: String) => ByteString.fromString(str), Option("application/csv"))
+
+      Result(
+        header = ResponseHeader(200, Map("Content-Disposition" -> s"attachment; filename=$fileName.csv")),
+        body = HttpEntity.Chunked(daysMillisSource.map(c => HttpChunk.Chunk(writeable.transform(c))), writeable.contentType)
+      )
     }
   }
 

--- a/server/src/test/scala/services/crunch/CrunchMinutesToCSVDataTest.scala
+++ b/server/src/test/scala/services/crunch/CrunchMinutesToCSVDataTest.scala
@@ -1,10 +1,12 @@
 package services.crunch
 
 import drt.shared.CrunchApi.{CrunchMinute, StaffMinute}
-import drt.shared.Queues
+import drt.shared.{Queues, TM, TQM}
 import org.specs2.matcher.Scope
 import org.specs2.mutable.Specification
 import services.{CSVData, SDate}
+
+import scala.collection.SortedMap
 
 class CrunchMinutesToCSVDataTest extends Specification {
 
@@ -15,22 +17,19 @@ class CrunchMinutesToCSVDataTest extends Specification {
 
   "Given a set of crunch minutes for a terminal, we should receive a CSV for that terminals data" in new Context {
     val startDateTime = SDate("2017-11-10T00:00:00Z")
-    val cms = List(
+    val cms = SortedMap[TQM, CrunchMinute]() ++ List(
       CrunchMinute("T1", "Q1", startDateTime.millisSinceEpoch, 1.1, 1, deskRec = 1, 1),
       CrunchMinute("T1", "Q3", startDateTime.millisSinceEpoch, 1.3, 1, deskRec = 1, 1),
-      CrunchMinute("T2", "Q1", startDateTime.millisSinceEpoch, 1.0, 1, deskRec = 1, 1),
       CrunchMinute("T1", "Q2", startDateTime.millisSinceEpoch, 1.2, 1, deskRec = 1, 1)
-    )
+    ).map(cm => (cm.key, cm))
 
-    val staffMins = List(
+    val staffMins = SortedMap[TM, StaffMinute]() ++ List(
       StaffMinute("T1", startDateTime.millisSinceEpoch, 5, fixedPoints = 1, movements = -1)
-    )
+    ).map(sm => (sm.key, sm))
 
-    val result = CSVData.terminalCrunchMinutesToCsvDataWithHeadings(cms, staffMins, "T1", List("Q1", "Q2", "Q3"))
+    val result = CSVData.terminalMinutesToCsvData(cms, staffMins, Seq("Q1", "Q2", "Q3"), startDateTime, startDateTime.addMinutes(14), 15)
 
-    val expected =
-      s"""$header
-         |2017-11-10,00:00,1,1,1,,,1,1,1,,,1,1,1,,,1,-1,4,4""".stripMargin
+    val expected = s"2017-11-10,00:00,1,1,1,,,1,1,1,,,1,1,1,,,1,-1,4,4"
 
     result === expected
   }
@@ -42,23 +41,22 @@ class CrunchMinutesToCSVDataTest extends Specification {
     val t14mins = startDateTime.addMinutes(14).millisSinceEpoch
     val t13mins = startDateTime.addMinutes(13).millisSinceEpoch
 
-    val cms = (0 until 16).flatMap((min: Int) => {
+    val cms = SortedMap[TQM, CrunchMinute]() ++ (0 until 16).flatMap((min: Int) => {
       List(
         CrunchMinute("T1", "Q1", startDateTime.addMinutes(min).millisSinceEpoch, 1.0, 1, deskRec = 1, 1),
         CrunchMinute("T1", "Q2", startDateTime.addMinutes(min).millisSinceEpoch, 1.0, 1, deskRec = 1, 1),
         CrunchMinute("T1", "Q3", startDateTime.addMinutes(min).millisSinceEpoch, 1.0, 1, deskRec = 1, 1)
       )
-    }).toList
+    }).map(cm => (cm.key, cm))
 
-    val staffMins = (0 until 16).map((min: Int) => {
+    val staffMins = SortedMap[TM, StaffMinute]() ++ (0 until 16).map((min: Int) => {
       StaffMinute("T1", startDateTime.addMinutes(min).millisSinceEpoch, 5, fixedPoints = 1, movements = -1)
-    }).toList
+    }).map(sm => (sm.key, sm))
 
-    val result = CSVData.terminalCrunchMinutesToCsvDataWithHeadings(cms, staffMins, "T1", List("Q1", "Q2", "Q3"))
+    val result = CSVData.terminalMinutesToCsvData(cms, staffMins, Seq("Q1", "Q2", "Q3"), startDateTime, startDateTime.addMinutes(29), 15)
 
     val expected =
-      s"""$header
-         |2017-11-10,00:00,15,1,1,,,15,1,1,,,15,1,1,,,1,-1,4,4
+      s"""2017-11-10,00:00,15,1,1,,,15,1,1,,,15,1,1,,,1,-1,4,4
          |2017-11-10,00:15,1,1,1,,,1,1,1,,,1,1,1,,,1,-1,4,4""".stripMargin
 
     result === expected
@@ -66,40 +64,38 @@ class CrunchMinutesToCSVDataTest extends Specification {
 
   "When exporting data, column names and order must exactly match V1" in {
     val startDateTime = SDate("2017-11-10T00:00:00Z")
-    val cms = List(
+    val cms = SortedMap[TQM, CrunchMinute]() ++ List(
       CrunchMinute("T1", Queues.EeaDesk, startDateTime.millisSinceEpoch, 1.0, 2.0, deskRec = 1, 100, Option(2), Option(100), Option(2), Option(100)),
       CrunchMinute("T1", Queues.EGate, startDateTime.millisSinceEpoch, 1.0, 2.0, deskRec = 1, 100, Option(2), Option(100), Option(2), Option(100)),
       CrunchMinute("T1", Queues.NonEeaDesk, startDateTime.millisSinceEpoch, 1.0, 2.0, deskRec = 1, 100, Option(2), Option(100), Option(2), Option(100))
-    )
+    ).map(cm => (cm.key, cm))
 
-    val staffMins = List(
+    val staffMins = SortedMap[TM, StaffMinute]() ++ List(
       StaffMinute("T1", startDateTime.millisSinceEpoch, 5, fixedPoints = 1, movements = -1)
-    )
+    ).map(sm => (sm.key, sm))
 
-    val expected = """|Date,,EEA,EEA,EEA,EEA,EEA,Non-EEA,Non-EEA,Non-EEA,Non-EEA,Non-EEA,e-Gates,e-Gates,e-Gates,e-Gates,e-Gates,Misc,Moves,PCP Staff,PCP Staff
-                      |,Start,Pax,Wait,Desks req,Act. wait time,Act. desks,Pax,Wait,Desks req,Act. wait time,Act. desks,Pax,Wait,Staff req,Act. wait time,Act. desks,Staff req,Staff movements,Avail,Req
-                      |2017-11-10,00:00,1,100,1,100,2,1,100,1,100,2,1,100,1,100,2,1,-1,4,4""".stripMargin
+    val expected = "2017-11-10,00:00,1,100,1,100,2,1,100,1,100,2,1,100,1,100,2,1,-1,4,4"
 
-    val result = CSVData.terminalCrunchMinutesToCsvDataWithHeadings(cms, staffMins, "T1", Queues.exportQueueOrderSansFastTrack)
+    val result = CSVData.terminalMinutesToCsvData(cms, staffMins, Seq(Queues.EeaDesk, Queues.EGate, Queues.NonEeaDesk), startDateTime, startDateTime.addMinutes(14), 15)
 
     result === expected
   }
 
   "When exporting data without headings, then we should not get headings back" >> {
     val startDateTime = SDate("2017-11-10T00:00:00Z")
-    val cms = List(
+    val cms = SortedMap[TQM, CrunchMinute]() ++ List(
       CrunchMinute("T1", Queues.EeaDesk, startDateTime.millisSinceEpoch, 1.0, 2.0, deskRec = 1, 100, Option(2), Option(100), Option(2), Option(100)),
       CrunchMinute("T1", Queues.EGate, startDateTime.millisSinceEpoch, 1.0, 2.0, deskRec = 1, 100, Option(2), Option(100), Option(2), Option(100)),
       CrunchMinute("T1", Queues.NonEeaDesk, startDateTime.millisSinceEpoch, 1.0, 2.0, deskRec = 1, 100, Option(2), Option(100), Option(2), Option(100))
-    )
+    ).map(cm => (cm.key, cm))
 
-    val staffMins = List(
+    val staffMins = SortedMap[TM, StaffMinute]() ++ List(
       StaffMinute("T1", startDateTime.millisSinceEpoch, 5, fixedPoints = 1, movements = -1)
-    )
+    ).map(sm => (sm.key, sm))
 
-    val expected = """2017-11-10,00:00,1,100,1,100,2,1,100,1,100,2,1,100,1,100,2,1,-1,4,4""".stripMargin
+    val expected = "2017-11-10,00:00,1,100,1,100,2,1,100,1,100,2,1,100,1,100,2,1,-1,4,4"
 
-    val result = CSVData.terminalCrunchMinutesToCsvData(cms, staffMins, "T1", Queues.exportQueueOrderSansFastTrack)
+    val result = CSVData.terminalMinutesToCsvData(cms, staffMins, Seq(Queues.EeaDesk, Queues.EGate, Queues.NonEeaDesk), startDateTime, startDateTime.addMinutes(14), 15)
 
     result === expected
   }

--- a/server/src/test/scala/services/export/DesksAndQueuesExportSpec.scala
+++ b/server/src/test/scala/services/export/DesksAndQueuesExportSpec.scala
@@ -60,7 +60,7 @@ class DesksAndQueuesExportSpec extends SpecificationLike {
       val allCms = mutable.SortedMap(cmNoon05.key -> cmNoon05)
       val result = queueSummariesForPeriod(allCms, queues, summaryStart, summaryPeriodMinutes)
 
-      result === Seq(QueueSummary(pax, deskRec, waitTime, Option(actDesk), Option(actWait)), QueueSummary(0, 0, 0, None, None))
+      result === Seq(QueueSummary(pax, deskRec, waitTime, Option(actDesk), Option(actWait)), EmptyQueueSummary)
     }
 
     "When I ask for a staff summary for a certain period " +

--- a/server/src/test/scala/services/export/DesksAndQueuesExportSpec.scala
+++ b/server/src/test/scala/services/export/DesksAndQueuesExportSpec.scala
@@ -1,48 +1,96 @@
 package services.export
 
-import drt.shared.CrunchApi.CrunchMinute
-import drt.shared.Queues
+import drt.shared.CrunchApi.{CrunchMinute, StaffMinute}
+import drt.shared._
 import org.specs2.mutable.SpecificationLike
 import services.SDate
 
+import scala.collection.mutable
+
 class DesksAndQueuesExportSpec extends SpecificationLike {
+
+  import Summaries._
+
   val terminalQueues = Map("T1" -> Seq(Queues.EeaDesk, Queues.NonEeaDesk))
-  "Given one crunch minute for a terminal " +
-    "When asking for an hour's worth of 15 summaries by queue " +
-    "I should see numbers from the crunch minute, and zeros where there was no data" >> {
-    val terminal = "T1"
-    val noon05 = SDate("2019-01-01T12:05:00")
-    val summaryStart = SDate("2019-01-01T12:00")
-    val summaryHours = 1
-    val summaryPeriodMinutes = 15
-    val cmNoon05 = CrunchMinute(terminal, Queues.EeaDesk, noon05.millisSinceEpoch, 5, 6, 7, 8, Option(9), Option(10), Option(11), Option(12))
 
-    for {
-      queue <- terminalQueues(terminal)
-      summaryPeriodStart <- summaryStart.millisSinceEpoch until summaryStart.addHours(summaryHours).millisSinceEpoch by (summaryPeriodMinutes * 60000L)
-    } yield {
+  "Given a list of optional ints where there are no values " +
+    "When I ask for the max value" +
+    "I should see None" >> {
+    val optionalInts: Seq[Option[Int]] = List(None, None, None)
+    val maxInt: Option[Int] = optionalMax(optionalInts)
 
-    }
-
+    maxInt === None
   }
 
-//  "Given some crunch minutes for a terminal " +
-//    "When asking for a 15 summary by queue " +
-//    "I should see appropriate numbers from the crunch minutes, and blanks where there was no data" >> {
-//    val noon05 = SDate("2019-01-01T12:05:00")
-//    val noon20 = SDate("2019-01-01T12:20:00")
-//    val cmNoon05 = CrunchMinute("T1", Queues.EeaDesk, noon05.millisSinceEpoch, 5, 6, 7, 8, Option(9), Option(10), Option(11), Option(12))
-//    val cmNoon02 = incCmNos(cmNoon05).copy(minute = noon05.addMinutes(-1).millisSinceEpoch)
-//  }
+  "Given a list of optional ints where there are some values and some Nones " +
+    "When I ask for the max value" +
+    "I should see Option(max value)" >> {
+    val optionalInts: Seq[Option[Int]] = List(None, Option(10), Option(2), None)
+    val maxInt: Option[Int] = optionalMax(optionalInts)
 
-  def incCmNos(cm: CrunchMinute): CrunchMinute = cm.copy(
-    paxLoad = cm.paxLoad + 1,
-    workLoad = cm.workLoad + 1,
-    deskRec = cm.deskRec+ 1,
-    waitTime = cm.waitTime + 1,
-    deployedDesks = cm.deployedDesks.map(_ + 1),
-    deployedWait = cm.deployedWait.map(_ + 1),
-    actDesks = cm.actDesks.map(_ + 1),
-    actWait = cm.actWait.map(_ + 1)
-  )
+    maxInt === Option(10)
+  }
+
+  "Given a SortedMap of a single CrunchMinute with a TQM key and a SortedMap of a single StaffMinute with a TM key " >> {
+    val terminal = "T1"
+    val queues = Seq(Queues.EeaDesk, Queues.NonEeaDesk)
+
+    val noon05 = SDate("2019-01-01T12:05:00")
+
+    val pax = 5
+    val deskRec = 7
+    val waitTime = 8
+    val depDesk = 9
+    val depWait = 10
+    val actDesk = 11
+    val actWait = 12
+    val cmNoon05 = CrunchMinute(terminal, Queues.EeaDesk, noon05.millisSinceEpoch, pax, 6, deskRec, waitTime, Option(depDesk), Option(depWait), Option(actDesk), Option(actWait))
+    val shifts = 2
+    val misc = 3
+    val moves = 4
+    val totalRec = deskRec + misc
+    val smNoon05 = StaffMinute(terminal, noon05.millisSinceEpoch, shifts, misc, moves)
+
+    val summaryStart = SDate("2019-01-01T12:00")
+    val summaryPeriodMinutes = 15
+
+    "When I ask for a queue summaries for a certain period " +
+      "I should get the appropriate max or min values, or defaults where there was no data" >> {
+
+      val allCms = mutable.SortedMap(cmNoon05.key -> cmNoon05)
+      val result = queueSummariesForPeriod(allCms, queues, summaryStart, summaryPeriodMinutes)
+
+      result === Seq(QueueSummary(pax, deskRec, waitTime, Option(actDesk), Option(actWait)), QueueSummary(0, 0, 0, None, None))
+    }
+
+    "When I ask for a staff summary for a certain period " +
+      "I should get the appropriate max or min values, or defaults where there was no data" >> {
+
+      val allSms = mutable.SortedMap(smNoon05.key -> smNoon05)
+      val allCms = mutable.SortedMap(cmNoon05.key -> cmNoon05)
+      val queueSummaries = queueSummariesForPeriod(allCms, queues, summaryStart, summaryPeriodMinutes)
+
+      val smResult = staffSummaryForPeriod(allSms, queueSummaries, summaryStart, summaryPeriodMinutes)
+
+      smResult === StaffSummary(shifts + moves, misc, moves, totalRec)
+    }
+
+    "When I ask for a TerminalSummary for a certain period " >> {
+      val allSms = mutable.SortedMap(smNoon05.key -> smNoon05)
+      val allCms = mutable.SortedMap(cmNoon05.key -> cmNoon05)
+
+      val queueSummaries = queueSummariesForPeriod(allCms, queues, summaryStart, summaryPeriodMinutes)
+      val smResult = staffSummaryForPeriod(allSms, queueSummaries, summaryStart, summaryPeriodMinutes)
+
+      val tSummary = terminalSummaryForPeriod(allCms, allSms, queues, summaryStart, summaryPeriodMinutes)
+
+      "I should get the appropriate Queue and Staff summaries" >> {
+        tSummary === TerminalSummary(summaryStart, queueSummaries, smResult)
+      }
+
+      "I should get a correctly formatted csv live when requested" >> {
+        tSummary.toCsv === s"2019-01-01,12:00,$pax,$waitTime,$deskRec,$actWait,$actDesk,0,0,0,,,$misc,$moves,${shifts + moves},$totalRec"
+      }
+    }
+  }
 }

--- a/server/src/test/scala/services/export/DesksAndQueuesExportSpec.scala
+++ b/server/src/test/scala/services/export/DesksAndQueuesExportSpec.scala
@@ -1,0 +1,48 @@
+package services.export
+
+import drt.shared.CrunchApi.CrunchMinute
+import drt.shared.Queues
+import org.specs2.mutable.SpecificationLike
+import services.SDate
+
+class DesksAndQueuesExportSpec extends SpecificationLike {
+  val terminalQueues = Map("T1" -> Seq(Queues.EeaDesk, Queues.NonEeaDesk))
+  "Given one crunch minute for a terminal " +
+    "When asking for an hour's worth of 15 summaries by queue " +
+    "I should see numbers from the crunch minute, and zeros where there was no data" >> {
+    val terminal = "T1"
+    val noon05 = SDate("2019-01-01T12:05:00")
+    val summaryStart = SDate("2019-01-01T12:00")
+    val summaryHours = 1
+    val summaryPeriodMinutes = 15
+    val cmNoon05 = CrunchMinute(terminal, Queues.EeaDesk, noon05.millisSinceEpoch, 5, 6, 7, 8, Option(9), Option(10), Option(11), Option(12))
+
+    for {
+      queue <- terminalQueues(terminal)
+      summaryPeriodStart <- summaryStart.millisSinceEpoch until summaryStart.addHours(summaryHours).millisSinceEpoch by (summaryPeriodMinutes * 60000L)
+    } yield {
+
+    }
+
+  }
+
+//  "Given some crunch minutes for a terminal " +
+//    "When asking for a 15 summary by queue " +
+//    "I should see appropriate numbers from the crunch minutes, and blanks where there was no data" >> {
+//    val noon05 = SDate("2019-01-01T12:05:00")
+//    val noon20 = SDate("2019-01-01T12:20:00")
+//    val cmNoon05 = CrunchMinute("T1", Queues.EeaDesk, noon05.millisSinceEpoch, 5, 6, 7, 8, Option(9), Option(10), Option(11), Option(12))
+//    val cmNoon02 = incCmNos(cmNoon05).copy(minute = noon05.addMinutes(-1).millisSinceEpoch)
+//  }
+
+  def incCmNos(cm: CrunchMinute): CrunchMinute = cm.copy(
+    paxLoad = cm.paxLoad + 1,
+    workLoad = cm.workLoad + 1,
+    deskRec = cm.deskRec+ 1,
+    waitTime = cm.waitTime + 1,
+    deployedDesks = cm.deployedDesks.map(_ + 1),
+    deployedWait = cm.deployedWait.map(_ + 1),
+    actDesks = cm.actDesks.map(_ + 1),
+    actWait = cm.actWait.map(_ + 1)
+  )
+}

--- a/shared/src/main/scala/drt/shared/Summaries.scala
+++ b/shared/src/main/scala/drt/shared/Summaries.scala
@@ -70,6 +70,7 @@ object Summaries {
     val totalMoves = if (moves.nonEmpty) moves.min else 0
     val queueRecs = if (queueSummaries.nonEmpty) queueSummaries.map(_.deskRecs).sum else 0
     val totalRec = queueRecs + totalMisc
-    StaffSummary(avail.max, totalMisc, totalMoves, totalRec)
+    val available = if (avail.nonEmpty) avail.max else 0
+    StaffSummary(available, totalMisc, totalMoves, totalRec)
   }
 }

--- a/shared/src/main/scala/drt/shared/Summaries.scala
+++ b/shared/src/main/scala/drt/shared/Summaries.scala
@@ -48,7 +48,10 @@ object Summaries {
             case ((sp, sd, sw, sad, saw), (_, CrunchMinute(_, _, _, p, _, d, w, _, _, ad, aw, _))) =>
               (p :: sp, d :: sd, w :: sw, ad :: sad, aw :: saw)
           }
-          QueueSummary(pax.sum, desks.max, waits.max, optionalMax(actDesks), optionalMax(actWaits))
+          val totalPax = if (pax.nonEmpty) pax.sum else 0
+          val maxDesks = if (desks.nonEmpty) desks.max else 0
+          val maxWait = if (waits.nonEmpty) waits.max else 0
+          QueueSummary(totalPax, maxDesks, maxWait, optionalMax(actDesks), optionalMax(actWaits))
       }
     }
   }
@@ -63,9 +66,10 @@ object Summaries {
       case ((fp, mm, av), (_, StaffMinute(_, _, s, f, m, _))) =>
         (f :: fp, m :: mm, (s + m) :: av)
     }
-    val totalMisc = fixed.max
-    val totalMoves = moves.min
-    val totalRec = queueSummaries.map(_.deskRecs).sum + totalMisc
+    val totalMisc = if (fixed.nonEmpty) fixed.max else 0
+    val totalMoves = if (moves.nonEmpty) moves.min else 0
+    val queueRecs = if (queueSummaries.nonEmpty) queueSummaries.map(_.deskRecs).sum else 0
+    val totalRec = queueRecs + totalMisc
     StaffSummary(avail.max, totalMisc, totalMoves, totalRec)
   }
 }

--- a/shared/src/main/scala/drt/shared/Summaries.scala
+++ b/shared/src/main/scala/drt/shared/Summaries.scala
@@ -4,15 +4,49 @@ import drt.shared.CrunchApi.{CrunchMinute, MillisSinceEpoch, StaffMinute}
 
 import scala.collection.SortedMap
 
-case class QueueSummary(pax: Double, deskRecs: Int, waitTime: Int, actDesks: Option[Int], actWaitTime: Option[Int]) {
+sealed trait QueueSummaryLike {
+  val pax: Double
+  val deskRecs: Int
+  val waitTime: Int
+  val actDesks: Option[Int]
+  val actWaitTime: Option[Int]
+  val toCsv: String
+}
+
+case object EmptyQueueSummary extends QueueSummaryLike {
+  override val pax: Double = 0d
+  override val deskRecs: Int = 0
+  override val waitTime: Int = 0
+  override val actDesks: Option[Int] = None
+  override val actWaitTime: Option[Int] = None
+  override val toCsv: String = "0,0,0,,"
+}
+
+case class QueueSummary(pax: Double, deskRecs: Int, waitTime: Int, actDesks: Option[Int], actWaitTime: Option[Int]) extends QueueSummaryLike {
   lazy val toCsv: String = s"${Math.round(pax)},$waitTime,$deskRecs,${actWaitTime.getOrElse("")},${actDesks.getOrElse("")}"
 }
 
-case class StaffSummary(available: Int, misc: Int, moves: Int, recommended: Int) {
+sealed trait StaffSummaryLike {
+  val available: Int
+  val misc: Int
+  val moves: Int
+  val recommended: Int
+  val toCsv: String
+}
+
+case object EmptyStaffSummary extends StaffSummaryLike {
+  override val available: Int = 0
+  override val misc: Int = 0
+  override val moves: Int = 0
+  override val recommended: Int = 0
+  override val toCsv: String = s"0,0,0,0"
+}
+
+case class StaffSummary(available: Int, misc: Int, moves: Int, recommended: Int) extends StaffSummaryLike {
   lazy val toCsv: String = s"$misc,$moves,$available,$recommended"
 }
 
-case class TerminalSummary(start: SDateLike, queueSummaries: Seq[QueueSummary], staffSummary: StaffSummary) {
+case class TerminalSummary(start: SDateLike, queueSummaries: Seq[QueueSummaryLike], staffSummary: StaffSummaryLike) {
   lazy val toCsv = s"${start.toISODateOnly},${start.toHoursAndMinutes()},${queueSummaries.map(_.toCsv).mkString(",")},${staffSummary.toCsv}"
 }
 
@@ -33,7 +67,7 @@ object Summaries {
     TerminalSummary(start = summaryStart, queueSummaries = queueSummaries, staffSummary = smResult)
   }
 
-  def queueSummariesForPeriod(terminalCms: SortedMap[TQM, CrunchMinute], queues: Seq[String], summaryStart: SDateLike, summaryMinutes: Int): Seq[QueueSummary] = {
+  def queueSummariesForPeriod(terminalCms: SortedMap[TQM, CrunchMinute], queues: Seq[String], summaryStart: SDateLike, summaryMinutes: Int): Seq[QueueSummaryLike] = {
     val startMillis = summaryStart.millisSinceEpoch
     val endMillis = summaryStart.addMinutes(summaryMinutes).millisSinceEpoch
 
@@ -42,7 +76,7 @@ object Summaries {
 
     queues.map { queue =>
       byQueue.get(queue) match {
-        case None => QueueSummary(0d, 0, 0, None, None)
+        case None => EmptyQueueSummary
         case Some(queueMins) =>
           val (pax, desks, waits, actDesks, actWaits) = queueMins.foldLeft((List[Double](), List[Int](), List[Int](), List[Option[Int]](), List[Option[Int]]())) {
             case ((sp, sd, sw, sad, saw), (_, CrunchMinute(_, _, _, p, _, d, w, _, _, ad, aw, _))) =>
@@ -56,21 +90,24 @@ object Summaries {
     }
   }
 
-  def staffSummaryForPeriod(terminalSms: SortedMap[TM, StaffMinute], queueSummaries: Seq[QueueSummary], summaryStart: SDateLike, summaryMinutes: Int): StaffSummary = {
+  def staffSummaryForPeriod(terminalSms: SortedMap[TM, StaffMinute], queueSummaries: Seq[QueueSummaryLike], summaryStart: SDateLike, summaryMinutes: Int): StaffSummaryLike = {
     val startMillis = summaryStart.millisSinceEpoch
     val endMillis = summaryStart.addMinutes(summaryMinutes).millisSinceEpoch
 
     val minutes = minutesForPeriod(startMillis, endMillis, TM.atTime, terminalSms)
 
-    val (fixed, moves, avail) = minutes.foldLeft((List[Int](), List[Int](), List[Int]())) {
-      case ((fp, mm, av), (_, StaffMinute(_, _, s, f, m, _))) =>
-        (f :: fp, m :: mm, (s + m) :: av)
+    if (minutes.isEmpty) EmptyStaffSummary
+    else {
+      val (fixed, moves, avail) = minutes.foldLeft((List[Int](), List[Int](), List[Int]())) {
+        case ((fp, mm, av), (_, StaffMinute(_, _, s, f, m, _))) =>
+          (f :: fp, m :: mm, (s + m) :: av)
+      }
+      val totalMisc = fixed.max
+      val totalMoves = moves.min
+      val queueRecs = if (queueSummaries.nonEmpty) queueSummaries.map(_.deskRecs).sum else 0
+      val totalRec = queueRecs + totalMisc
+      val available = avail.max
+      StaffSummary(available, totalMisc, totalMoves, totalRec)
     }
-    val totalMisc = if (fixed.nonEmpty) fixed.max else 0
-    val totalMoves = if (moves.nonEmpty) moves.min else 0
-    val queueRecs = if (queueSummaries.nonEmpty) queueSummaries.map(_.deskRecs).sum else 0
-    val totalRec = queueRecs + totalMisc
-    val available = if (avail.nonEmpty) avail.max else 0
-    StaffSummary(available, totalMisc, totalMoves, totalRec)
   }
 }

--- a/shared/src/main/scala/drt/shared/Summaries.scala
+++ b/shared/src/main/scala/drt/shared/Summaries.scala
@@ -1,0 +1,71 @@
+package drt.shared
+
+import drt.shared.CrunchApi.{CrunchMinute, MillisSinceEpoch, StaffMinute}
+
+import scala.collection.SortedMap
+
+case class QueueSummary(pax: Double, deskRecs: Int, waitTime: Int, actDesks: Option[Int], actWaitTime: Option[Int]) {
+  lazy val toCsv: String = s"${Math.round(pax)},$waitTime,$deskRecs,${actWaitTime.getOrElse("")},${actDesks.getOrElse("")}"
+}
+
+case class StaffSummary(available: Int, misc: Int, moves: Int, recommended: Int) {
+  lazy val toCsv: String = s"$misc,$moves,$available,$recommended"
+}
+
+case class TerminalSummary(start: SDateLike, queueSummaries: Seq[QueueSummary], staffSummary: StaffSummary) {
+  lazy val toCsv = s"${start.toISODateOnly},${start.toHoursAndMinutes()},${queueSummaries.map(_.toCsv).mkString(",")},${staffSummary.toCsv}"
+}
+
+
+object Summaries {
+  def optionalMax(optionalInts: Seq[Option[Int]]): Option[Int] = {
+    val ints = optionalInts.flatten
+    if (ints.isEmpty) None else Option(ints.max)
+  }
+
+  def minutesForPeriod[A, B](startMillis: MillisSinceEpoch, endMillis: MillisSinceEpoch, atTime: MillisSinceEpoch => A, data: SortedMap[A, B]): SortedMap[A, B] =
+    data.range(atTime(startMillis), atTime(endMillis))
+
+  def terminalSummaryForPeriod(terminalCms: SortedMap[TQM, CrunchMinute], terminalSms: SortedMap[TM, StaffMinute], queues: Seq[String], summaryStart: SDateLike, summaryPeriodMinutes: Int): TerminalSummary = {
+    val queueSummaries = Summaries.queueSummariesForPeriod(terminalCms, queues, summaryStart, summaryPeriodMinutes)
+    val smResult = Summaries.staffSummaryForPeriod(terminalSms, queueSummaries, summaryStart, summaryPeriodMinutes)
+
+    TerminalSummary(start = summaryStart, queueSummaries = queueSummaries, staffSummary = smResult)
+  }
+
+  def queueSummariesForPeriod(terminalCms: SortedMap[TQM, CrunchMinute], queues: Seq[String], summaryStart: SDateLike, summaryMinutes: Int): Seq[QueueSummary] = {
+    val startMillis = summaryStart.millisSinceEpoch
+    val endMillis = summaryStart.addMinutes(summaryMinutes).millisSinceEpoch
+
+    val byQueue = minutesForPeriod(startMillis, endMillis, TQM.atTime, terminalCms)
+      .groupBy { case (tqm, _) => tqm.queueName }
+
+    queues.map { queue =>
+      byQueue.get(queue) match {
+        case None => QueueSummary(0d, 0, 0, None, None)
+        case Some(queueMins) =>
+          val (pax, desks, waits, actDesks, actWaits) = queueMins.foldLeft((List[Double](), List[Int](), List[Int](), List[Option[Int]](), List[Option[Int]]())) {
+            case ((sp, sd, sw, sad, saw), (_, CrunchMinute(_, _, _, p, _, d, w, _, _, ad, aw, _))) =>
+              (p :: sp, d :: sd, w :: sw, ad :: sad, aw :: saw)
+          }
+          QueueSummary(pax.sum, desks.max, waits.max, optionalMax(actDesks), optionalMax(actWaits))
+      }
+    }
+  }
+
+  def staffSummaryForPeriod(terminalSms: SortedMap[TM, StaffMinute], queueSummaries: Seq[QueueSummary], summaryStart: SDateLike, summaryMinutes: Int): StaffSummary = {
+    val startMillis = summaryStart.millisSinceEpoch
+    val endMillis = summaryStart.addMinutes(summaryMinutes).millisSinceEpoch
+
+    val minutes = minutesForPeriod(startMillis, endMillis, TM.atTime, terminalSms)
+
+    val (fixed, moves, avail) = minutes.foldLeft((List[Int](), List[Int](), List[Int]())) {
+      case ((fp, mm, av), (_, StaffMinute(_, _, s, f, m, _))) =>
+        (f :: fp, m :: mm, (s + m) :: av)
+    }
+    val totalMisc = fixed.max
+    val totalMoves = moves.min
+    val totalRec = queueSummaries.map(_.deskRecs).sum + totalMisc
+    StaffSummary(avail.max, totalMisc, totalMoves, totalRec)
+  }
+}


### PR DESCRIPTION
Reworking of the export. No longer assumes data exists for every minute. Empty data is now filled in with appropriate zeros or empty cells.

Days are processed sequentially in a stream rather than waiting for all data before processing. This reduces the memory footprint

Also addresses DRT-5862 - streaming data to the browser