### PR TITLE
Drtii 564 stop acking updatedmillis

### DIFF
--- a/server/src/main/scala/actors/queues/QueueLikeActor.scala
+++ b/server/src/main/scala/actors/queues/QueueLikeActor.scala
@@ -86,7 +86,7 @@ abstract class QueueLikeActor(val now: () => SDateLike, val journalType: Streami
       val days: Set[MillisSinceEpoch] = uniqueDays(millis)
       updateState(days)
       emitNextDayIfReady()
-      persistAndMaybeSnapshot(DaysMessage(days.toList), Option((sender(), Ack)))
+      persistAndMaybeSnapshot(DaysMessage(days.toList))
 
     case _: SaveSnapshotSuccess =>
       log.info(s"Successfully saved snapshot")

--- a/server/src/test/scala/actors/queues/CrunchQueueSpec.scala
+++ b/server/src/test/scala/actors/queues/CrunchQueueSpec.scala
@@ -57,7 +57,7 @@ class CrunchQueueSpec extends CrunchTestLike with ImplicitSender {
         watch(actor)
         actor ! UpdatedMillis(Iterable(today, tomorrow))
         daysSourceProbe.expectMsg(today)
-        expectMsg(Ack)
+        Thread.sleep(200)
         actor ! PoisonPill
         expectMsgAllClassOf(classOf[Terminated])
 

--- a/server/src/test/scala/actors/queues/DeploymentQueueSpec.scala
+++ b/server/src/test/scala/actors/queues/DeploymentQueueSpec.scala
@@ -57,7 +57,7 @@ class DeploymentQueueSpec extends CrunchTestLike with ImplicitSender {
         watch(actor)
         actor ! UpdatedMillis(Iterable(today, tomorrow))
         daysSourceProbe.expectMsg(today)
-        expectMsg(Ack)
+        Thread.sleep(200)
         actor ! PoisonPill
         expectMsgAllClassOf(classOf[Terminated])
 

--- a/server/src/test/scala/manifests/graph/ManifestGraphSpec.scala
+++ b/server/src/test/scala/manifests/graph/ManifestGraphSpec.scala
@@ -118,9 +118,11 @@ class ManifestGraphSpec extends CrunchTestLike {
       Crunch.isDueLookup,
       () => SDate("2019-03-06T11:00:00Z"))
 
+    val eventualResponses = responseSource.runWith(Sink.seq)
+
     Source(List(List(testArrival))).runWith(requestSink)
 
-    val responses = Await.result(responseSource.runWith(Sink.seq), 2 second)
+    val responses = Await.result(eventualResponses, 2 second)
 
     killSwitch.shutdown()
 


### PR DESCRIPTION
Stop sending Acks as they're being logged as errors now
Fix tests - unfortunately this means waiting a short time to be sure things are persisted before terminating
Possibly fix for the flaky manifests test