### PR TITLE
Drtii 444 unhandled lhr forecast feed exception

### DIFF
--- a/server/src/main/scala/actors/DrtSystemInterface.scala
+++ b/server/src/main/scala/actors/DrtSystemInterface.scala
@@ -330,7 +330,7 @@ trait DrtSystemInterface extends UserRoleProviderLike {
   }
 
   def createForecastLHRFeed(): Source[ArrivalsFeedResponse, Cancellable] = {
-    implicit val maxFeedResponseWait: FiniteDuration = 10 seconds
+    implicit val timeout: Timeout = new Timeout(10 seconds)
     val lhrForecastFeed = LHRForecastFeed(arrivalsImportActor)
     Source
       .tick(10 seconds, 60 seconds, NotUsed)

--- a/server/src/main/scala/actors/DrtSystemInterface.scala
+++ b/server/src/main/scala/actors/DrtSystemInterface.scala
@@ -330,12 +330,12 @@ trait DrtSystemInterface extends UserRoleProviderLike {
   }
 
   def createForecastLHRFeed(): Source[ArrivalsFeedResponse, Cancellable] = {
+    implicit val maxFeedResponseWait: FiniteDuration = 10 seconds
     val lhrForecastFeed = LHRForecastFeed(arrivalsImportActor)
     Source
       .tick(10 seconds, 60 seconds, NotUsed)
-      .map(_ => lhrForecastFeed.requestFeed)
+      .mapAsync(1)(_ => lhrForecastFeed.requestFeed)
   }
-
 
   def initialState[A](askableActor: ActorRef): Option[A] = Await.result(initialStateFuture[A](askableActor), 2 minutes)
 

--- a/server/src/main/scala/drt/server/feeds/lhr/LHRForecastFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/lhr/LHRForecastFeed.scala
@@ -19,11 +19,11 @@ import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
 import scala.util.Try
 
-case class LHRForecastFeed(arrivalsActor: ActorRef)(implicit maxWait: FiniteDuration) {
+case class LHRForecastFeed(arrivalsActor: ActorRef)(implicit timeout: Timeout) {
   val log: Logger = LoggerFactory.getLogger(getClass)
 
   def requestFeed: Future[ArrivalsFeedResponse] =
-    arrivalsActor.ask(GetFeedImportArrivals)(new Timeout(maxWait))
+    arrivalsActor.ask(GetFeedImportArrivals)
       .map {
         case Some(Flights(arrivals)) =>
           log.info(s"Got ${arrivals.length} LHR port forecast arrivals")

--- a/server/src/test/scala/drt/server/feeds/lhr/LHRForecastFeedSpec.scala
+++ b/server/src/test/scala/drt/server/feeds/lhr/LHRForecastFeedSpec.scala
@@ -1,6 +1,7 @@
 package drt.server.feeds.lhr
 
 import akka.actor.{Actor, Props}
+import akka.util.Timeout
 import server.feeds.ArrivalsFeedFailure
 import services.crunch.CrunchTestLike
 
@@ -18,9 +19,11 @@ class SlowResponseActor extends Actor {
 class LHRForecastFeedSpec extends CrunchTestLike {
   "Given an LHR forecast feed with a mock actor that takes longer than the timeout to respond" >> {
     val mockActor = system.actorOf(Props(new SlowResponseActor()))
-    val lhrFeed = LHRForecastFeed(mockActor)(100 milliseconds)
+    val lhrFeed = LHRForecastFeed(mockActor)(new Timeout(100 milliseconds))
+
     "When I request the feed" >> {
       val result = Await.result(lhrFeed.requestFeed, 2 seconds)
+
       "I should get a ArrivalsFeedFailure rather than an uncaught exception" >> {
         result.getClass === classOf[ArrivalsFeedFailure]
       }

--- a/server/src/test/scala/drt/server/feeds/lhr/LHRForecastFeedSpec.scala
+++ b/server/src/test/scala/drt/server/feeds/lhr/LHRForecastFeedSpec.scala
@@ -1,0 +1,29 @@
+package drt.server.feeds.lhr
+
+import akka.actor.{Actor, Props}
+import server.feeds.ArrivalsFeedFailure
+import services.crunch.CrunchTestLike
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class SlowResponseActor extends Actor {
+  override def receive: Receive = {
+    case _ =>
+      Thread.sleep(1000L)
+      sender() ! "response"
+  }
+}
+
+class LHRForecastFeedSpec extends CrunchTestLike {
+  "Given an LHR forecast feed with a mock actor that takes longer than the timeout to respond" >> {
+    val mockActor = system.actorOf(Props(new SlowResponseActor()))
+    val lhrFeed = LHRForecastFeed(mockActor)(100 milliseconds)
+    "When I request the feed" >> {
+      val result = Await.result(lhrFeed.requestFeed, 2 seconds)
+      "I should get a ArrivalsFeedFailure rather than an uncaught exception" >> {
+        result.getClass === classOf[ArrivalsFeedFailure]
+      }
+    }
+  }
+}


### PR DESCRIPTION
Use `mapAsync` to eliminate need for `Await.result`
Add test