### PR TITLE
Drtii 503 wait for state initialisation before processing messages

### DIFF
--- a/server/src/main/scala/actors/PortStateActor.scala
+++ b/server/src/main/scala/actors/PortStateActor.scala
@@ -102,12 +102,12 @@ class PortStateActor(liveCrunchStateProps: Props,
   override def receive: Receive = {
     case Start =>
       unstashAll()
-      context.become(regularBehaviour)
+      context.become(readyBehaviour)
 
-    case msg => stash()
+    case _ => stash()
   }
 
-  def regularBehaviour: Receive = {
+  def readyBehaviour: Receive = {
     case SetCrunchQueueActor(crunchActor) =>
       log.info(s"Received crunchSourceActor")
       if (maybeCrunchQueueActor.isEmpty) maybeCrunchQueueActor = Option(crunchActor)

--- a/server/src/main/scala/actors/PortStateActor.scala
+++ b/server/src/main/scala/actors/PortStateActor.scala
@@ -1,11 +1,12 @@
 package actors
 
 import actors.DrtStaticParameters.liveDaysAhead
+import actors.PortStateActor.Start
 import actors.acking.AckingReceiver.{Ack, StreamCompleted, StreamFailure, StreamInitialized}
 import actors.daily.{RequestAndTerminate, RequestAndTerminateActor}
 import actors.pointInTime.CrunchStateReadActor
 import actors.queues.CrunchQueueActor.UpdatedMillis
-import akka.actor.{Actor, ActorRef, ActorSystem, Props}
+import akka.actor.{Actor, ActorRef, ActorSystem, Props, Stash}
 import akka.pattern.{ask, pipe}
 import akka.util.Timeout
 import drt.shared.CrunchApi._
@@ -31,13 +32,16 @@ object PortStateActor {
            (implicit system: ActorSystem): ActorRef = {
     system.actorOf(Props(new PortStateActor(liveCrunchStateProps, forecastCrunchStateProps, now, liveDaysAhead, queues)), name = "port-state-actor")
   }
+
+  case object Start
+
 }
 
 class PortStateActor(liveCrunchStateProps: Props,
                      forecastCrunchStateProps: Props,
                      now: () => SDateLike,
                      liveDaysAhead: Int,
-                     queuesByTerminal: Map[Terminal, Seq[Queue]]) extends Actor {
+                     queuesByTerminal: Map[Terminal, Seq[Queue]]) extends Actor with Stash {
   val log: Logger = LoggerFactory.getLogger(getClass)
 
   val portStateSnapshotInterval: Int = 1000
@@ -51,7 +55,7 @@ class PortStateActor(liveCrunchStateProps: Props,
 
   val state: PortStateMutable = PortStateMutable.empty
 
-  val killActor: ActorRef = context.system.actorOf(Props(new RequestAndTerminateActor()))//, "port-state-kill-actor")
+  val killActor: ActorRef = context.system.actorOf(Props(new RequestAndTerminateActor())) //, "port-state-kill-actor")
 
   var maybeCrunchQueueActor: Option[ActorRef] = None
   var crunchSourceIsReady: Boolean = true
@@ -61,15 +65,21 @@ class PortStateActor(liveCrunchStateProps: Props,
   override def preStart(): Unit = {
     val eventualLiveState = liveCrunchStateActor.ask(GetState).mapTo[Option[PortState]]
     val eventualFcstState = forecastCrunchStateActor.ask(GetState).mapTo[Option[PortState]]
-    for {
+    val eventualStates = for {
       liveState <- eventualLiveState
       fcstState <- eventualFcstState
-    } yield mergePortStates(fcstState, liveState).foreach { initialPortState =>
-      log.info(s"Setting initial PortState from live & forecast")
-      state.crunchMinutes ++= initialPortState.crunchMinutes
-      state.staffMinutes ++= initialPortState.staffMinutes
-      state.flights ++= initialPortState.flights
+    } yield mergePortStates(fcstState, liveState)
+
+    eventualStates.foreach { maybeInitialPortState =>
+      maybeInitialPortState.foreach { initialPortState =>
+        log.info(s"Setting initial PortState from live & forecast")
+        state.crunchMinutes ++= initialPortState.crunchMinutes
+        state.staffMinutes ++= initialPortState.staffMinutes
+        state.flights ++= initialPortState.flights
+      }
     }
+
+    eventualStates.onComplete(_ => self ! Start)
   }
 
   def mergePortStates(maybeForecastPs: Option[PortState],
@@ -90,7 +100,14 @@ class PortStateActor(liveCrunchStateProps: Props,
   }
 
   override def receive: Receive = {
+    case Start =>
+      unstashAll()
+      context.become(regularBehaviour)
 
+    case msg => stash()
+  }
+
+  def regularBehaviour: Receive = {
     case SetCrunchQueueActor(crunchActor) =>
       log.info(s"Received crunchSourceActor")
       if (maybeCrunchQueueActor.isEmpty) maybeCrunchQueueActor = Option(crunchActor)
@@ -98,14 +115,6 @@ class PortStateActor(liveCrunchStateProps: Props,
     case SetSimulationActor(simActor) =>
       log.info(s"Received simulationSourceActor")
       maybeSimActor = Option(simActor)
-
-    case ps: PortState =>
-      log.info(s"Received initial PortState")
-      state.crunchMinutes ++= ps.crunchMinutes
-      state.staffMinutes ++= ps.staffMinutes
-      state.flights ++= ps.flights
-      log.info(s"Finished setting state (${state.crunchMinutes.all.size} crunch minutes, ${state.staffMinutes.all.size} staff minutes, ${state.flights.all.size} flights)")
-      sender() ! Ack
 
     case StreamInitialized => sender() ! Ack
 
@@ -150,10 +159,6 @@ class PortStateActor(liveCrunchStateProps: Props,
 
     case HandleSimulationRequest =>
       handleSimulationRequest()
-
-    case GetState =>
-      log.debug(s"Received GetState request. Replying with PortState containing ${state.crunchMinutes.count} crunch minutes")
-      sender() ! Option(state.immutable)
 
     case PointInTimeQuery(millis, query) =>
       replyWithPointInTimeQuery(SDate(millis), query)

--- a/server/src/main/scala/services/crunch/deskrecs/DesksAndWaitsPortProvider.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/DesksAndWaitsPortProvider.scala
@@ -35,7 +35,7 @@ case class DesksAndWaitsPortProvider(queuesByTerminal: SortedMap[Terminal, Seq[Q
     .map { case (terminal, maxDesksProvider) =>
       val terminalPax = terminalPaxLoadsByQueue(terminal, minuteMillis, loadsByQueue)
       val terminalWork = terminalWorkLoadsByQueue(terminal, minuteMillis, loadsByQueue)
-      log.info(s"Optimising $terminal")
+      log.debug(s"Optimising $terminal")
 
       terminalDescRecs(terminal).workToDeskRecs(terminal, minuteMillis, terminalPax, terminalWork, maxDesksProvider)
     }
@@ -95,7 +95,7 @@ case class DesksAndWaitsPortProvider(queuesByTerminal: SortedMap[Terminal, Seq[Q
       .map { case (terminal, maxDesksProvider) =>
         val terminalPax = terminalPaxLoadsByQueue(terminal, minuteMillis, loads)
         val terminalWork = terminalWorkLoadsByQueue(terminal, minuteMillis, loads)
-        log.info(s"Optimising $terminal")
+        log.debug(s"Optimising $terminal")
 
         terminalDescRecs(terminal).workToDeskRecs(terminal, minuteMillis, terminalPax, terminalWork, maxDesksProvider)
       }

--- a/server/src/main/scala/test/TestActors.scala
+++ b/server/src/main/scala/test/TestActors.scala
@@ -150,7 +150,7 @@ object TestActors {
           .foreach(_ => replyTo ! Ack)
     }
 
-    override def receive: Receive = reset orElse super.receive
+    override def regularBehaviour: Receive = reset orElse super.regularBehaviour
   }
 
   trait TestMinuteActorLike[A, B <: WithTimeAccessor] extends MinutesActorLike[A, B] {

--- a/server/src/main/scala/test/TestActors.scala
+++ b/server/src/main/scala/test/TestActors.scala
@@ -150,7 +150,7 @@ object TestActors {
           .foreach(_ => replyTo ! Ack)
     }
 
-    override def regularBehaviour: Receive = reset orElse super.regularBehaviour
+    override def readyBehaviour: Receive = reset orElse super.readyBehaviour
   }
 
   trait TestMinuteActorLike[A, B <: WithTimeAccessor] extends MinutesActorLike[A, B] {

--- a/server/src/test/scala/actors/CrunchStateMockActor.scala
+++ b/server/src/test/scala/actors/CrunchStateMockActor.scala
@@ -6,9 +6,7 @@ import drt.shared.PortState
 
 class CrunchStateMockActor(initialPortState: Option[PortState]) extends Actor {
   override def receive: Receive = {
-    case GetState =>
-      println(s"\n\nGot GetState, replying with $initialPortState\n\n")
-      sender() ! initialPortState
+    case GetState => sender() ! initialPortState
     case _ => sender() ! Ack
   }
 }

--- a/server/src/test/scala/actors/CrunchStateMockActor.scala
+++ b/server/src/test/scala/actors/CrunchStateMockActor.scala
@@ -2,9 +2,13 @@ package actors
 
 import actors.acking.AckingReceiver.Ack
 import akka.actor.Actor
+import drt.shared.PortState
 
-class CrunchStateMockActor extends Actor {
+class CrunchStateMockActor(initialPortState: Option[PortState]) extends Actor {
   override def receive: Receive = {
+    case GetState =>
+      println(s"\n\nGot GetState, replying with $initialPortState\n\n")
+      sender() ! initialPortState
     case _ => sender() ! Ack
   }
 }

--- a/server/src/test/scala/actors/PortStateTestActor.scala
+++ b/server/src/test/scala/actors/PortStateTestActor.scala
@@ -4,13 +4,13 @@ import akka.actor.{ActorRef, ActorSystem, Props}
 import akka.testkit.TestProbe
 import drt.shared.Queues.Queue
 import drt.shared.Terminals.Terminal
-import drt.shared.{PortStateDiff, SDateLike}
-import services.graphstages.Crunch
+import drt.shared.{PortState, PortStateDiff, SDateLike}
 
 object PortStateTestActor {
-  def apply(testProbe: TestProbe, now: () => SDateLike, queues: Map[Terminal, Seq[Queue]])(implicit system: ActorSystem): ActorRef = {
-    val crunchStateMockActor: Props = Props(classOf[CrunchStateMockActor])
-    system.actorOf(Props(new PortStateTestActor(crunchStateMockActor, crunchStateMockActor, testProbe.ref, now, 100, queues)), name = "port-state-actor")
+  def apply(testProbe: TestProbe, now: () => SDateLike, queues: Map[Terminal, Seq[Queue]], initialPortState: Option[PortState])(implicit system: ActorSystem): ActorRef = {
+    val crunchStateMockLiveProps: Props = Props(new CrunchStateMockActor(initialPortState))
+    val crunchStateMockFcstProps: Props = Props(new CrunchStateMockActor(None))
+    system.actorOf(Props(new PortStateTestActor(crunchStateMockLiveProps, crunchStateMockFcstProps, testProbe.ref, now, 100, queues)), name = "port-state-actor")
   }
 }
 

--- a/server/src/test/scala/services/PortStateSpec.scala
+++ b/server/src/test/scala/services/PortStateSpec.scala
@@ -1,18 +1,23 @@
 package services
 
+import actors.{GetState, PortStateActor}
+import akka.actor.{Actor, Props}
+import akka.pattern.{after, ask}
 import controllers.ArrivalGenerator
 import drt.shared.CrunchApi._
-import drt.shared.FlightsApi.Flights
+import drt.shared.FlightsApi.{Flights, FlightsWithSplits}
 import drt.shared.Queues.Queue
 import drt.shared.Terminals.{T1, T2, Terminal}
 import drt.shared._
 import drt.shared.api.Arrival
 import server.feeds.ArrivalsFeedSuccess
+import services.crunch.deskrecs.GetFlights
 import services.crunch.{CrunchTestLike, TestConfig}
 import services.graphstages.{SimulationMinute, SimulationMinutes}
 
 import scala.collection.mutable
 import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 
 class PortStateSpec extends CrunchTestLike {
   "Given an initial PortState with some pax loads " +
@@ -287,5 +292,33 @@ class PortStateSpec extends CrunchTestLike {
 
   private def arrivalsToFlightsWithSplits(arrivals: List[Arrival]): List[ApiFlightWithSplits] = {
     arrivals.map(a => ApiFlightWithSplits(a, Set()))
+  }
+
+  "Given a 'slow' live crunch actor containing a single flight which takes 2 seconds to provide its state to the PortStateActor" >> {
+    "When I immediately ask the PortStateActor for flights for the day the crunch actor's flight is scheduled" >> {
+      "Then the response should contain the crunch actor's flight" >> {
+        val today = SDate("2020-07-03T00:00")
+        val flightsWithSplits = ApiFlightWithSplits(ArrivalGenerator.arrival(iata = "BA0001", schDt = today.toISOString()), Set())
+        val maybePortState = Option(PortState(Iterable(flightsWithSplits), Iterable(), Iterable()))
+        val liveActor = Props(new SlowCrunchStateActor(maybePortState, delay = 2 seconds))
+        val fcstActor = Props(new SlowCrunchStateActor(Option(PortState.empty), delay = 0 seconds))
+        val portStateActor = system.actorOf(Props(new PortStateActor(liveActor, fcstActor, () => today, 2, defaultAirportConfig.queuesByTerminal)))
+        val response = Await.result(portStateActor.ask(GetFlights(today.millisSinceEpoch, today.addMinutes(1).millisSinceEpoch)), 5 seconds)
+
+        response === FlightsWithSplits(Map(flightsWithSplits.unique -> flightsWithSplits))
+      }
+    }
+  }
+}
+
+class SlowCrunchStateActor(maybeState: Option[PortState], delay: FiniteDuration) extends Actor {
+  implicit val ec: ExecutionContextExecutor = context.dispatcher
+
+  override def receive: Receive = {
+    case GetState =>
+      val replyTo = sender()
+      after(delay, context.system.scheduler)(
+        Future(replyTo ! maybeState)
+      )
   }
 }

--- a/server/src/test/scala/services/PortStateSpec.scala
+++ b/server/src/test/scala/services/PortStateSpec.scala
@@ -294,13 +294,13 @@ class PortStateSpec extends CrunchTestLike {
     arrivals.map(a => ApiFlightWithSplits(a, Set()))
   }
 
-  "Given a 'slow' live crunch actor containing a single flight which takes 2 seconds to provide its state to the PortStateActor" >> {
+  "Given a 'slow' live crunch actor containing a single flight which takes 1 second to provide its state to the PortStateActor" >> {
     "When I immediately ask the PortStateActor for flights for the day the crunch actor's flight is scheduled" >> {
       "Then the response should contain the crunch actor's flight" >> {
         val today = SDate("2020-07-03T00:00")
         val flightsWithSplits = ApiFlightWithSplits(ArrivalGenerator.arrival(iata = "BA0001", schDt = today.toISOString()), Set())
         val maybePortState = Option(PortState(Iterable(flightsWithSplits), Iterable(), Iterable()))
-        val liveActor = Props(new SlowCrunchStateActor(maybePortState, delay = 2 seconds))
+        val liveActor = Props(new SlowCrunchStateActor(maybePortState, delay = 1 second))
         val fcstActor = Props(new SlowCrunchStateActor(Option(PortState.empty), delay = 0 seconds))
         val portStateActor = system.actorOf(Props(new PortStateActor(liveActor, fcstActor, () => today, 2, defaultAirportConfig.queuesByTerminal)))
         val response = Await.result(portStateActor.ask(GetFlights(today.millisSinceEpoch, today.addMinutes(1).millisSinceEpoch)), 5 seconds)

--- a/server/src/test/scala/services/crunch/StaffMinutesSpec.scala
+++ b/server/src/test/scala/services/crunch/StaffMinutesSpec.scala
@@ -45,17 +45,17 @@ class StaffMinutesSpec extends CrunchTestLike {
             SplitSources.TerminalAverage,
             SplitRatio(eeaMachineReadableToDesk, 0.5),
             SplitRatio(visaNationalToDesk, 0.5)
-            )),
+          )),
           terminalProcessingTimes = Map(
             T1 -> Map(
               eeaMachineReadableToDesk -> 25d / 60,
               visaNationalToDesk -> 75d / 60
-              )
             )
-          ),
+          )
+        ),
         useLegacyDeployments = true,
         now = () => shiftStart
-        ))
+      ))
 
       offerAndWait(crunch.shiftsInput, initialShifts)
 
@@ -114,17 +114,17 @@ class StaffMinutesSpec extends CrunchTestLike {
             SplitSources.TerminalAverage,
             SplitRatio(eeaMachineReadableToDesk, 0.1),
             SplitRatio(eeaMachineReadableToEGate, 0.9)
-            )),
+          )),
           terminalProcessingTimes = Map(
             T1 -> Map(
               eeaMachineReadableToDesk -> 20d / 60,
               eeaMachineReadableToEGate -> 20d / 60
-              )
             )
-          ),
+          )
+        ),
         useLegacyDeployments = true,
         now = () => shiftStart
-        ))
+      ))
 
       offerAndWait(crunch.shiftsInput, initialShifts)
       offerAndWait(crunch.fixedPointsInput, initialFixedPoints)
@@ -172,24 +172,24 @@ class StaffMinutesSpec extends CrunchTestLike {
             SplitRatio(eeaMachineReadableToDesk, 0.45),
             SplitRatio(visaNationalToDesk, 0.45),
             SplitRatio(visaNationalToFastTrack, 0.1)
-            )),
+          )),
           terminalProcessingTimes = Map(
             T1 -> Map(
               eeaMachineReadableToDesk -> 20d / 60,
               visaNationalToDesk -> 20d / 60,
               visaNationalToFastTrack -> 5d / 60
-              )
-            ),
+            )
+          ),
           minMaxDesksByTerminalQueue24Hrs = Map(
             T1 -> Map(
               Queues.EeaDesk -> ((List.fill[Int](24)(1), List.fill[Int](24)(20))),
               Queues.NonEeaDesk -> ((List.fill[Int](24)(1), List.fill[Int](24)(20))),
               Queues.FastTrack -> ((List.fill[Int](24)(1), List.fill[Int](24)(5)))
-              ))
-          ),
+            ))
+        ),
         useLegacyDeployments = true,
         now = () => shiftStart
-        ))
+      ))
 
       offerAndWait(crunch.shiftsInput, initialShifts)
 
@@ -206,7 +206,7 @@ class StaffMinutesSpec extends CrunchTestLike {
         (Queues.NonEeaDesk, shiftStart.addMinutes(0).toISOString(), 20),
         (Queues.NonEeaDesk, shiftStart.addMinutes(1).toISOString(), 20),
         (Queues.NonEeaDesk, shiftStart.addMinutes(2).toISOString(), 20)
-        )
+      )
 
       crunch.portStateTestProbe.fishForMessage(5 seconds) {
         case ps: PortState =>
@@ -247,17 +247,17 @@ class StaffMinutesSpec extends CrunchTestLike {
             SplitSources.TerminalAverage,
             SplitRatio(eeaMachineReadableToDesk, 0.5),
             SplitRatio(visaNationalToDesk, 0.5)
-            )),
+          )),
           terminalProcessingTimes = Map(
             T1 -> Map(
               eeaMachineReadableToDesk -> 25d / 60,
               visaNationalToDesk -> 75d / 60
-              )
             )
-          ),
+          )
+        ),
         now = () => shiftStart,
         cruncher = Optimiser.crunch
-        ))
+      ))
 
       offerAndWait(crunch.shiftsInput, initialShifts)
 
@@ -310,11 +310,11 @@ class StaffMinutesSpec extends CrunchTestLike {
     val crunch = runCrunchGraph(TestConfig(
       airportConfig = defaultAirportConfig.copy(
         queuesByTerminal = defaultAirportConfig.queuesByTerminal.filterKeys(_ == T1)
-        ),
+      ),
       now = () => shiftStart,
       initialShifts = initialShifts,
       checkRequiredStaffUpdatesOnStartup = true
-      ))
+    ))
 
     val expectedStaff = List.fill(15)(1) ::: List.fill(15)(2)
     val expectedMillis = (shiftStart.millisSinceEpoch to (shiftStart.millisSinceEpoch + 29 * oneMinuteMillis) by oneMinuteMillis).toList
@@ -346,14 +346,14 @@ class StaffMinutesSpec extends CrunchTestLike {
     val initialMovements = Seq(
       StaffMovement(T1, "lunch start", MilliDate(shiftStart.millisSinceEpoch), -1, uuid, createdBy = None),
       StaffMovement(T1, "lunch end", MilliDate(shiftStart.addMinutes(15).millisSinceEpoch), 1, uuid, createdBy = None)
-      )
+    )
 
     val crunch = runCrunchGraph(TestConfig(
       airportConfig = defaultAirportConfig.copy(
         queuesByTerminal = defaultAirportConfig.queuesByTerminal.filterKeys(_ == T1)
-        ),
+      ),
       now = () => shiftStart
-      ))
+    ))
 
     offerAndWait(crunch.shiftsInput, initialShifts)
     offerAndWait(crunch.liveStaffMovementsInput, initialMovements)
@@ -369,7 +369,7 @@ class StaffMinutesSpec extends CrunchTestLike {
       shiftStart.addMinutes(7).millisSinceEpoch -> 1,
       shiftStart.addMinutes(8).millisSinceEpoch -> 1,
       shiftStart.addMinutes(9).millisSinceEpoch -> 1
-      )
+    )
 
     crunch.portStateTestProbe.fishForMessage(2 seconds) {
       case ps: PortState =>
@@ -392,16 +392,16 @@ class StaffMinutesSpec extends CrunchTestLike {
     val initialMovements = Seq(
       StaffMovement(T1, "lunch start", MilliDate(startDate.millisSinceEpoch), -1, uuid, createdBy = None),
       StaffMovement(T1, "lunch end", MilliDate(endDate.millisSinceEpoch), 1, uuid, createdBy = None)
-      )
+    )
 
     val crunch = runCrunchGraph(TestConfig(
       airportConfig = defaultAirportConfig.copy(
         queuesByTerminal = defaultAirportConfig.queuesByTerminal.filterKeys(_ == T1)
-        ),
+      ),
       now = () => startDate,
       checkRequiredStaffUpdatesOnStartup = true,
       initialStaffMovements = initialMovements
-      ))
+    ))
 
     val minutesToCheck = 5
     val expectedStaffAvailableAndMovements = List.fill(minutesToCheck)((0, -1))
@@ -431,14 +431,14 @@ class StaffMinutesSpec extends CrunchTestLike {
     val initialMovements = Seq(
       StaffMovement(T1, "lunch start", MilliDate(startDate.millisSinceEpoch), -1, uuid, createdBy = None),
       StaffMovement(T1, "lunch end", MilliDate(endDate.addMinutes(1).millisSinceEpoch), 1, uuid, createdBy = None)
-      )
+    )
 
     val crunch = runCrunchGraph(TestConfig(
       airportConfig = defaultAirportConfig.copy(
         queuesByTerminal = defaultAirportConfig.queuesByTerminal.filterKeys(_ == T1)
-        ),
+      ),
       now = () => startDate
-      ))
+    ))
 
     offerAndWait(crunch.shiftsInput, initialShifts)
     offerAndWait(crunch.liveStaffMovementsInput, initialMovements)
@@ -469,14 +469,14 @@ class StaffMinutesSpec extends CrunchTestLike {
       StaffMovement(T1, "lunch end", MilliDate(shiftStart.addMinutes(15).millisSinceEpoch), 1, uuid1, createdBy = None),
       StaffMovement(T1, "lunch start", MilliDate(shiftStart.millisSinceEpoch), -5, uuid2, createdBy = None),
       StaffMovement(T1, "lunch end", MilliDate(shiftStart.addMinutes(15).millisSinceEpoch), 5, uuid2, createdBy = None)
-      )
+    )
 
     val crunch = runCrunchGraph(TestConfig(
       airportConfig = defaultAirportConfig.copy(
         queuesByTerminal = defaultAirportConfig.queuesByTerminal.filterKeys(_ == T1)
-        ),
+      ),
       now = () => shiftStart
-      ))
+    ))
 
     offerAndWait(crunch.liveStaffMovementsInput, initialMovements)
 
@@ -491,7 +491,7 @@ class StaffMinutesSpec extends CrunchTestLike {
       shiftStart.addMinutes(7).millisSinceEpoch -> -6,
       shiftStart.addMinutes(8).millisSinceEpoch -> -6,
       shiftStart.addMinutes(9).millisSinceEpoch -> -6
-      )
+    )
 
     crunch.portStateTestProbe.fishForMessage(2 seconds) {
       case ps: PortState =>
@@ -518,9 +518,9 @@ class StaffMinutesSpec extends CrunchTestLike {
     val crunch = runCrunchGraph(TestConfig(
       airportConfig = defaultAirportConfig.copy(
         queuesByTerminal = defaultAirportConfig.queuesByTerminal.filterKeys(_ == T1)
-        ),
+      ),
       now = () => shiftStart
-      ))
+    ))
 
     offerAndWait(crunch.fixedPointsInput, initialFixedPoints)
 
@@ -537,7 +537,7 @@ class StaffMinutesSpec extends CrunchTestLike {
       shiftStart.addMinutes(7).millisSinceEpoch -> 0,
       shiftStart.addMinutes(8).millisSinceEpoch -> 0,
       shiftStart.addMinutes(9).millisSinceEpoch -> 0
-      )
+    )
 
     crunch.portStateTestProbe.fishForMessage(10 seconds) {
       case ps: PortState =>
@@ -566,7 +566,7 @@ class StaffMinutesSpec extends CrunchTestLike {
       initialFixedPoints = fixedPoints,
       maxDaysToCrunch = 5,
       checkRequiredStaffUpdatesOnStartup = true
-      ))
+    ))
 
     val expectedStaffMinutes = (0 until 5).map { day =>
       val date = SDate(scheduled).addDays(day).toISODateOnly
@@ -613,7 +613,7 @@ class StaffMinutesSpec extends CrunchTestLike {
       maxDaysToCrunch = daysToCrunch,
       initialPortState = Option(PortState(SortedMap[UniqueArrival, ApiFlightWithSplits](), SortedMap[TQM, CrunchMinute](), staffMinutes(daysToCrunch, 15, scheduled))),
       checkRequiredStaffUpdatesOnStartup = true
-      ))
+    ))
 
     val expectedStaffMinutes = (0 until 5).map { day =>
       val date = SDate(scheduled).addDays(day).toISODateOnly
@@ -650,7 +650,7 @@ class StaffMinutesSpec extends CrunchTestLike {
       airportConfig = defaultAirportConfig.copy(queuesByTerminal = defaultAirportConfig.queuesByTerminal.filterKeys(_ == T1)),
       maxDaysToCrunch = daysToCrunch,
       initialPortState = Option(PortState(SortedMap[UniqueArrival, ApiFlightWithSplits](), SortedMap[TQM, CrunchMinute](), SortedMap[TM, StaffMinute]()))
-      ))
+    ))
 
     offerAndWait(crunch.shiftsInput, shifts)
 
@@ -658,7 +658,7 @@ class StaffMinutesSpec extends CrunchTestLike {
       "2017-01-01T00:00:00Z",
       "2017-01-01T00:01:00Z",
       "2017-01-01T00:02:00Z"
-      )
+    )
 
     crunch.portStateTestProbe.fishForMessage(2 seconds, s"Didn't find expected minutes ($expectedIsoMinutes)") {
       case PortState(_, _, staffMinutes) =>
@@ -687,7 +687,7 @@ class StaffMinutesSpec extends CrunchTestLike {
       airportConfig = defaultAirportConfig.copy(queuesByTerminal = defaultAirportConfig.queuesByTerminal.filterKeys(_ == T1)),
       maxDaysToCrunch = daysToCrunch,
       initialPortState = Option(PortState(SortedMap[UniqueArrival, ApiFlightWithSplits](), SortedMap[TQM, CrunchMinute](), SortedMap[TM, StaffMinute]()))
-      ))
+    ))
 
     offerAndWait(crunch.fixedPointsInput, fixedPoints)
 
@@ -695,7 +695,7 @@ class StaffMinutesSpec extends CrunchTestLike {
       "2017-01-01T00:00:00Z",
       "2017-01-01T00:01:00Z",
       "2017-01-01T00:02:00Z"
-      )
+    )
 
     crunch.portStateTestProbe.fishForMessage(2 seconds, s"Didn't find expected minutes ($expectedIsoMinutes)") {
       case PortState(_, _, staffMinutes) =>
@@ -725,14 +725,14 @@ class StaffMinutesSpec extends CrunchTestLike {
       airportConfig = defaultAirportConfig.copy(queuesByTerminal = defaultAirportConfig.queuesByTerminal.filterKeys(_ == T1)),
       maxDaysToCrunch = daysToCrunch,
       initialPortState = Option(PortState(SortedMap[UniqueArrival, ApiFlightWithSplits](), SortedMap[TQM, CrunchMinute](), SortedMap[TM, StaffMinute]()))
-      ))
+    ))
 
     offerAndWait(crunch.liveStaffMovementsInput, Seq(staffMovement1, staffMovement2))
 
     val expectedIsoMinutes = Seq(
       "2017-01-01T00:00:00Z",
       "2017-01-01T00:01:00Z"
-      )
+    )
 
     crunch.portStateTestProbe.fishForMessage(2 seconds, s"Didn't find expected minutes ($expectedIsoMinutes)") {
       case PortState(_, _, staffMinutes) =>

--- a/server/src/test/scala/services/crunch/TestDrtActor.scala
+++ b/server/src/test/scala/services/crunch/TestDrtActor.scala
@@ -63,8 +63,7 @@ class TestDrtActor extends Actor {
       val manifestsActor: ActorRef = system.actorOf(Props(new VoyageManifestsActor(oneMegaByte, tc.now, DrtStaticParameters.expireAfterMillis, Option(snapshotInterval))))
       val crunchQueueActor = system.actorOf(Props(new CrunchQueueActor(journalType, tc.airportConfig.crunchOffsetMinutes)))
 
-      val portStateActor = PortStateTestActor(portStateProbe, tc.now, tc.airportConfig.queuesByTerminal)
-      if (tc.initialPortState.isDefined) Await.ready(portStateActor.ask(tc.initialPortState.get)(new Timeout(1 second)), 1 second)
+      val portStateActor = PortStateTestActor(portStateProbe, tc.now, tc.airportConfig.queuesByTerminal, tc.initialPortState)
 
       val portDeskRecs = DesksAndWaitsPortProvider(tc.airportConfig, tc.cruncher, tc.pcpPaxFn)
 


### PR DESCRIPTION
Fix case where a request for state is processed before the PortStateActor has received its state from the crunch state actors
PortStateActor now stashes messages until it's received its initial state, and then `becomes` the regular behaviour to begin processing messages requested
Tests now pass initial state to the crunch state actors rather than sending a message to the port state actor. Code to set state via a message has been removed as it was only used in tests