### PR TITLE
Drtii 5 missing historic manifests for long range forecast

### DIFF
--- a/server/src/main/scala/actors/DrtSystem.scala
+++ b/server/src/main/scala/actors/DrtSystem.scala
@@ -114,7 +114,7 @@ case class DrtConfigParameters(config: Configuration) {
     log.warn("Refresh arrivals flag is active. Turning on historic manifest refresh")
     true
   } else config.getOptional[Boolean]("crunch.manifests.reset-registered-arrivals-on-start").getOrElse(false)
-  
+
   val useNationalityBasedProcessingTimes: Boolean = config.getOptional[String]("feature-flags.nationality-based-processing-times").isDefined
 
   val manifestLookupBatchSize: Int = config.getOptional[Int]("crunch.manifests.lookup-batch-size").getOrElse(10)

--- a/server/src/main/scala/actors/DrtSystem.scala
+++ b/server/src/main/scala/actors/DrtSystem.scala
@@ -37,6 +37,7 @@ import manifests.graph.{BatchStage, ManifestsGraph}
 import manifests.passengers.{BestAvailableManifest, S3ManifestPoller}
 import org.apache.spark.sql.SparkSession
 import org.joda.time.DateTimeZone
+import org.slf4j.{Logger, LoggerFactory}
 import play.api.Configuration
 import play.api.mvc.{Headers, Session}
 import server.feeds.{ArrivalsFeedResponse, ArrivalsFeedSuccess, ManifestsFeedResponse}
@@ -88,6 +89,8 @@ object PostgresTables extends {
 } with Tables
 
 case class DrtConfigParameters(config: Configuration) {
+  val log: Logger = LoggerFactory.getLogger(getClass)
+
   val forecastMaxDays: Int = config.get[Int]("crunch.forecast.max_days")
   val aclPollMinutes: Int = config.get[Int]("crunch.forecast.poll_minutes")
   val snapshotIntervalVm: Int = config.getOptional[Int]("persistence.snapshot-interval.voyage-manifest").getOrElse(1000)
@@ -107,7 +110,11 @@ case class DrtConfigParameters(config: Configuration) {
   val path: String = ConfigFactory.load.getString("acl.keypath")
   val refreshArrivalsOnStart: Boolean = config.getOptional[Boolean]("crunch.refresh-arrivals-on-start").getOrElse(false)
   val recrunchOnStart: Boolean = config.getOptional[Boolean]("crunch.recrunch-on-start").getOrElse(false)
-  val resetRegisteredArrivalOnStart: Boolean = config.getOptional[Boolean]("crunch.manifests.reset-registered-arrivals-on-start").getOrElse(false)
+  val resetRegisteredArrivalOnStart: Boolean = if (refreshArrivalsOnStart) {
+    log.warn("Refresh arrivals flag is active. Turning on historic manifest refresh")
+    true
+  } else config.getOptional[Boolean]("crunch.manifests.reset-registered-arrivals-on-start").getOrElse(false)
+  
   val useNationalityBasedProcessingTimes: Boolean = config.getOptional[String]("feature-flags.nationality-based-processing-times").isDefined
 
   val manifestLookupBatchSize: Int = config.getOptional[Int]("crunch.manifests.lookup-batch-size").getOrElse(10)

--- a/server/src/main/scala/services/graphstages/Crunch.scala
+++ b/server/src/main/scala/services/graphstages/Crunch.scala
@@ -91,6 +91,8 @@ object Crunch {
     val soonWithExpiredLookup = isWithinHours(scheduled, 48, now) && !wasWithinHours(lastLookupMillis, 24, now)
     val notSoonWithExpiredLookup = !isWithinHours(scheduled, 48, now) && !wasWithinHours(lastLookupMillis, 24 * 7, now)
 
+    println(s"soonWithExpiredLookup: $soonWithExpiredLookup, notSoonWithExpiredLookup: $notSoonWithExpiredLookup")
+
     soonWithExpiredLookup || notSoonWithExpiredLookup
   }
 

--- a/server/src/main/scala/services/graphstages/Crunch.scala
+++ b/server/src/main/scala/services/graphstages/Crunch.scala
@@ -91,8 +91,6 @@ object Crunch {
     val soonWithExpiredLookup = isWithinHours(scheduled, 48, now) && !wasWithinHours(lastLookupMillis, 24, now)
     val notSoonWithExpiredLookup = !isWithinHours(scheduled, 48, now) && !wasWithinHours(lastLookupMillis, 24 * 7, now)
 
-    println(s"soonWithExpiredLookup: $soonWithExpiredLookup, notSoonWithExpiredLookup: $notSoonWithExpiredLookup")
-
     soonWithExpiredLookup || notSoonWithExpiredLookup
   }
 

--- a/server/src/test/scala/services/PortStateSpec.scala
+++ b/server/src/test/scala/services/PortStateSpec.scala
@@ -36,7 +36,7 @@ class PortStateSpec extends CrunchTestLike {
 
         staffUpdated && paxLoadUnchanged
     }
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/AggregatedArrivalsSpec.scala
+++ b/server/src/test/scala/services/crunch/AggregatedArrivalsSpec.scala
@@ -103,7 +103,7 @@ class AggregatedArrivalsSpec extends CrunchTestLike with BeforeEach {
 
     val expected = AggregatedArrival(liveArrival, airportConfig.portCode.iata)
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     arrivalsResult === AggregatedArrivals(Seq(expected))
   }
@@ -150,7 +150,7 @@ class AggregatedArrivalsSpec extends CrunchTestLike with BeforeEach {
       AggregatedArrival(expiredArrival, airportConfig.portCode.iata)
     )
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     arrivalsResult === expected
   }
@@ -191,7 +191,7 @@ class AggregatedArrivalsSpec extends CrunchTestLike with BeforeEach {
 
     val expected = Set()
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     arrivalsResult === expected
   }

--- a/server/src/test/scala/services/crunch/ApiPaxNosCrunchSpecSpec.scala
+++ b/server/src/test/scala/services/crunch/ApiPaxNosCrunchSpecSpec.scala
@@ -58,7 +58,7 @@ class ApiPaxNosCrunchSpecSpec extends CrunchTestLike {
         resultSummary == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -86,7 +86,7 @@ class ApiPaxNosCrunchSpecSpec extends CrunchTestLike {
         resultSummary == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/ApplicationRestartSpec.scala
+++ b/server/src/test/scala/services/crunch/ApplicationRestartSpec.scala
@@ -76,7 +76,7 @@ class ApplicationRestartSpec extends CrunchTestLike {
 
     crunch.portStateTestProbe.expectNoMessage(2 second)
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/ArrivalUpdatesCorrectlyAffectLoads.scala
+++ b/server/src/test/scala/services/crunch/ArrivalUpdatesCorrectlyAffectLoads.scala
@@ -127,7 +127,7 @@ ArrivalUpdatesCorrectlyAffectLoads extends CrunchTestLike {
       success
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
     success
   }
 

--- a/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
+++ b/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
@@ -57,7 +57,7 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
           arrivals == expectedArrivals
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }
@@ -80,7 +80,7 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
           portStateSources == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }
@@ -108,7 +108,7 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
           portStateSources == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }
@@ -131,7 +131,7 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
           intExists && domDoesNotExist
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }

--- a/server/src/test/scala/services/crunch/BlackJackFlowSpec.scala
+++ b/server/src/test/scala/services/crunch/BlackJackFlowSpec.scala
@@ -59,7 +59,7 @@ class BlackJackFlowSpec extends CrunchTestLike {
         actDesks == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -107,7 +107,7 @@ class BlackJackFlowSpec extends CrunchTestLike {
         actDesks == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/CodeshareWorkloadSpec.scala
+++ b/server/src/test/scala/services/crunch/CodeshareWorkloadSpec.scala
@@ -52,7 +52,7 @@ class CodeshareWorkloadSpec extends CrunchTestLike {
         minute1paxCorrect && minute2paxCorrect
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/CrunchCodeSharesSpec.scala
+++ b/server/src/test/scala/services/crunch/CrunchCodeSharesSpec.scala
@@ -50,7 +50,7 @@ class CrunchCodeSharesSpec extends CrunchTestLike {
           resultSummary == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }
@@ -90,7 +90,7 @@ class CrunchCodeSharesSpec extends CrunchTestLike {
           resultSummary == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }

--- a/server/src/test/scala/services/crunch/CrunchEgateBanksSpec.scala
+++ b/server/src/test/scala/services/crunch/CrunchEgateBanksSpec.scala
@@ -66,7 +66,7 @@ class CrunchEgateBanksSpec extends CrunchTestLike {
           resultSummary == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }

--- a/server/src/test/scala/services/crunch/CrunchFlightExclusionsSpec.scala
+++ b/server/src/test/scala/services/crunch/CrunchFlightExclusionsSpec.scala
@@ -52,7 +52,7 @@ class CrunchFlightExclusionsSpec extends CrunchTestLike {
         resultSummary == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -94,7 +94,7 @@ class CrunchFlightExclusionsSpec extends CrunchTestLike {
         resultSummary == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/CrunchQueueAndTerminalValidationSpec.scala
+++ b/server/src/test/scala/services/crunch/CrunchQueueAndTerminalValidationSpec.scala
@@ -53,7 +53,7 @@ class CrunchQueueAndTerminalValidationSpec extends CrunchTestLike {
           resultSummary == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }
@@ -91,7 +91,7 @@ class CrunchQueueAndTerminalValidationSpec extends CrunchTestLike {
         resultSummary == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/CrunchSplitsToLoadAndDeskRecsSpec.scala
+++ b/server/src/test/scala/services/crunch/CrunchSplitsToLoadAndDeskRecsSpec.scala
@@ -61,7 +61,7 @@ class CrunchSplitsToLoadAndDeskRecsSpec extends CrunchTestLike {
           resultSummary == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }
@@ -92,7 +92,7 @@ class CrunchSplitsToLoadAndDeskRecsSpec extends CrunchTestLike {
           resultSummary == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }
@@ -138,7 +138,7 @@ class CrunchSplitsToLoadAndDeskRecsSpec extends CrunchTestLike {
           resultSummary == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }
@@ -178,7 +178,7 @@ class CrunchSplitsToLoadAndDeskRecsSpec extends CrunchTestLike {
             resultSummary == expected
         }
 
-        crunch.liveArrivalsInput.complete()
+        crunch.shutdown
 
         success
       }
@@ -224,7 +224,7 @@ class CrunchSplitsToLoadAndDeskRecsSpec extends CrunchTestLike {
             resultSummary == expected
         }
 
-        crunch.liveArrivalsInput.complete()
+        crunch.shutdown
 
         success
       }

--- a/server/src/test/scala/services/crunch/CrunchTimezoneSpec.scala
+++ b/server/src/test/scala/services/crunch/CrunchTimezoneSpec.scala
@@ -85,7 +85,7 @@ class CrunchTimezoneSpec extends CrunchTestLike {
             resultSummary == expected
         }
 
-        crunch.liveArrivalsInput.complete()
+        crunch.shutdown
 
         success
       }

--- a/server/src/test/scala/services/crunch/FlightUpdatesTriggerNewPortStateSpec.scala
+++ b/server/src/test/scala/services/crunch/FlightUpdatesTriggerNewPortStateSpec.scala
@@ -53,7 +53,7 @@ class FlightUpdatesTriggerNewPortStateSpec extends CrunchTestLike {
         flightsAfterUpdate == expectedFlights
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -93,7 +93,7 @@ class FlightUpdatesTriggerNewPortStateSpec extends CrunchTestLike {
         flightsAfterUpdate == expectedFlights
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/ForecastCrunchSpec.scala
+++ b/server/src/test/scala/services/crunch/ForecastCrunchSpec.scala
@@ -45,7 +45,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
         forecastSummary == expectedForecast
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -98,7 +98,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
         deployedStaff == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -155,7 +155,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
         waitTimeOneMinuteBeforeMidnight < waitTimeAtMidnight
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -198,7 +198,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
         deployedStaff == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -226,7 +226,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
         forecastSummary == expectedForecast
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -243,13 +243,13 @@ class ForecastCrunchSpec extends CrunchTestLike {
     val crunch = runCrunchGraph(now = () => SDate(forecastScheduled).addDays(-1))
 
     offerAndWait(crunch.forecastArrivalsInput, ArrivalsFeedSuccess(forecastArrivals))
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     val gotAnyFlights = crunch.portStateTestProbe.receiveWhile(2 seconds) {
       case PortState(flights, _, _) => flights.size
     }.exists(_ > 0)
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     gotAnyFlights === false
   }
@@ -280,7 +280,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
         crunchForecastArrivals == expectedForecastArrivals
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -310,7 +310,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
         crunchForecastArrivals == expectedForecastArrivals
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -345,7 +345,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
         crunchForecastArrivals == expectedForecastArrivals
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -383,7 +383,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
         crunchForecastArrivals == expectedForecastArrivals
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -420,7 +420,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
         flightCodes == expectedFlightCodes
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/LiveStateRollingForwardSpec.scala
+++ b/server/src/test/scala/services/crunch/LiveStateRollingForwardSpec.scala
@@ -41,7 +41,7 @@ class LiveStateRollingForwardSpec extends CrunchTestLike {
     stateContainsArrivals(crunch.portStateTestProbe, Seq(futureArrival))
     stateContainsArrivals(crunch.portStateTestProbe, Seq(futureArrival, futureArrival2))
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -70,7 +70,7 @@ class LiveStateRollingForwardSpec extends CrunchTestLike {
 
     stateContainsArrivals(crunch.portStateTestProbe, Seq(futureArrival, futureArrival2))
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/PlanningActualStaffSpec.scala
+++ b/server/src/test/scala/services/crunch/PlanningActualStaffSpec.scala
@@ -63,7 +63,7 @@ class PlanningActualStaffSpec() extends CrunchTestLike {
         firstDayFirstHour == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/PlanningPageSpec.scala
+++ b/server/src/test/scala/services/crunch/PlanningPageSpec.scala
@@ -59,7 +59,7 @@ class PlanningPageSpec() extends CrunchTestLike {
         firstDayFirstHour == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/StaffMinutesSpec.scala
+++ b/server/src/test/scala/services/crunch/StaffMinutesSpec.scala
@@ -51,7 +51,7 @@ class StaffMinutesSpec extends CrunchTestLike {
         (staffMillis, staff) == Tuple2(expectedMillis, expectedStaff)
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -102,7 +102,7 @@ class StaffMinutesSpec extends CrunchTestLike {
         staffAvailable == expectedStaffAvailable
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -137,7 +137,7 @@ class StaffMinutesSpec extends CrunchTestLike {
         actualAvailableAndMovements == expectedStaffAvailableAndMovements
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -177,7 +177,7 @@ class StaffMinutesSpec extends CrunchTestLike {
         actualAvailableAndMovements == expectedStaffAvailableAndMovements
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -224,7 +224,7 @@ class StaffMinutesSpec extends CrunchTestLike {
         staffMovements == expectedStaffMovements
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -297,7 +297,7 @@ class StaffMinutesSpec extends CrunchTestLike {
         deployments == expectedCrunchDeployments
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -345,7 +345,7 @@ class StaffMinutesSpec extends CrunchTestLike {
         fixedPoints == expectedFixedPoints
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -409,7 +409,7 @@ class StaffMinutesSpec extends CrunchTestLike {
         deployments == expectedCrunchDeployments
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -478,7 +478,7 @@ class StaffMinutesSpec extends CrunchTestLike {
         deployments == expectedCrunchDeployments
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -515,7 +515,7 @@ class StaffMinutesSpec extends CrunchTestLike {
         actualMinutes == expectedStaffMinutes
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -562,7 +562,7 @@ class StaffMinutesSpec extends CrunchTestLike {
         actualMinutes == expectedStaffMinutes
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/VoyageManifestsSpec.scala
+++ b/server/src/test/scala/services/crunch/VoyageManifestsSpec.scala
@@ -65,7 +65,7 @@ class VoyageManifestsSpec extends CrunchTestLike {
         nonZeroQueues == expectedNonZeroQueues
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -110,7 +110,7 @@ class VoyageManifestsSpec extends CrunchTestLike {
         queuePax == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -156,7 +156,7 @@ class VoyageManifestsSpec extends CrunchTestLike {
         queuePax == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -271,7 +271,7 @@ class VoyageManifestsSpec extends CrunchTestLike {
         queuePax == expected
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/crunch/deskrecs/RunnableDeskRecsSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/RunnableDeskRecsSpec.scala
@@ -356,7 +356,7 @@ class RunnableDeskRecsSpec extends CrunchTestLike {
         zeroAtNoon && nonZeroAtOnePm
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -411,7 +411,7 @@ class RunnableDeskRecsSpec extends CrunchTestLike {
         zeroAtNoon && nonZeroAtOnePm
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -498,7 +498,7 @@ class RunnableDeskRecsSpec extends CrunchTestLike {
         fewerAtNoon
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }
@@ -551,7 +551,7 @@ class RunnableDeskRecsSpec extends CrunchTestLike {
         crunchDays == expectedCrunchDays
     }
 
-    crunch.liveArrivalsInput.complete()
+    crunch.shutdown
 
     success
   }

--- a/server/src/test/scala/services/inputfeeds/AclFeedSpec.scala
+++ b/server/src/test/scala/services/inputfeeds/AclFeedSpec.scala
@@ -352,7 +352,7 @@ class AclFeedSpec extends CrunchTestLike {
           flightsResult == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }
@@ -383,7 +383,7 @@ class AclFeedSpec extends CrunchTestLike {
           flightsResult == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }
@@ -416,7 +416,7 @@ class AclFeedSpec extends CrunchTestLike {
           flightsResult == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }
@@ -450,7 +450,7 @@ class AclFeedSpec extends CrunchTestLike {
           flightsResult == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }
@@ -487,7 +487,7 @@ class AclFeedSpec extends CrunchTestLike {
           flightsResult == expected
       }
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       success
     }
@@ -514,7 +514,7 @@ class AclFeedSpec extends CrunchTestLike {
       val nonEmptyFlightsList = List(aclArrival.copy(FeedSources = Set(AclFeedSource)))
       val expected = List(nonEmptyFlightsList)
 
-      crunch.liveArrivalsInput.complete()
+      crunch.shutdown
 
       portStateFlightLists.distinct === expected
     }


### PR DESCRIPTION
Trigger `manifest refresh flag` when the `refresh arrivals flag` is set to ensure manifests are looked up for the new arrivals