### PR TITLE
Drtii 348 headers for empty exports

### DIFF
--- a/server/src/main/scala/services/exports/Exports.scala
+++ b/server/src/main/scala/services/exports/Exports.scala
@@ -51,6 +51,7 @@ object Exports {
       }
 
       summaryForDay.map {
+        case None if addHeader => "\n"
         case None => "\n"
         case Some(summaryLike) if addHeader => summaryLike.toCsvWithHeader
         case Some(summaryLike) => summaryLike.toCsv
@@ -74,7 +75,7 @@ object Exports {
             case None => Future(None)
             case Some(extract) if extract.isEmpty =>
               log.warn(s"Empty summary from port state. Won't send to be persisted")
-              Future(None)
+              Future(Option(extract))
             case Some(extract) => sendSummaryToBePersisted(askableSummaryActor, extract)
           }
         case someSummaries =>
@@ -104,7 +105,7 @@ object Exports {
     val terminalRequest = GetPortStateForTerminal(startTime.millisSinceEpoch, endTime.millisSinceEpoch, terminal)
     val pointInTime = startTime.addHours(2)
     queryPortState(pointInTime, terminalRequest).map {
-      case None => None
+      case None => fromPortState(startTime, endTime, PortState.empty)
       case Some(portState) => fromPortState(startTime, endTime, portState)
     }
   }

--- a/server/src/main/scala/services/exports/Exports.scala
+++ b/server/src/main/scala/services/exports/Exports.scala
@@ -51,7 +51,6 @@ object Exports {
       }
 
       summaryForDay.map {
-        case None if addHeader => "\n"
         case None => "\n"
         case Some(summaryLike) if addHeader => summaryLike.toCsvWithHeader
         case Some(summaryLike) => summaryLike.toCsv

--- a/server/src/test/scala/services/export/DesksAndQueuesExportSpec.scala
+++ b/server/src/test/scala/services/export/DesksAndQueuesExportSpec.scala
@@ -185,13 +185,14 @@ class DesksAndQueuesExportSpec extends SpecificationLike {
 
   "Given a desks summary actor for a given day which does not have any persisted data for that day and there is no port state available" >> {
     "When I ask for terminal summaries for that day" >> {
-      "I should get back a None, in reflection of the missing data" >> {
+      "I should still get back 96 summaries" >> {
         val mockTerminalSummariesActor = system.actorOf(Props(classOf[MockTerminalSummariesActor], None, None))
         val portStateToSummaries = queueSummariesFromPortState(Seq(EeaDesk), 15)
 
         val result = Await.result(historicSummaryForDay(terminal, from, mockTerminalSummariesActor, GetSummaries, eventualPortState(None), portStateToSummaries), 1 second)
+          .get.asInstanceOf[TerminalQueuesSummary].summaries
 
-        result === None
+        result.size === 96
       }
     }
   }


### PR DESCRIPTION
A fix to ensure export csv headers are present in the absence of data