### PR TITLE
DRTII-355 Crunch all terminals rather than just the ones with flights

### DIFF
--- a/server/src/main/scala/services/crunch/deskrecs/DesksAndWaitsTerminalProvider.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/DesksAndWaitsTerminalProvider.scala
@@ -48,7 +48,7 @@ case class DesksAndWaitsTerminalProvider(slas: Map[Queue, Int],
           log.info(s"Optimising $queue")
           val queueWork = adjustedWork(queue, loadsByQueue(queue))
           val minDesks = deskLimitsProvider.minDesksForMinutes(minuteMillis, queue).toSeq
-          val queueDeskAllocations = queueRecsSoFar.mapValues(_._1.toList)
+          val queueDeskAllocations = queueRecsSoFar.mapValues { case (desks, _) => desks.toList }
           val maxDesks = deskLimitsProvider.maxDesksForMinutes(minuteMillis, queue, queueDeskAllocations).toSeq
           queueWork match {
             case noWork if noWork.isEmpty || noWork.max == 0 =>

--- a/server/src/test/scala/services/StreamingWorkloadSpec.scala
+++ b/server/src/test/scala/services/StreamingWorkloadSpec.scala
@@ -1,7 +1,7 @@
 package services
 
 import akka.NotUsed
-import akka.actor.ActorRef
+import akka.actor.{ActorRef, Props}
 import akka.pattern.AskableActorRef
 import akka.stream.scaladsl.{Sink, Source}
 import akka.testkit.TestProbe
@@ -43,7 +43,7 @@ class StreamingWorkloadSpec extends CrunchTestLike {
 
   def newBuffer: Buffer = Buffer(Iterable())
 
-  val mockPortStateActor: ActorRef = system.actorOf(MockPortStateActor.props(portStateProbe, smallDelay))
+  val mockPortStateActor: ActorRef = system.actorOf(Props(new MockPortStateActor(portStateProbe, smallDelay)))
   mockPortStateActor ! SetFlights(List(ApiFlightWithSplits(ArrivalGenerator.arrival(terminal = T1, origin = PortCode("JFK"), actPax = Option(100)), Set())))
   val portDeskRecs: MockDesksAndWaitsPort = MockDesksAndWaitsPort(1440, defaultAirportConfig.crunchOffsetMinutes)
   val maxDesksProvider: Map[Terminal, TerminalDeskLimitsLike] = PortDeskLimits.flexed(defaultAirportConfig)

--- a/server/src/test/scala/services/crunch/CrunchSplitsToLoadAndDeskRecsSpec.scala
+++ b/server/src/test/scala/services/crunch/CrunchSplitsToLoadAndDeskRecsSpec.scala
@@ -5,7 +5,7 @@ import drt.shared.CrunchApi.{CrunchMinute, StaffMinute}
 import drt.shared.FlightsApi.Flights
 import drt.shared.PaxTypesAndQueues._
 import drt.shared.SplitRatiosNs.{SplitRatio, SplitRatios, SplitSources}
-import drt.shared.Terminals.T1
+import drt.shared.Terminals.{T1, T2}
 import drt.shared._
 import passengersplits.parsing.VoyageManifestParser.{ManifestDateOfArrival, ManifestTimeOfArrival, VoyageManifest}
 import server.feeds.{ArrivalsFeedSuccess, DqManifests, ManifestsFeedSuccess}
@@ -21,210 +21,219 @@ class CrunchSplitsToLoadAndDeskRecsSpec extends CrunchTestLike {
   sequential
 
   "Crunch split workload flow " >> {
-    "Given a flight with 21 passengers and splits to eea desk & egates " +
-      "When I ask for queue loads " +
-      "Then I should see 4 queue loads, 2 for the first 20 pax to each queue and 2 for the last 1 split to each queue" >> {
+    "Given a flight with 21 passengers and splits to eea desk & egates " >> {
+      "When I ask for queue loads " >> {
+        "Then I should see 4 queue loads, 2 for the first 20 pax to each queue and 2 for the last 1 split to each queue" >> {
 
-      val scheduled = "2017-01-01T00:00Z"
-      val edSplit = 0.25
-      val egSplit = 0.75
+          val scheduled = "2017-01-01T00:00Z"
+          val edSplit = 0.25
+          val egSplit = 0.75
 
-      val flights = Flights(List(
-        ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(21))
-      ))
+          val flights = Flights(List(
+            ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(21))
+            ))
 
-      val crunch = runCrunchGraph(
-        now = () => SDate(scheduled),
-        airportConfig = defaultAirportConfig.copy(
-          queuesByTerminal = SortedMap(T1 -> Seq(Queues.EeaDesk, Queues.EGate)),
-          terminalPaxSplits = Map(T1 -> SplitRatios(
-            SplitSources.TerminalAverage,
-            SplitRatio(eeaMachineReadableToDesk, edSplit),
-            SplitRatio(eeaMachineReadableToEGate, egSplit)
-          )),
-          terminalProcessingTimes = Map(T1 -> Map(
-            eeaMachineReadableToDesk -> 20d / 60,
-            eeaMachineReadableToEGate -> 35d / 60))
-        ))
+          val crunch = runCrunchGraph(
+            now = () => SDate(scheduled),
+            airportConfig = defaultAirportConfig.copy(
+              queuesByTerminal = SortedMap(T1 -> Seq(Queues.EeaDesk, Queues.EGate)),
+              terminalPaxSplits = Map(T1 -> SplitRatios(
+                SplitSources.TerminalAverage,
+                SplitRatio(eeaMachineReadableToDesk, edSplit),
+                SplitRatio(eeaMachineReadableToEGate, egSplit)
+                )),
+              terminalProcessingTimes = Map(T1 -> Map(
+                eeaMachineReadableToDesk -> 20d / 60,
+                eeaMachineReadableToEGate -> 35d / 60))
+              ))
 
-      offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(flights))
+          offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(flights))
 
-      val expected = Map(T1 -> Map(
-        Queues.EeaDesk -> Seq(20 * edSplit, 1 * edSplit),
-        Queues.EGate -> Seq(20 * egSplit, 1 * egSplit)
-      ))
+          val expected = Map(T1 -> Map(
+            Queues.EeaDesk -> Seq(20 * edSplit, 1 * edSplit),
+            Queues.EGate -> Seq(20 * egSplit, 1 * egSplit)
+            ))
 
-      crunch.portStateTestProbe.fishForMessage(5 seconds) {
-        case ps: PortState =>
-          val resultSummary = paxLoadsFromPortState(ps, 2)
-          resultSummary == expected
+          crunch.portStateTestProbe.fishForMessage(5 seconds) {
+            case ps: PortState =>
+              val resultSummary = paxLoadsFromPortState(ps, 2)
+              resultSummary == expected
+          }
+
+          success
+        }
       }
-
-      crunch.shutdown
-
-      success
     }
 
-    "Given 2 flights with one passenger each and one split to eea desk arriving at pcp 1 minute apart" +
-      "When I ask for queue loads " +
-      "Then I should see two eea desk queue loads containing the 2 passengers and their proc time" >> {
-      val scheduled = "2017-01-01T00:00Z"
-      val scheduled2 = "2017-01-01T00:01Z"
+    "Given 2 flights with one passenger each and one split to eea desk arriving at pcp 1 minute apart" >> {
+      "When I ask for queue loads " >> {
+        "Then I should see two eea desk queue loads containing the 2 passengers and their proc time" >> {
+          val scheduled = "2017-01-01T00:00Z"
+          val scheduled2 = "2017-01-01T00:01Z"
 
-      val flights = Flights(List(
-        ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(1)),
-        ArrivalGenerator.arrival(schDt = scheduled2, iata = "SA123", terminal = T1, actPax = Option(1))
-      ))
+          val flights = Flights(List(
+            ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(1)),
+            ArrivalGenerator.arrival(schDt = scheduled2, iata = "SA123", terminal = T1, actPax = Option(1))
+            ))
 
-      val crunch = runCrunchGraph(now = () => SDate(scheduled))
+          val crunch = runCrunchGraph(now = () => SDate(scheduled))
 
-      offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(flights))
+          offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(flights))
 
-      val expected = Map(T1 -> Map(
-        Queues.EeaDesk -> Seq(1.0, 1.0, 0.0, 0.0, 0.0),
-        Queues.NonEeaDesk -> Seq(0.0, 0.0, 0.0, 0.0, 0.0)
-      ))
+          val expected = Map(
+            T1 -> Map(
+              Queues.EeaDesk -> Seq(1.0, 1.0, 0.0, 0.0, 0.0),
+              Queues.NonEeaDesk -> Seq(0.0, 0.0, 0.0, 0.0, 0.0)),
+            T2 -> Map(
+              Queues.EeaDesk -> Seq(0.0, 0.0, 0.0, 0.0, 0.0),
+              Queues.NonEeaDesk -> Seq(0.0, 0.0, 0.0, 0.0, 0.0)))
 
-      crunch.portStateTestProbe.fishForMessage(5 seconds) {
-        case ps: PortState =>
-          val resultSummary = paxLoadsFromPortState(ps, 5)
-          resultSummary == expected
+          crunch.portStateTestProbe.fishForMessage(5 seconds) {
+            case ps: PortState =>
+              val resultSummary = paxLoadsFromPortState(ps, 5)
+              resultSummary == expected
+          }
+
+          success
+        }
       }
-
-      crunch.shutdown
-
-      success
     }
 
-    "Given 1 flight with 100 passengers eaa splits to desk and eGates" +
-      "When I ask for queue loads " +
-      "Then I should see the correct loads for each queue" >> {
-      val scheduled = "2017-01-01T00:00Z"
+    "Given 1 flight with 100 passengers eaa splits to desk and eGates" >> {
+      "When I ask for queue loads " >> {
+        "Then I should see the correct loads for each queue" >> {
+          val scheduled = "2017-01-01T00:00Z"
 
-      val flights = Flights(List(
-        ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(100))
-      ))
+          val flights = Flights(List(
+            ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(100))
+            ))
 
-      val crunch = runCrunchGraph(
-        now = () => SDate(scheduled),
-        airportConfig = defaultAirportConfig.copy(
-          queuesByTerminal = SortedMap(T1 -> Seq(Queues.EeaDesk, Queues.NonEeaDesk, Queues.EGate)),
-          terminalProcessingTimes = Map(T1 -> Map(
-            eeaMachineReadableToDesk -> 0.25,
-            eeaMachineReadableToEGate -> 0.3,
-            eeaNonMachineReadableToDesk -> 0.4
-          )),
-          terminalPaxSplits = Map(T1 -> SplitRatios(
-            SplitSources.TerminalAverage,
-            List(SplitRatio(eeaMachineReadableToDesk, 0.25),
-              SplitRatio(eeaMachineReadableToEGate, 0.25),
-              SplitRatio(eeaNonMachineReadableToDesk, 0.5)
-            )
-          ))
-        ))
-      offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(flights))
+          val crunch = runCrunchGraph(
+            now = () => SDate(scheduled),
+            airportConfig = defaultAirportConfig.copy(
+              queuesByTerminal = SortedMap(T1 -> Seq(Queues.EeaDesk, Queues.NonEeaDesk, Queues.EGate)),
+              terminalProcessingTimes = Map(T1 -> Map(
+                eeaMachineReadableToDesk -> 0.25,
+                eeaMachineReadableToEGate -> 0.3,
+                eeaNonMachineReadableToDesk -> 0.4
+                )),
+              terminalPaxSplits = Map(T1 -> SplitRatios(
+                SplitSources.TerminalAverage,
+                List(SplitRatio(eeaMachineReadableToDesk, 0.25),
+                     SplitRatio(eeaMachineReadableToEGate, 0.25),
+                     SplitRatio(eeaNonMachineReadableToDesk, 0.5)
+                     )
+                ))
+              ))
+          offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(flights))
 
-      val expected = Map(T1 -> Map(
-        Queues.EeaDesk -> List(5.25, 5.25, 5.25, 5.25, 5.25),
-        Queues.EGate -> List(1.5, 1.5, 1.5, 1.5, 1.5),
-        Queues.NonEeaDesk -> List(0, 0, 0, 0, 0)
-      ))
+          val expected = Map(T1 -> Map(
+            Queues.EeaDesk -> List(5.25, 5.25, 5.25, 5.25, 5.25),
+            Queues.EGate -> List(1.5, 1.5, 1.5, 1.5, 1.5),
+            Queues.NonEeaDesk -> List(0, 0, 0, 0, 0)
+            ))
 
-      crunch.portStateTestProbe.fishForMessage(5 seconds) {
-        case ps: PortState =>
-          val resultSummary = workLoadsFromPortState(ps, 5)
-          println(s"resultSummary: $resultSummary")
-          resultSummary == expected
+          crunch.portStateTestProbe.fishForMessage(5 seconds) {
+            case ps: PortState =>
+              val resultSummary = workLoadsFromPortState(ps, 5)
+              println(s"resultSummary: $resultSummary")
+              resultSummary == expected
+          }
+
+          success
+        }
       }
-
-      crunch.shutdown
-
-      success
     }
 
     "CSV split ratios " >> {
-      "Given a flight with 20 passengers and one CSV split of 25% to eea desk " +
-        "When request a crunch " +
-        "Then I should see a pax load of 5 (20 * 0.25)" >> {
-        val scheduled = "2017-01-01T00:00Z"
+      "Given a flight with 20 passengers and one CSV split of 25% to eea desk " >> {
+        "When request a crunch " >> {
+          "Then I should see a pax load of 5 (20 * 0.25)" >> {
+            val scheduled = "2017-01-01T00:00Z"
 
-        val flight = ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(20))
-        val flights = Flights(List(flight))
+            val flight = ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(20))
+            val flights = Flights(List(flight))
 
-        val crunch = runCrunchGraph(
-          now = () => SDate(scheduled),
-          airportConfig = defaultAirportConfig.copy(
-            terminalProcessingTimes = Map(T1 -> Map(
-              eeaMachineReadableToDesk -> 20d / 60,
-              eeaMachineReadableToEGate -> 35d / 60)),
-            terminalPaxSplits = Map(T1 -> SplitRatios(
-              SplitSources.TerminalAverage,
-              SplitRatio(eeaMachineReadableToDesk, 0.25)
-            ))
-          )
-        )
+            val crunch = runCrunchGraph(
+              now = () => SDate(scheduled),
+              airportConfig = defaultAirportConfig.copy(
+                terminalProcessingTimes = Map(T1 -> Map(
+                  eeaMachineReadableToDesk -> 20d / 60,
+                  eeaMachineReadableToEGate -> 35d / 60)),
+                terminalPaxSplits = Map(T1 -> SplitRatios(
+                  SplitSources.TerminalAverage,
+                  SplitRatio(eeaMachineReadableToDesk, 0.25)
+                  ))
+                )
+              )
 
-        offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(flights))
+            offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(flights))
 
-        val expected = Map(T1 -> Map(
-          Queues.EeaDesk -> Seq(5.0, 0.0, 0.0, 0.0, 0.0),
-          Queues.NonEeaDesk -> Seq(0.0, 0.0, 0.0, 0.0, 0.0)
-        ))
+            val expected = Map(
+              T1 -> Map(
+                Queues.EeaDesk -> Seq(5.0, 0.0, 0.0, 0.0, 0.0),
+                Queues.NonEeaDesk -> Seq(0.0, 0.0, 0.0, 0.0, 0.0)),
+              T2 -> Map(
+                Queues.EeaDesk -> Seq(0.0, 0.0, 0.0, 0.0, 0.0),
+                Queues.NonEeaDesk -> Seq(0.0, 0.0, 0.0, 0.0, 0.0)
+                ))
 
-        crunch.portStateTestProbe.fishForMessage(5 seconds) {
-          case ps: PortState =>
-            val resultSummary = paxLoadsFromPortState(ps, 5)
-            resultSummary == expected
+            crunch.portStateTestProbe.fishForMessage(5 seconds) {
+              case ps: PortState =>
+                val resultSummary = paxLoadsFromPortState(ps, 5)
+                println(s"resultSummary: $resultSummary")
+                resultSummary == expected
+            }
+
+            success
+          }
         }
-
-        crunch.shutdown
-
-        success
       }
     }
 
     "Split source precedence " >> {
-      "Given a flight with both api & csv splits " +
-        "When I crunch " +
-        "I should see pax loads calculated from the api splits and applied to the arrival's pax " >> {
+      "Given a flight with both api & csv splits " >> {
+        "When I crunch " >> {
+          "I should see pax loads calculated from the api splits and applied to the arrival's pax " >> {
 
-        val scheduled = "2017-01-01T00:00Z"
+            val scheduled = "2017-01-01T00:00Z"
 
-        val arrival = ArrivalGenerator.arrival(origin = PortCode("JFK"), schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(10), airportId = PortCode("LHR"))
+            val arrival = ArrivalGenerator.arrival(origin = PortCode("JFK"), schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(10), airportId = PortCode("LHR"))
 
-        val crunch = runCrunchGraph(
-          now = () => SDate(scheduled),
-          airportConfig = defaultAirportConfig.copy(
-            queuesByTerminal = SortedMap(T1 -> Seq(Queues.EeaDesk, Queues.EGate)),
-            terminalProcessingTimes = Map(T1 -> Map(
-              eeaMachineReadableToDesk -> 20d / 60,
-              eeaMachineReadableToEGate -> 35d / 60))
-          ),
-          initialPortState = Option(PortState(SortedMap(arrival.unique -> ApiFlightWithSplits(arrival, Set())), SortedMap[TQM, CrunchMinute](), SortedMap[TM, StaffMinute]()))
-        )
+            val crunch = runCrunchGraph(
 
-        val voyageManifests = ManifestsFeedSuccess(DqManifests("", Set(
-          VoyageManifest(EventTypes.CI, PortCode("STN"), PortCode("JFK"), VoyageNumber("0001"), CarrierCode("BA"), ManifestDateOfArrival("2017-01-01"), ManifestTimeOfArrival("00:00"),
-            manifestPax(10, euPassport)
-          )
-        )))
+              now = () => SDate(scheduled),
+              airportConfig = defaultAirportConfig.copy(
+                queuesByTerminal = SortedMap(T1 -> Seq(Queues.EeaDesk, Queues.EGate)),
+                terminalProcessingTimes = Map(T1 -> Map(
+                  eeaMachineReadableToDesk -> 20d / 60,
+                  eeaMachineReadableToEGate -> 35d / 60))
+                ),
+              initialPortState = Option(PortState(SortedMap(arrival.unique -> ApiFlightWithSplits(arrival, Set())), SortedMap[TQM, CrunchMinute](), SortedMap[TM, StaffMinute]()))
+              )
 
-        offerAndWait(crunch.manifestsLiveInput, voyageManifests)
+            val voyageManifests = ManifestsFeedSuccess(DqManifests("", Set(
+              VoyageManifest(EventTypes.CI, PortCode("STN"), PortCode("JFK"), VoyageNumber("0001"), CarrierCode("BA"), ManifestDateOfArrival("2017-01-01"), ManifestTimeOfArrival("00:00"),
+                             manifestPax(10, euPassport)
+                             )
+              )))
 
-        val expected = Map(T1 -> Map(
-          Queues.EeaDesk -> Seq(2.0, 0.0, 0.0, 0.0, 0.0),
-          Queues.EGate -> Seq(8.0, 0.0, 0.0, 0.0, 0.0)
-        ))
+            offerAndWait(crunch.manifestsLiveInput, voyageManifests)
 
-        crunch.portStateTestProbe.fishForMessage(5 seconds) {
-          case ps: PortState =>
-            val resultSummary = paxLoadsFromPortState(ps, 5)
-            resultSummary == expected
+            val expected = Map(T1 -> Map(
+              Queues.EeaDesk -> Seq(2.0, 0.0, 0.0, 0.0, 0.0),
+              Queues.EGate -> Seq(8.0, 0.0, 0.0, 0.0, 0.0)
+              ))
+
+            crunch.portStateTestProbe.fishForMessage(5 seconds) {
+              case ps: PortState =>
+                val resultSummary = paxLoadsFromPortState(ps, 5)
+                resultSummary == expected
+            }
+
+            success
+          }
         }
-
-        crunch.shutdown
-
-        success
       }
     }
   }

--- a/server/src/test/scala/services/crunch/FlightUpdatesTriggerNewPortStateSpec.scala
+++ b/server/src/test/scala/services/crunch/FlightUpdatesTriggerNewPortStateSpec.scala
@@ -19,80 +19,125 @@ class FlightUpdatesTriggerNewPortStateSpec extends CrunchTestLike {
   isolated
   sequential
 
-  "Given an update to an existing flight " +
-    "When I expect a PortState " +
-    "Then I should see one containing the updated flight" >> {
+  "Given an update to an existing flight " >> {
+    "When I expect a PortState " >> {
+      "Then I should see one containing the updated flight" >> {
 
-    val scheduled = "2017-01-01T00:00Z"
+        val scheduled = "2017-01-01T00:00Z"
 
-    val flight = ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(21))
-    val inputFlightsBefore = Flights(List(flight))
-    val updatedArrival = flight.copy(ActPax = Some(50))
-    val inputFlightsAfter = Flights(List(updatedArrival))
-    val crunch = runCrunchGraph(
-      now = () => SDate(scheduled),
-      airportConfig = defaultAirportConfig.copy(
-        terminalProcessingTimes = Map(T1 -> Map(
-          eeaMachineReadableToDesk -> 25d / 60,
-          eeaMachineReadableToEGate -> 25d / 60
-        )),
-        queuesByTerminal = SortedMap(T1 -> Seq(EeaDesk, EGate))
-      ))
+        val flight = ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(21))
+        val inputFlightsBefore = Flights(List(flight))
+        val updatedArrival = flight.copy(ActPax = Some(50))
+        val inputFlightsAfter = Flights(List(updatedArrival))
+        val crunch = runCrunchGraph(
+          now = () => SDate(scheduled),
+          airportConfig = defaultAirportConfig.copy(
+            terminalProcessingTimes = Map(T1 -> Map(
+              eeaMachineReadableToDesk -> 25d / 60,
+              eeaMachineReadableToEGate -> 25d / 60
+              )),
+            queuesByTerminal = SortedMap(T1 -> Seq(EeaDesk, EGate))
+            ))
 
-    offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(inputFlightsBefore))
-    offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(inputFlightsAfter))
+        offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(inputFlightsBefore))
+        offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(inputFlightsAfter))
 
-    val expectedFlights = Set(ApiFlightWithSplits(
-      updatedArrival.copy(FeedSources = Set(LiveFeedSource)),
-      Set(Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, Queues.EeaDesk, 100.0, None)), TerminalAverage, None, Percentage))))
+        val expectedFlights = Set(ApiFlightWithSplits(
+          updatedArrival.copy(FeedSources = Set(LiveFeedSource)),
+          Set(Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, Queues.EeaDesk, 100.0, None)), TerminalAverage, None, Percentage))))
 
-    crunch.portStateTestProbe.fishForMessage(3 seconds) {
-      case ps: PortState =>
-        val flightsAfterUpdate = ps.flights.values.map(_.copy(lastUpdated = None)).toSet
-        flightsAfterUpdate == expectedFlights
+        crunch.portStateTestProbe.fishForMessage(3 seconds) {
+          case ps: PortState =>
+            val flightsAfterUpdate = ps.flights.values.map(_.copy(lastUpdated = None)).toSet
+            flightsAfterUpdate == expectedFlights
+        }
+
+        success
+      }
     }
-
-    crunch.shutdown
-
-    success
   }
 
-  "Given a noop update to an existing flight followed by a real update " +
-    "When I expect a PortState " +
-    "Then I should see one containing the updated flight" >> {
+  "Given a noop update to an existing flight followed by a real update " >> {
+    "When I expect a PortState " >> {
+      "Then I should see one containing the updated flight" >> {
 
-    val scheduled = "2017-01-01T00:00Z"
+        val scheduled = "2017-01-01T00:00Z"
 
-    val flight = ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(21))
-    val inputFlightsBefore = Flights(List(flight))
-    val updatedArrival = flight.copy(ActPax = Some(50))
-    val inputFlightsAfter = Flights(List(updatedArrival))
-    val crunch = runCrunchGraph(
-      now = () => SDate(scheduled),
-      airportConfig = defaultAirportConfig.copy(
-        terminalProcessingTimes = Map(T1 -> Map(
-          eeaMachineReadableToDesk -> 25d / 60,
-          eeaMachineReadableToEGate -> 25d / 60
-        )),
-        queuesByTerminal = SortedMap(T1 -> Seq(EeaDesk, EGate))
-      ))
+        val flight = ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(21))
+        val inputFlightsBefore = Flights(List(flight))
+        val updatedArrival = flight.copy(ActPax = Some(50))
+        val inputFlightsAfter = Flights(List(updatedArrival))
+        val crunch = runCrunchGraph(
+          now = () => SDate(scheduled),
+          airportConfig = defaultAirportConfig.copy(
+            terminalProcessingTimes = Map(T1 -> Map(
+              eeaMachineReadableToDesk -> 25d / 60,
+              eeaMachineReadableToEGate -> 25d / 60
+              )),
+            queuesByTerminal = SortedMap(T1 -> Seq(EeaDesk, EGate))
+            ))
 
-    offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(inputFlightsBefore))
-    offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(inputFlightsBefore))
-    offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(inputFlightsAfter))
+        offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(inputFlightsBefore))
+        offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(inputFlightsBefore))
+        offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(inputFlightsAfter))
 
-    val expectedFlights = Set(ApiFlightWithSplits(
-      updatedArrival.copy(FeedSources = Set(LiveFeedSource)),
-      Set(Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, Queues.EeaDesk, 100.0, None)), TerminalAverage, None, Percentage))))
+        val expectedFlights = Set(ApiFlightWithSplits(
+          updatedArrival.copy(FeedSources = Set(LiveFeedSource)),
+          Set(Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, Queues.EeaDesk, 100.0, None)), TerminalAverage, None, Percentage))))
 
-    crunch.portStateTestProbe.fishForMessage(3 seconds) {
-      case ps: PortState =>
-        val flightsAfterUpdate = ps.flights.values.map(_.copy(lastUpdated = None)).toSet
-        flightsAfterUpdate == expectedFlights
+        crunch.portStateTestProbe.fishForMessage(3 seconds) {
+          case ps: PortState =>
+            val flightsAfterUpdate = ps.flights.values.map(_.copy(lastUpdated = None)).toSet
+            flightsAfterUpdate == expectedFlights
+        }
+
+        success
+      }
     }
+  }
 
-    crunch.shutdown
+  "Given an existing ACL flight and crunch data" >> {
+    "When I send an empty set of ACL flights" >> {
+      "Then I should see the pax nos and workloads fall to zero for the flight that was removed" >> {
 
-    success
+        val scheduled = "2017-01-01T00:00Z"
+
+        val flight = ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(21))
+        val oneFlight = Flights(List(flight))
+        val zeroFlights = Flights(List())
+
+        val crunch = runCrunchGraph(
+          now = () => SDate(scheduled),
+          airportConfig = defaultAirportConfig.copy(
+            terminalProcessingTimes = Map(T1 -> Map(
+              eeaMachineReadableToDesk -> 25d / 60,
+              eeaMachineReadableToEGate -> 25d / 60
+              )),
+            queuesByTerminal = SortedMap(T1 -> Seq(EeaDesk, EGate))
+            ))
+
+        offerAndWait(crunch.baseArrivalsInput, ArrivalsFeedSuccess(oneFlight))
+
+        crunch.portStateTestProbe.fishForMessage(1 second) {
+          case PortState(_, cms, _) if cms.nonEmpty =>
+            val nonZeroPax = cms.values.map(_.paxLoad).max > 0
+            val nonZeroWorkload = cms.values.map(_.workLoad).max > 0
+            nonZeroPax && nonZeroWorkload
+          case _ => false
+        }
+
+        offerAndWait(crunch.baseArrivalsInput, ArrivalsFeedSuccess(zeroFlights))
+
+        crunch.portStateTestProbe.fishForMessage(1 seconds) {
+          case PortState(_, cms, _) if cms.nonEmpty =>
+            val nonZeroPax = cms.values.map(_.paxLoad).max == 0
+            val nonZeroWorkload = cms.values.map(_.workLoad).max == 0
+            nonZeroPax && nonZeroWorkload
+          case _ => false
+        }
+
+        success
+      }
+    }
   }
 }


### PR DESCRIPTION
This fixes the case where a terminal with no flights doesn't get crunched resulting in phantom pax & wait times