### PR TITLE
Drtii 403 future sequence to source map async

### DIFF
--- a/server/src/main/scala/actors/DrtSystemInterface.scala
+++ b/server/src/main/scala/actors/DrtSystemInterface.scala
@@ -89,7 +89,7 @@ trait DrtSystemInterface extends UserRoleProviderLike {
 
   val voyageManifestsActor: ActorRef
 
-  def feedActors: Seq[ActorRef] = Seq(liveArrivalsActor, liveBaseArrivalsActor, forecastArrivalsActor, baseArrivalsActor, voyageManifestsActor)
+  def feedActors: List[ActorRef] = List(liveArrivalsActor, liveBaseArrivalsActor, forecastArrivalsActor, baseArrivalsActor, voyageManifestsActor)
 
   val aclFeed: AclFeed = AclFeed(params.ftpServer, params.username, params.path, airportConfig.feedPortCode, AclFeed.aclToPortMapping(airportConfig.portCode), params.aclMinFileSizeInBytes)
 
@@ -154,7 +154,7 @@ trait DrtSystemInterface extends UserRoleProviderLike {
         "live-base-arrivals" -> liveBaseArrivalsActor,
         "live-arrivals" -> liveArrivalsActor,
         "aggregated-arrivals" -> aggregatedArrivalsActor
-      ),
+        ),
       useNationalityBasedProcessingTimes = params.useNationalityBasedProcessingTimes,
       useLegacyManifests = params.useLegacyManifests,
       manifestsLiveSource = voyageManifestsLiveSource,
@@ -367,15 +367,11 @@ trait DrtSystemInterface extends UserRoleProviderLike {
         fps.staffMinutes ++ lps.staffMinutes))
   }
 
-  def getFeedStatus: Future[Seq[FeedSourceStatuses]] = {
-    val futureMaybeStatuses = feedActors.map(a => queryActorWithRetry[FeedSourceStatuses](a, GetFeedStatuses))
-
-    Future
-      .sequence(futureMaybeStatuses)
-      .map(
-        maybeStatuses => maybeStatuses
-          .collect { case Some(fs) => fs }
-          .filter(fss => isValidFeedSource(fss.feedSource))
-      )
-  }
+  def getFeedStatus: Future[Seq[FeedSourceStatuses]] = Source(feedActors)
+      .mapAsync(1) { actor =>
+        queryActorWithRetry[FeedSourceStatuses](actor, GetFeedStatuses)
+      }
+      .collect { case Some(fs) => fs }
+      .filter(fss => isValidFeedSource(fss.feedSource))
+      .runWith(Sink.seq)
 }

--- a/server/src/main/scala/actors/MinutesActor.scala
+++ b/server/src/main/scala/actors/MinutesActor.scala
@@ -157,9 +157,7 @@ class MinutesActor[A, B](now: () => SDateLike,
                              minutesForDay: Iterable[MinuteLike[A, B]]): Future[MinutesContainer[A, B]] =
     updateMinutes(terminal, day, MinutesContainer(minutesForDay))
 
-  private def daysToFetch(start: SDateLike, end: SDateLike): List[SDateLike]
-
-  = {
+  private def daysToFetch(start: SDateLike, end: SDateLike): List[SDateLike] = {
     val localStart = SDate(start, Crunch.europeLondonTimeZone)
     val localEnd = SDate(end, Crunch.europeLondonTimeZone)
 

--- a/server/src/main/scala/manifests/graph/ManifestsGraph.scala
+++ b/server/src/main/scala/manifests/graph/ManifestsGraph.scala
@@ -8,7 +8,7 @@ import akka.stream.scaladsl.{GraphDSL, RunnableGraph, Sink, Source}
 import akka.stream.stage.GraphStage
 import drt.shared.api.Arrival
 import drt.shared.{ArrivalKey, PortCode}
-import manifests.ManifestLookupLike
+import manifests.{ManifestLookupLike, UniqueArrivalKey}
 import manifests.actors.RegisteredArrivals
 import manifests.passengers.BestAvailableManifest
 import org.slf4j.{Logger, LoggerFactory}
@@ -23,7 +23,7 @@ object ManifestsGraph {
             registeredArrivalsActor: ActorRef,
             portCode: PortCode,
             manifestLookup: ManifestLookupLike
-           ): RunnableGraph[UniqueKillSwitch] = {
+           )(implicit mat: Materializer): RunnableGraph[UniqueKillSwitch] = {
     import akka.stream.scaladsl.GraphDSL.Implicits._
 
     val killSwitch = KillSwitches.single[List[Arrival]]

--- a/server/src/test/scala/manifests/graph/ManifestGraphSpec.scala
+++ b/server/src/test/scala/manifests/graph/ManifestGraphSpec.scala
@@ -2,7 +2,7 @@ package manifests.graph
 
 import akka.NotUsed
 import akka.pattern.pipe
-import akka.stream.UniqueKillSwitch
+import akka.stream.{ActorMaterializer, Materializer, UniqueKillSwitch}
 import akka.stream.scaladsl.{Sink, Source}
 import akka.testkit.TestProbe
 import controllers.ArrivalGenerator
@@ -37,7 +37,7 @@ class ManifestGraphSpec extends CrunchTestLike {
       CarrierCode("TST"),
       scheduled,
       List()
-    )
+      )
     val manifestSinkProbe = TestProbe("manifest-test-probe")
     val registeredArrivalSinkProbe = TestProbe(name = "registered-arrival-test-probe")
 
@@ -69,7 +69,7 @@ class ManifestGraphSpec extends CrunchTestLike {
       CarrierCode("TST"),
       scheduled,
       List()
-    )
+      )
 
     val testArrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = "2019-03-06T12:00:00Z")
 
@@ -105,7 +105,7 @@ class ManifestGraphSpec extends CrunchTestLike {
       CarrierCode("TST"),
       scheduled,
       List()
-    )
+      )
 
     val testArrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = "2019-03-06T12:00:00Z")
 
@@ -179,7 +179,7 @@ class ManifestGraphSpec extends CrunchTestLike {
       registeredArrivalSinkProbe.ref,
       PortCode("STN"),
       MockManifestLookupService(testManifest)
-    ).run()
+      ).run()
 
     (killSwitch, manifestRequestsSink, manifestResponsesSource)
   }
@@ -191,6 +191,7 @@ case class MockManifestLookupService(bestAvailableManifest: BestAvailableManifes
   override def maybeBestAvailableManifest(arrivalPort: PortCode,
                                           departurePort: PortCode,
                                           voyageNumber: VoyageNumber,
-                                          scheduled: SDateLike): Future[(UniqueArrivalKey, Option[BestAvailableManifest])] =
+                                          scheduled: SDateLike)
+                                         (implicit mat: Materializer): Future[(UniqueArrivalKey, Option[BestAvailableManifest])] =
     Future((UniqueArrivalKey(arrivalPort, departurePort, voyageNumber, scheduled), Option(bestAvailableManifest)))
 }


### PR DESCRIPTION
To reduce strain on resources like database connections, cpu & memory, we should use a controlled sequence of asynchronous operations. `Future.sequence` executes all the futures in parallel and can result in large amounts of resources being used. `mapAsync` makes sure the futures are executed at most by `parallelism` at a time