### PR TITLE
DRTII-375 

### DIFF
--- a/server/src/main/scala/services/crunch/CrunchSystem.scala
+++ b/server/src/main/scala/services/crunch/CrunchSystem.scala
@@ -76,7 +76,8 @@ case class CrunchProps[FR](logLabel: String = "",
                            adjustEGateUseByUnder12s: Boolean,
                            optimiser: TryCrunch,
                            useLegacyDeployments: Boolean,
-                           aclPaxAdjustmentDays: Int)
+                           aclPaxAdjustmentDays: Int,
+                           startDeskRecs: () => UniqueKillSwitch)
 
 object CrunchSystem {
 
@@ -195,6 +196,8 @@ object CrunchSystem {
 
     val (forecastBaseIn, forecastIn, liveBaseIn, liveIn, manifestsLiveIn, shiftsIn, fixedPointsIn, movementsIn, simloadsIn, actDesksIn, arrivalsKillSwitch, manifestsKillSwitch, shiftsKS, fixedPKS, movementsKS) = crunchSystem.run
 
+    val drKillSwitch = props.startDeskRecs()
+
     CrunchSystem(
       shifts = shiftsIn,
       fixedPoints = fixedPointsIn,
@@ -206,7 +209,7 @@ object CrunchSystem {
       liveArrivalsResponse = liveIn,
       manifestsLiveResponse = manifestsLiveIn,
       actualDeskStats = actDesksIn,
-      List(arrivalsKillSwitch, manifestsKillSwitch, shiftsKS, fixedPKS, movementsKS)
+      List(arrivalsKillSwitch, manifestsKillSwitch, shiftsKS, fixedPKS, movementsKS, drKillSwitch)
       )
   }
 

--- a/server/src/main/scala/services/graphstages/DeploymentGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/DeploymentGraphStage.scala
@@ -83,12 +83,12 @@ class DeploymentGraphStage(name: String = "",
             val lastMinute = firstMinute.addMinutes(airportConfig.minutesToCrunch)
 
             terminalsWithNonZeroStaff(affectedTerminals, firstMinute, lastMinute) match {
-              case affectedTerminalsWithStaff =>
+              case affectedTerminalsWithStaff: Seq[Terminal] =>
                 purgeExpired(deployments, TQM.atTime, now, expireAfterMillis.toInt)
-                val affectedTerminalsWithNoStaff = affectedTerminals.diff(affectedTerminalsWithStaff)
-                val updates = updateSimulationsForPeriod(firstMinute, lastMinute, affectedTerminalsWithStaff)
-                val resets = resetSimulationsForPeriod(affectedTerminalsWithNoStaff, firstMinute, lastMinute)
-                setDeployments(updates ++ resets)
+                val affectedTerminalsWithNoStaff: Seq[Terminal] = affectedTerminals.diff(affectedTerminalsWithStaff)
+                val updatedMinutes: Map[TQM, SimulationMinute] = updateSimulationsForPeriod(firstMinute, lastMinute, affectedTerminalsWithStaff)
+                val resetMinutes: Seq[(TQM, SimulationMinute)] = resetSimulationsForPeriod(affectedTerminalsWithNoStaff, firstMinute, lastMinute)
+                setDeployments(updatedMinutes ++ resetMinutes)
                 pushStateIfReady()
             }
         }

--- a/server/src/main/scala/services/graphstages/DeploymentGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/DeploymentGraphStage.scala
@@ -78,7 +78,7 @@ class DeploymentGraphStage(name: String = "",
             loadMinutes ++= incomingLoads.loadMinutes
             purgeExpired(loadMinutes, TQM.atTime, now, expireAfterMillis.toInt)
 
-            val allMinuteMillis = incomingLoads.loadMinutes.keys.map(_.minute)
+            val allMinuteMillis: Iterable[MillisSinceEpoch] = incomingLoads.loadMinutes.keys.map(_.minute)
             val firstMinute = crunchPeriodStartMillis(SDate(allMinuteMillis.min))
             val lastMinute = firstMinute.addMinutes(airportConfig.minutesToCrunch)
 

--- a/server/src/main/scala/services/graphstages/DeploymentGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/DeploymentGraphStage.scala
@@ -67,26 +67,30 @@ class DeploymentGraphStage(name: String = "",
     setHandler(inLoads, new InHandler {
       override def onPush(): Unit = {
         val timer = StageTimer(stageName, inLoads)
-        val incomingLoads = grab(inLoads)
-        log.debug(s"Received ${incomingLoads.loadMinutes.size} load minutes")
+        grab(inLoads) match {
+          case incomingLoads if incomingLoads.loadMinutes.isEmpty =>
+            log.debug("Received empty load minutes")
+          case incomingLoads =>
+            log.info(s"Received ${incomingLoads.loadMinutes.size} load minutes")
 
-        val affectedTerminals = incomingLoads.loadMinutes.map { case (TQM(t, _, _), _) => t }.toSet.toSeq
+            val affectedTerminals = incomingLoads.loadMinutes.map { case (TQM(t, _, _), _) => t }.toSet.toSeq
 
-        loadMinutes ++= incomingLoads.loadMinutes
-        purgeExpired(loadMinutes, TQM.atTime, now, expireAfterMillis.toInt)
+            loadMinutes ++= incomingLoads.loadMinutes
+            purgeExpired(loadMinutes, TQM.atTime, now, expireAfterMillis.toInt)
 
-        val allMinuteMillis = incomingLoads.loadMinutes.keys.map(_.minute)
-        val firstMinute = crunchPeriodStartMillis(SDate(allMinuteMillis.min))
-        val lastMinute = firstMinute.addMinutes(airportConfig.minutesToCrunch)
+            val allMinuteMillis = incomingLoads.loadMinutes.keys.map(_.minute)
+            val firstMinute = crunchPeriodStartMillis(SDate(allMinuteMillis.min))
+            val lastMinute = firstMinute.addMinutes(airportConfig.minutesToCrunch)
 
-        terminalsWithNonZeroStaff(affectedTerminals, firstMinute, lastMinute) match {
-          case affectedTerminalsWithStaff if affectedTerminalsWithStaff.isEmpty =>
-            log.debug(s"No affected terminals with deployments. Skipping simulations")
-          case affectedTerminalsWithStaff =>
-            purgeExpired(deployments, TQM.atTime, now, expireAfterMillis.toInt)
-            val updates = updateSimulationsForPeriod(firstMinute, lastMinute, affectedTerminalsWithStaff)
-            setDeployments(updates)
-            pushStateIfReady()
+            terminalsWithNonZeroStaff(affectedTerminals, firstMinute, lastMinute) match {
+              case affectedTerminalsWithStaff =>
+                purgeExpired(deployments, TQM.atTime, now, expireAfterMillis.toInt)
+                val affectedTerminalsWithNoStaff = affectedTerminals.diff(affectedTerminalsWithStaff)
+                val updates = updateSimulationsForPeriod(firstMinute, lastMinute, affectedTerminalsWithStaff)
+                val resets = resetSimulationsForPeriod(affectedTerminalsWithNoStaff, firstMinute, lastMinute)
+                setDeployments(updates ++ resets)
+                pushStateIfReady()
+            }
         }
 
         pullAll()
@@ -99,9 +103,11 @@ class DeploymentGraphStage(name: String = "",
         val timer = StageTimer(stageName, inStaffMinutes)
 
         grab(inStaffMinutes) match {
+          case StaffMinutes(minutes) if minutes.isEmpty =>
+            log.debug(s"Received empty staff minutes")
           case StaffMinutes(minutes) if minutes.nonEmpty =>
             val affectedTerminals = minutes.map(_.terminal).distinct
-            log.info(s"Received ${minutes.length} staff minutes affecting ${affectedTerminals.mkString(", ")}")
+            log.debug(s"Received ${minutes.length} staff minutes affecting ${affectedTerminals.mkString(", ")}")
 
             updateStaffMinutes(StaffMinutes(minutes))
             purgeExpired(staffMinutes, TM.atTime, now, expireAfterMillis.toInt)
@@ -253,6 +259,23 @@ class DeploymentGraphStage(name: String = "",
             if (staffByMillis.count(_._2 > 0) > 0) terminal :: nonZeroTerminals
             else nonZeroTerminals
         }
+    }
+
+    def resetSimulationsForPeriod(terminals: Seq[Terminal],
+                                  firstMinute: SDateLike,
+                                  lastMinute: SDateLike): Seq[(TQM, SimulationMinute)] = {
+      val resetMinutes = for {
+        terminal <- terminals
+        queue <- airportConfig.queuesByTerminal(terminal)
+        minute <- firstMinute.millisSinceEpoch to lastMinute.millisSinceEpoch by MilliTimes.oneMinuteMillis
+      } yield {
+        val sm = SimulationMinute(terminal, queue, minute, 0, 0)
+        (sm.key, sm)
+      }
+
+      simulationMinutesToPush ++= resetMinutes
+
+      resetMinutes
     }
   }
 }

--- a/server/src/test/scala/services/crunch/ReCrunchSpec.scala
+++ b/server/src/test/scala/services/crunch/ReCrunchSpec.scala
@@ -1,0 +1,31 @@
+package services.crunch
+
+import drt.shared.CrunchApi.CrunchMinute
+import drt.shared.PortState
+import drt.shared.Queues.EeaDesk
+import drt.shared.Terminals.T1
+import services.SDate
+
+import scala.concurrent.duration._
+
+class ReCrunchSpec extends CrunchTestLike {
+  "Given an existing PortState with no arrivals but an existing crunch minute containing pax, desks & waits and deployments & waits" >> {
+    "When I start the app with the recrunch flag set" >> {
+      "Then then i should see the pax and waits fall to zero, and the desks fall to the minimum" >> {
+        val minute = SDate("2020-04-09T23:00")
+        val crunchMinute = CrunchMinute(T1, EeaDesk, minute.millisSinceEpoch, 10, 10, 10, 10, Option(10), Option(10))
+        val crunch = runCrunchGraph(now = () => minute, recrunchOnStart = true, initialPortState = Option(PortState(Seq(), Seq(crunchMinute), Seq())))
+
+        val expected = CrunchMinute(T1, EeaDesk, minute.millisSinceEpoch, 0, 0, 1, 0, Option(0), Option(0))
+
+        crunch.portStateTestProbe.fishForMessage(1 second) {
+          case PortState(_, cms, _) =>
+            val minute = cms(expected.key)
+            minute.equals(expected)
+        }
+
+        success
+      }
+    }
+  }
+}


### PR DESCRIPTION
Refactor to
 - Start runnable desk recs after the runnable crunch so we are ready to receive simulation requests
 - Reset terminals with zero staff to zero deployments and zero wait times