### PR TITLE
Drtii 544 replay more crunch state messages at ema

### DIFF
--- a/server/src/main/scala/actors/FlightsStateActor.scala
+++ b/server/src/main/scala/actors/FlightsStateActor.scala
@@ -56,7 +56,8 @@ class FlightsStateActor(val now: () => SDateLike,
 
   override def persistenceId: String = "flights-state-actor"
 
-  override val maybeSnapshotInterval: Option[Int] = Option(1000)
+  val snapshotInterval = 1000
+  override val maybeSnapshotInterval: Option[Int] = Option(snapshotInterval)
   override val snapshotBytesThreshold: Int = Sizes.oneMegaByte
   override val recoveryStartMillis: MillisSinceEpoch = now().millisSinceEpoch
 

--- a/server/src/main/scala/actors/FlightsStateActor.scala
+++ b/server/src/main/scala/actors/FlightsStateActor.scala
@@ -37,11 +37,11 @@ object FlightsStateActor {
                         queues: Map[Terminal, Seq[Queue]],
                         expireAfterMillis: Int,
                         legacyDataCutoff: SDateLike,
-                        replayMaxMessages: Int): Props = {
+                        replayMaxCrunchStateMessages: Int): Props = {
     if (isNonLegacyRequest(pointInTime, legacyDataCutoff))
-      Props(new FlightsStateReadActor(now, expireAfterMillis, pointInTime.millisSinceEpoch, queues, legacyDataCutoff))
+      Props(new FlightsStateReadActor(now, expireAfterMillis, pointInTime.millisSinceEpoch, queues, legacyDataCutoff, replayMaxCrunchStateMessages))
     else
-      Props(new CrunchStateReadActor(pointInTime, expireAfterMillis, queues, message.from, message.to, replayMaxMessages))
+      Props(new CrunchStateReadActor(pointInTime, expireAfterMillis, queues, message.from, message.to, replayMaxCrunchStateMessages))
   }
 }
 
@@ -56,7 +56,7 @@ class FlightsStateActor(val now: () => SDateLike,
 
   override def persistenceId: String = "flights-state-actor"
 
-  override val maybeSnapshotInterval: Option[Int] = Option(5000)
+  override val maybeSnapshotInterval: Option[Int] = Option(1000)
   override val snapshotBytesThreshold: Int = Sizes.oneMegaByte
   override val recoveryStartMillis: MillisSinceEpoch = now().millisSinceEpoch
 

--- a/server/src/main/scala/actors/MinuteLookups.scala
+++ b/server/src/main/scala/actors/MinuteLookups.scala
@@ -66,7 +66,7 @@ trait MinuteLookupsLike {
   }
 
   def crunchStateReadActor(date: SDateLike): ActorRef = {
-    system.actorOf(Props(new CrunchStateReadActor(date.addHours(4), expireAfterMillis, queuesByTerminal, date.millisSinceEpoch, date.addDays(1).millisSinceEpoch)))
+    system.actorOf(Props(new CrunchStateReadActor(date.addHours(4), expireAfterMillis, queuesByTerminal, date.millisSinceEpoch, date.addDays(1).millisSinceEpoch, 1000)))
   }
 
   def queueMinutesActor: ActorRef

--- a/server/src/main/scala/actors/MinuteLookups.scala
+++ b/server/src/main/scala/actors/MinuteLookups.scala
@@ -25,6 +25,7 @@ trait MinuteLookupsLike {
   val now: () => SDateLike
   val expireAfterMillis: Int
   val queuesByTerminal: Map[Terminal, Seq[Queue]]
+  val replayMaxCrunchStateMessages: Int
   val requestAndTerminateActor: ActorRef = system.actorOf(Props(new RequestAndTerminateActor()))//, "minutes-lookup-kill-actor")
 
   val updateCrunchMinutes: (Terminal, SDateLike, MinutesContainer[CrunchMinute, TQM]) => Future[MinutesContainer[CrunchMinute, TQM]] = (terminal: Terminal, date: SDateLike, container: MinutesContainer[CrunchMinute, TQM]) => {
@@ -77,7 +78,8 @@ trait MinuteLookupsLike {
 case class MinuteLookups(system: ActorSystem,
                          now: () => SDateLike,
                          expireAfterMillis: Int,
-                         queuesByTerminal: Map[Terminal, Seq[Queue]])
+                         queuesByTerminal: Map[Terminal, Seq[Queue]],
+                         override val replayMaxCrunchStateMessages: Int)
                         (implicit val ec: ExecutionContext) extends MinuteLookupsLike {
   override val queueMinutesActor: ActorRef = system.actorOf(Props(new QueueMinutesActor(now, queuesByTerminal.keys, queuesLookup, legacyQueuesLookup, updateCrunchMinutes)))
 

--- a/server/src/main/scala/actors/PartitionedPortStateActor.scala
+++ b/server/src/main/scala/actors/PartitionedPortStateActor.scala
@@ -24,7 +24,7 @@ import scala.language.postfixOps
 object PartitionedPortStateActor {
   def apply(now: () => SDateLike, airportConfig: AirportConfig, journalType: StreamingJournalLike, legacyDataCutoff: SDateLike, replayMaxCrunchStateMessages: Int)
            (implicit system: ActorSystem, ec: ExecutionContext): ActorRef = {
-    val lookups: MinuteLookups = MinuteLookups(system, now, MilliTimes.oneDayMillis, airportConfig.queuesByTerminal)
+    val lookups: MinuteLookups = MinuteLookups(system, now, MilliTimes.oneDayMillis, airportConfig.queuesByTerminal, replayMaxCrunchStateMessages)
     val flightsActor: ActorRef = system.actorOf(Props(new FlightsStateActor(now, expireAfterMillis, airportConfig.queuesByTerminal, legacyDataCutoff, replayMaxCrunchStateMessages)))
     val queuesActor: ActorRef = lookups.queueMinutesActor
     val staffActor: ActorRef = lookups.staffMinutesActor

--- a/server/src/main/scala/actors/pointInTime/CrunchStateReadActor.scala
+++ b/server/src/main/scala/actors/pointInTime/CrunchStateReadActor.scala
@@ -18,17 +18,15 @@ case class GetCrunchMinutes(terminal: Terminal)
 
 case class GetStaffMinutes(terminal: Terminal)
 
-object CrunchStateReadActor {
-  val snapshotInterval = 1000
-}
 
 class CrunchStateReadActor(pointInTime: SDateLike,
                            expireAfterMillis: Int,
                            portQueues: Map[Terminal, Seq[Queue]],
                            startMillis: MillisSinceEpoch,
-                           endMillis: MillisSinceEpoch)
+                           endMillis: MillisSinceEpoch,
+                           replayMaxMessages: Int)
   extends CrunchStateActor(
-    initialMaybeSnapshotInterval = Option(CrunchStateReadActor.snapshotInterval),
+    initialMaybeSnapshotInterval = Option(replayMaxMessages),
     initialSnapshotBytesThreshold = oneMegaByte,
     name = "crunch-state",
     portQueues = portQueues,
@@ -93,7 +91,7 @@ class CrunchStateReadActor(pointInTime: SDateLike,
     val criteria = SnapshotSelectionCriteria(maxTimestamp = pointInTime.millisSinceEpoch)
     val recovery = Recovery(
       fromSnapshot = criteria,
-      replayMax = CrunchStateReadActor.snapshotInterval)
+      replayMax = replayMaxMessages)
     log.info(s"recovery: $recovery")
     recovery
   }

--- a/server/src/main/scala/actors/pointInTime/FlightsStateReadActor.scala
+++ b/server/src/main/scala/actors/pointInTime/FlightsStateReadActor.scala
@@ -21,7 +21,7 @@ class FlightsStateReadActor(now: () => SDateLike, expireAfterMillis: Int, pointI
 
   override def recovery: Recovery = {
     val criteria = SnapshotSelectionCriteria(maxTimestamp = pointInTime)
-    val recovery = Recovery(fromSnapshot = criteria, replayMax = 1000)
+    val recovery = Recovery(fromSnapshot = criteria, replayMax = snapshotInterval)
     log.info(s"Recovery: $recovery")
     recovery
   }

--- a/server/src/main/scala/actors/pointInTime/FlightsStateReadActor.scala
+++ b/server/src/main/scala/actors/pointInTime/FlightsStateReadActor.scala
@@ -15,7 +15,7 @@ import services.crunch.deskrecs.{GetStateForDateRange, GetStateForTerminalDateRa
 trait FlightsDataLike extends Actor
 
 class FlightsStateReadActor(now: () => SDateLike, expireAfterMillis: Int, pointInTime: MillisSinceEpoch, queues: Map[Terminal, Seq[Queue]], legacyDataCutoff: SDateLike)
-  extends FlightsStateActor(now, expireAfterMillis, queues, legacyDataCutoff) with FlightsDataLike {
+  extends FlightsStateActor(now, expireAfterMillis, queues, legacyDataCutoff, 1000) with FlightsDataLike {
 
   override val log: Logger = LoggerFactory.getLogger(s"$getClass-${SDate(pointInTime).toISOString()}")
 

--- a/server/src/main/scala/actors/pointInTime/FlightsStateReadActor.scala
+++ b/server/src/main/scala/actors/pointInTime/FlightsStateReadActor.scala
@@ -14,14 +14,14 @@ import services.crunch.deskrecs.{GetStateForDateRange, GetStateForTerminalDateRa
 
 trait FlightsDataLike extends Actor
 
-class FlightsStateReadActor(now: () => SDateLike, expireAfterMillis: Int, pointInTime: MillisSinceEpoch, queues: Map[Terminal, Seq[Queue]], legacyDataCutoff: SDateLike)
-  extends FlightsStateActor(now, expireAfterMillis, queues, legacyDataCutoff, 1000) with FlightsDataLike {
+class FlightsStateReadActor(now: () => SDateLike, expireAfterMillis: Int, pointInTime: MillisSinceEpoch, queues: Map[Terminal, Seq[Queue]], legacyDataCutoff: SDateLike, replayMaxCrunchStateMessages: Int)
+  extends FlightsStateActor(now, expireAfterMillis, queues, legacyDataCutoff, replayMaxCrunchStateMessages) with FlightsDataLike {
 
   override val log: Logger = LoggerFactory.getLogger(s"$getClass-${SDate(pointInTime).toISOString()}")
 
   override def recovery: Recovery = {
     val criteria = SnapshotSelectionCriteria(maxTimestamp = pointInTime)
-    val recovery = Recovery(fromSnapshot = criteria, replayMax = 10000)
+    val recovery = Recovery(fromSnapshot = criteria, replayMax = 1000)
     log.info(s"Recovery: $recovery")
     recovery
   }

--- a/server/src/main/scala/test/TestActors.scala
+++ b/server/src/main/scala/test/TestActors.scala
@@ -140,7 +140,7 @@ object TestActors {
   }
 
   class TestPortStateActor(liveProps: Props, forecastProps: Props, now: () => SDateLike, liveDaysAhead: Int, queues: Map[Terminal, Seq[Queue]])
-    extends PortStateActor(liveProps, forecastProps, now, liveDaysAhead, queues) {
+    extends PortStateActor(liveProps, forecastProps, now, liveDaysAhead, queues, replayMaxCrunchStateMessages = 1000) {
     def reset: Receive = {
       case ResetData =>
         val replyTo = sender()
@@ -225,7 +225,8 @@ object TestActors {
                                       staffActor: ActorRef,
                                       now: () => SDateLike,
                                       queues: Map[Terminal, Seq[Queue]],
-                                      journalType: StreamingJournalLike) extends PartitionedPortStateActor(flightsActor, queuesActor, staffActor, now, queues, journalType, SDate("1970-01-01"), PartitionedPortStateActor.tempLegacyActorProps) with TestPartitionedPortStateActorLike {
+                                      journalType: StreamingJournalLike)
+    extends PartitionedPortStateActor(flightsActor, queuesActor, staffActor, now, queues, journalType, SDate("1970-01-01"), PartitionedPortStateActor.tempLegacyActorProps(1000)) with TestPartitionedPortStateActorLike {
     val actorClearRequests = Map(
       flightsActor -> ResetData,
       queuesActor -> ResetData,
@@ -272,7 +273,7 @@ object TestActors {
                               name: String,
                               now: () => SDateLike,
                               expireAfterMillis: Int,
-                              queues: Map[Terminal, Seq[Queue]]) extends FlightsStateActor(now, expireAfterMillis, queues, SDate("1970-01-01")) with Resettable {
+                              queues: Map[Terminal, Seq[Queue]]) extends FlightsStateActor(now, expireAfterMillis, queues, SDate("1970-01-01"), 1000) with Resettable {
     override def resetState(): Unit = state = FlightsWithSplits.empty
 
     override def receiveCommand: Receive = resetBehaviour orElse super.receiveCommand

--- a/server/src/main/scala/test/TestMinuteLookups.scala
+++ b/server/src/main/scala/test/TestMinuteLookups.scala
@@ -18,7 +18,7 @@ case class TestMinuteLookups(system: ActorSystem,
                              queuesByTerminal: Map[Terminal, Seq[Queue]])
                             (implicit val ec: ExecutionContext) extends MinuteLookupsLike {
   override val replayMaxCrunchStateMessages = 1000
-  
+
   val resetQueuesData: (Terminal, MillisSinceEpoch) => Future[Any] = (terminal: Terminal, millis: MillisSinceEpoch) => {
     val date = SDate(millis)
     val actor = system.actorOf(Props(new TestTerminalDayQueuesActor(date.getFullYear(), date.getMonth(), date.getDate(), terminal, now)))

--- a/server/src/main/scala/test/TestMinuteLookups.scala
+++ b/server/src/main/scala/test/TestMinuteLookups.scala
@@ -17,6 +17,8 @@ case class TestMinuteLookups(system: ActorSystem,
                              expireAfterMillis: Int,
                              queuesByTerminal: Map[Terminal, Seq[Queue]])
                             (implicit val ec: ExecutionContext) extends MinuteLookupsLike {
+  override val replayMaxCrunchStateMessages = 1000
+  
   val resetQueuesData: (Terminal, MillisSinceEpoch) => Future[Any] = (terminal: Terminal, millis: MillisSinceEpoch) => {
     val date = SDate(millis)
     val actor = system.actorOf(Props(new TestTerminalDayQueuesActor(date.getFullYear(), date.getMonth(), date.getDate(), terminal, now)))

--- a/server/src/test/scala/actors/FlightsStateActorResponsesSpec.scala
+++ b/server/src/test/scala/actors/FlightsStateActorResponsesSpec.scala
@@ -24,7 +24,7 @@ class FlightsStateActorResponsesSpec extends CrunchTestLike {
 
   val legacyDataCutoff: SDateLike = SDate("1970-01-01")
 
-  def actor: ActorRef = system.actorOf(Props(new FlightsStateActor(myNow, MilliTimes.oneDayMillis, Map(), legacyDataCutoff)))
+  def actor: ActorRef = system.actorOf(Props(new FlightsStateActor(myNow, MilliTimes.oneDayMillis, Map(), legacyDataCutoff, 1000)))
 
   val messagesAndResponseTypes: Map[Any, (PartialFunction[Any, Result], Any)] = Map(
     GetStateForTerminalDateRange(0L, 1L, T1) -> (({ case _: FlightsWithSplits => success }, classOf[FlightsWithSplits])),

--- a/server/src/test/scala/actors/PartitionedPortStateActorSpec.scala
+++ b/server/src/test/scala/actors/PartitionedPortStateActorSpec.scala
@@ -19,7 +19,7 @@ class TestCrunchStateReadActor(probe: ActorRef,
                                expireAfterMillis: Int,
                                portQueues: Map[Terminal, Seq[Queue]],
                                startMillis: MillisSinceEpoch,
-                               endMillis: MillisSinceEpoch) extends CrunchStateReadActor(pointInTime, expireAfterMillis, portQueues, startMillis, endMillis) {
+                               endMillis: MillisSinceEpoch) extends CrunchStateReadActor(pointInTime, expireAfterMillis, portQueues, startMillis, endMillis, 1000) {
   override def receiveCommand: Receive = {
     case msg => probe ! msg
   }

--- a/server/src/test/scala/actors/PartitionedPortStateTestActor.scala
+++ b/server/src/test/scala/actors/PartitionedPortStateTestActor.scala
@@ -19,7 +19,7 @@ import scala.concurrent.ExecutionContext
 object PartitionedPortStateTestActor {
   def apply(testProbe: TestProbe, flightsActor: ActorRef, now: () => SDateLike, airportConfig: AirportConfig)
            (implicit system: ActorSystem, ec: ExecutionContext): ActorRef = {
-    val lookups = MinuteLookups(system, now, MilliTimes.oneDayMillis, airportConfig.queuesByTerminal)
+    val lookups = MinuteLookups(system, now, MilliTimes.oneDayMillis, airportConfig.queuesByTerminal, 1000)
     val queuesActor = lookups.queueMinutesActor
     val staffActor = lookups.staffMinutesActor
     system.actorOf(Props(new PartitionedPortStateTestActor(testProbe.ref, flightsActor, queuesActor, staffActor, now, airportConfig.queuesByTerminal)))
@@ -31,7 +31,8 @@ class PartitionedPortStateTestActor(probe: ActorRef,
                                     queuesActor: ActorRef,
                                     staffActor: ActorRef,
                                     now: () => SDateLike,
-                                    queues: Map[Terminal, Seq[Queue]]) extends PartitionedPortStateActor(flightsActor, queuesActor, staffActor, now, queues, InMemoryStreamingJournal, SDate("1970-01-01"), PartitionedPortStateActor.tempLegacyActorProps(1000)) {
+                                    queues: Map[Terminal, Seq[Queue]])
+  extends PartitionedPortStateActor(flightsActor, queuesActor, staffActor, now, queues, InMemoryStreamingJournal, SDate("1970-01-01"), PartitionedPortStateActor.tempLegacyActorProps(1000)) {
   var state: PortState = PortState.empty
 
   override def receive: Receive = processMessage orElse {

--- a/server/src/test/scala/actors/PartitionedPortStateTestActor.scala
+++ b/server/src/test/scala/actors/PartitionedPortStateTestActor.scala
@@ -31,7 +31,7 @@ class PartitionedPortStateTestActor(probe: ActorRef,
                                     queuesActor: ActorRef,
                                     staffActor: ActorRef,
                                     now: () => SDateLike,
-                                    queues: Map[Terminal, Seq[Queue]]) extends PartitionedPortStateActor(flightsActor, queuesActor, staffActor, now, queues, InMemoryStreamingJournal, SDate("1970-01-01"), PartitionedPortStateActor.tempLegacyActorProps) {
+                                    queues: Map[Terminal, Seq[Queue]]) extends PartitionedPortStateActor(flightsActor, queuesActor, staffActor, now, queues, InMemoryStreamingJournal, SDate("1970-01-01"), PartitionedPortStateActor.tempLegacyActorProps(1000)) {
   var state: PortState = PortState.empty
 
   override def receive: Receive = processMessage orElse {

--- a/server/src/test/scala/actors/PortStateTestActor.scala
+++ b/server/src/test/scala/actors/PortStateTestActor.scala
@@ -20,7 +20,7 @@ class PortStateTestActor(liveProps: Props,
                          now: () => SDateLike,
                          liveDaysAhead: Int,
                          queues: Map[Terminal, Seq[Queue]])
-  extends PortStateActor(liveProps, forecastProps, now, liveDaysAhead, queues) {
+  extends PortStateActor(liveProps, forecastProps, now, liveDaysAhead, queues, replayMaxCrunchStateMessages = 1000) {
   override def splitDiffAndSend(diff: PortStateDiff): Unit = {
     super.splitDiffAndSend(diff)
     probe ! state.immutable

--- a/server/src/test/scala/services/PortStateSpec.scala
+++ b/server/src/test/scala/services/PortStateSpec.scala
@@ -302,7 +302,7 @@ class PortStateSpec extends CrunchTestLike {
         val maybePortState = Option(PortState(Iterable(flightsWithSplits), Iterable(), Iterable()))
         val liveActor = Props(new SlowCrunchStateActor(maybePortState, delay = 1 second))
         val fcstActor = Props(new SlowCrunchStateActor(Option(PortState.empty), delay = 0 seconds))
-        val portStateActor = system.actorOf(Props(new PortStateActor(liveActor, fcstActor, () => today, 2, defaultAirportConfig.queuesByTerminal)))
+        val portStateActor = system.actorOf(Props(new PortStateActor(liveActor, fcstActor, () => today, 2, defaultAirportConfig.queuesByTerminal, replayMaxCrunchStateMessages = 1000)))
         val response = Await.result(portStateActor.ask(GetFlights(today.millisSinceEpoch, today.addMinutes(1).millisSinceEpoch)), 5 seconds)
 
         response === FlightsWithSplits(Map(flightsWithSplits.unique -> flightsWithSplits))

--- a/server/src/test/scala/services/crunch/PortStateRequestsSpec.scala
+++ b/server/src/test/scala/services/crunch/PortStateRequestsSpec.scala
@@ -28,10 +28,10 @@ class PortStateRequestsSpec extends CrunchTestLike {
   def portStateActorProvider: () => ActorRef = () => {
     val liveCsa = Props(new CrunchStateActor(None, Sizes.oneMegaByte, "crunch-state", airportConfig.queuesByTerminal, myNow, expireAfterMillis, false, forecastMaxMillis))
     val fcstCsa = Props(new CrunchStateActor(None, Sizes.oneMegaByte, "forecast-crunch-state", airportConfig.queuesByTerminal, myNow, expireAfterMillis, false, forecastMaxMillis))
-    PortStateActor(myNow, liveCsa, fcstCsa, defaultAirportConfig.queuesByTerminal)
+    PortStateActor(myNow, liveCsa, fcstCsa, defaultAirportConfig.queuesByTerminal, 1000)
   }
 
-  def partitionedPortStateActorProvider: () => ActorRef = () => PartitionedPortStateActor(myNow, airportConfig, InMemoryStreamingJournal, SDate("1970-01-01"))
+  def partitionedPortStateActorProvider: () => ActorRef = () => PartitionedPortStateActor(myNow, airportConfig, InMemoryStreamingJournal, SDate("1970-01-01"), 1000)
 
   def resetData(terminal: Terminal, day: SDateLike): Unit = {
     val actor = system.actorOf(Props(new TestTerminalDayQueuesActor(day.getFullYear(), day.getMonth(), day.getDate(), terminal, () => SDate.now())))

--- a/shared/src/main/scala/drt/shared/airportconfig/Lhr.scala
+++ b/shared/src/main/scala/drt/shared/airportconfig/Lhr.scala
@@ -95,7 +95,6 @@ object Lhr extends AirportConfigLike {
       "Evening shift, T2, {date}, 17:00, 23:59, 22"
     ),
     hasActualDeskStats = true,
-    portStateSnapshotInterval = 250,
     hasEstChox = true,
     exportQueueOrder = Queues.exportQueueOrderWithFastTrack,
     role = LHRAccess,


### PR DESCRIPTION
Use the snapshotInterval from AirportConfig for replaying CrunchState messages, allowing us to override the default value of 1000