### PR TITLE
Drtii 574 properly handle dead streaming updates actors

### DIFF
--- a/server/src/main/scala/actors/ArrivalsActor.scala
+++ b/server/src/main/scala/actors/ArrivalsActor.scala
@@ -167,7 +167,6 @@ abstract class ArrivalsActor(now: () => SDateLike,
   override def receiveCommand: Receive = {
     case ArrivalsFeedSuccess(Flights(incomingArrivals), createdAt) =>
       handleFeedSuccess(incomingArrivals, createdAt)
-      sender() ! ArrivalsFeedSuccessAck
 
     case ArrivalsFeedFailure(message, createdAt) => handleFeedFailure(message, createdAt)
 

--- a/server/src/main/scala/actors/daily/UpdatesSupervisor.scala
+++ b/server/src/main/scala/actors/daily/UpdatesSupervisor.scala
@@ -40,10 +40,16 @@ class StaffUpdatesSupervisor(now: () => SDateLike,
                              updatesActorFactory: (Terminal, SDateLike) => Props)
   extends UpdatesSupervisor[StaffMinute, TM](now, terminals, updatesActorFactory)
 
+object UpdatesSupervisor {
+  case class UpdateLastRequest(terminal: Terminal, day: MillisSinceEpoch, lastRequestMillis: MillisSinceEpoch)
+}
+
 abstract class UpdatesSupervisor[A, B <: WithTimeAccessor](now: () => SDateLike,
                                                   terminals: List[Terminal],
                                                   updatesActorFactory: (Terminal, SDateLike) => Props) extends Actor {
   val log: Logger = LoggerFactory.getLogger(getClass)
+
+  import UpdatesSupervisor._
 
   implicit val ex: ExecutionContextExecutor = context.dispatcher
   implicit val mat: ActorMaterializer = ActorMaterializer.create(context)
@@ -91,6 +97,9 @@ abstract class UpdatesSupervisor[A, B <: WithTimeAccessor](now: () => SDateLike,
       terminalsAndDaysUpdatesSource(terminalDays, sinceMillis)
         .runWith(Sink.fold(MinutesContainer.empty[A, B])(_ ++ _))
         .pipeTo(replyTo)
+
+    case UpdateLastRequest(terminal, day, lastRequestMillis) =>
+      lastRequests = lastRequests + ((terminal, day) -> lastRequestMillis)
   }
 
   def terminalDaysForPeriod(fromMillis: MillisSinceEpoch,
@@ -116,10 +125,13 @@ abstract class UpdatesSupervisor[A, B <: WithTimeAccessor](now: () => SDateLike,
     Source(terminalDays)
       .mapAsync(1) {
         case (terminal, day) =>
-          lastRequests = lastRequests + ((terminal, day) -> now().millisSinceEpoch)
           updatesActor(terminal, day)
             .ask(GetAllUpdatesSince(sinceMillis))
             .mapTo[MinutesContainer[A, B]]
+            .map { container =>
+              self ! UpdateLastRequest(terminal, day, now().millisSinceEpoch)
+              container
+            }
             .recoverWith {
               case t: AskTimeoutException =>
                 log.warn(s"Timed out waiting for updates. Actor may have already been terminated", t)


### PR DESCRIPTION
- Only update the last request-time on a successful response
- A run of unsuccessful responses will result in the actor being shut down and removed due to an old last-request time
- Remove unused actors from the two maps before shutting them down to reduce the chances of them being queried as they're shut down