### PR TITLE
Drtii 627 redirect new users to access request form

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,7 +59,7 @@ pipeline:
       - play
     commands:
       - docker login -u $${DOCKER_USERNAME} -p $${DOCKER_PASSWORD} docker.digital.homeoffice.gov.uk
-      - docker run -m 5g -d --name $${DRONE_COMMIT_SHA} -e ENABLE_STATSD=false -e CONTACT_EMAIL=support@test.com -e OOH_PHONE=012345 -e KEY_CLOAK_URL="https://sso-dev.notprod.homeoffice.gov.uk/auth/admin/realms/drt-notprod" -e JAVA_OPTS="-Xmx4g -Dconfig.resource=application-inmemory.conf" -e USE_API_PAX_NOS=true -e ADJUST_EGATES_USE_BY_U12S=true -e PORT_CODE="test" -e ENV="test" -e FORECAST_MAX_DAYS=2 -e STAGE_THROTTLE_MILLIS=50 docker.digital.homeoffice.gov.uk/drt/drt:latest $${PLAY}
+      - docker run -m 5g -d --name $${DRONE_COMMIT_SHA} -e ENABLE_STATSD=false -e CONTACT_EMAIL=support@test.com -e OOH_PHONE=012345 -e KEY_CLOAK_URL="https://sso-dev.notprod.homeoffice.gov.uk/auth/admin/realms/drt-notprod" -e JAVA_OPTS="-Xmx4g -Dconfig.resource=application-inmemory.conf" -e USE_API_PAX_NOS=true -e ADJUST_EGATES_USE_BY_U12S=true -e PORT_CODE="test" -e ENV="test" -e FORECAST_MAX_DAYS=2 -e STAGE_THROTTLE_MILLIS=50 -e BASE_DOMAIN=drt-test.homeoffice.gov.uk docker.digital.homeoffice.gov.uk/drt/drt:latest $${PLAY}
       - docker build -t drt-cypress -f cy-drt-dockfile .
       - docker run --net=container:$${DRONE_COMMIT_SHA} -e CYPRESS_baseUrl="http://localhost:9000" drt-cypress /bin/bash -c "npm run test"
     when:

--- a/client/src/main/scala/drt/client/components/Layout.scala
+++ b/client/src/main/scala/drt/client/components/Layout.scala
@@ -33,25 +33,20 @@ object Layout {
           ),
           <.div(
             layoutModelItems.userPot.renderReady(loggedInUser => {
-              layoutModelItems.hasPortAccessPot.renderReady(userHasPortAccess => {
-                if (userHasPortAccess) {
-                  val airportConfigRCP = SPACircuit.connect(_.airportConfig)
+              val airportConfigRCP = SPACircuit.connect(_.airportConfig)
 
-                  airportConfigRCP(airportConfigMP => {
-                    val airportConfig = airportConfigMP()
+              airportConfigRCP(airportConfigMP => {
+                val airportConfig = airportConfigMP()
+                <.div(
+                  airportConfig.renderReady(airportConfig => {
                     <.div(
-                      airportConfig.renderReady(airportConfig => {
-                        <.div(
-                          Navbar(props.ctl, props.currentLoc.page, loggedInUser, airportConfig),
-                          <.div(^.className := "container",
-                            <.div(<.div(props.currentLoc.render()))
-                          ), VersionUpdateNotice())
-                      }), layoutModelItems
-                        .displayAlertDialog
-                        .renderReady(displayDialog => PortRestrictionsModalAlert(displayDialog, loggedInUser)))
-                  })
-
-                } else <.div(RestrictedAccessByPortPage(loggedInUser, props.ctl))
+                      Navbar(props.ctl, props.currentLoc.page, loggedInUser, airportConfig),
+                      <.div(^.className := "container",
+                        <.div(<.div(props.currentLoc.render()))
+                      ), VersionUpdateNotice())
+                  }), layoutModelItems
+                    .displayAlertDialog
+                    .renderReady(displayDialog => PortRestrictionsModalAlert(displayDialog, loggedInUser)))
               })
             }))
         )

--- a/client/src/main/scala/drt/client/components/RestrictedAccessByPortPage.scala
+++ b/client/src/main/scala/drt/client/components/RestrictedAccessByPortPage.scala
@@ -1,17 +1,9 @@
 package drt.client.components
 
+import drt.shared.{AirportConfig, AirportConfigs, PortCode}
+import org.scalajs.dom
 import uk.gov.homeoffice.drt.auth.LoggedInUser
 import uk.gov.homeoffice.drt.auth.Roles.Role
-import drt.client.SPAMain.Loc
-import drt.client.logger.{Logger, LoggerFactory}
-import drt.client.modules.GoogleEventTracker
-import drt.shared.CrunchApi.MillisSinceEpoch
-import drt.shared.{AirportConfig, AirportConfigs, PortCode}
-import japgolly.scalajs.react.component.Scala.Component
-import japgolly.scalajs.react.extra.router.{BaseUrl, RouterCtl}
-import japgolly.scalajs.react.vdom.html_<^.{^, _}
-import japgolly.scalajs.react.{Callback, CtorType, ScalaComponent}
-import org.scalajs.dom
 
 object RestrictedAccessByPortPage {
   val allAirportConfigsToDisplay: List[AirportConfig] = AirportConfigs.allPortConfigs diff AirportConfigs.testPorts
@@ -29,46 +21,5 @@ object RestrictedAccessByPortPage {
     .find(_.portCode == portCode)
     .exists(c => loggedInUser.hasRole(c.role))
 
-  case class Props(loggedInUser: LoggedInUser, ctl: RouterCtl[Loc])
-
-  val log: Logger = LoggerFactory.getLogger(getClass.getName)
-
-  case class State(title: Option[String] = None, message: Option[String] = None, expiryDateTime: Option[MillisSinceEpoch] = None)
-
-  def url(port: PortCode) = urlLowerCase.replace(portRequested.toString.toLowerCase, port.toString.toLowerCase)
-
-  val component: Component[Props, Unit, Unit, CtorType.Props] = ScalaComponent.builder[Props]("RestrictedAccessForPort")
-    .render_P(props => {
-      val portsAccessible: Set[PortCode] = allPortsAccessible(props.loggedInUser.roles)
-      <.div(^.className := "access-restricted",
-        <.span(
-          <.h2(^.id := "access-restricted", "Access Restricted"),
-          <.div(
-            <.p(^.id := "email-for-access", s"You do not currently have permission to access $portRequested. If you would like access to this port, " +
-              "please contact us to request access."),
-            <.p(
-              "Once your request has been processed, please ", <.a(Icon.signOut, "Log Out", ^.href := "/oauth/logout?redirect=" + BaseUrl.until_#.value,
-                ^.onClick --> Callback(GoogleEventTracker.sendEvent(portRequested.toString, "Log Out from Access Restricted Page", props.loggedInUser.id))),
-              " and login again to update your permissions."
-            ),
-            <.h3("Contact Details"),
-            ContactDetailsComponent(),
-
-            if (portsAccessible.nonEmpty) {
-              <.div(^.id := "alternate-ports",
-                <.p("Alternatively you are able to access the following ports"),
-                <.ul(
-                  portsAccessible.map(port =>
-                    <.li(^.key := port.toString, <.a(^.id := s"$port-link", port.toString, ^.href := url(port)))
-                  ).toVdomArray
-                )
-              )
-            } else TagMod()
-          )
-        )
-      )
-    })
-    .build
-
-  def apply(loggedInUser: LoggedInUser, ctl: RouterCtl[Loc] ): VdomElement = component(Props(loggedInUser, ctl))
+  def url(port: PortCode): String = urlLowerCase.replace(portRequested.toString.toLowerCase, port.toString.toLowerCase)
 }

--- a/client/src/main/scala/drt/client/components/RestrictedAccessByPortPage.scala
+++ b/client/src/main/scala/drt/client/components/RestrictedAccessByPortPage.scala
@@ -39,7 +39,6 @@ object RestrictedAccessByPortPage {
 
   val component: Component[Props, Unit, Unit, CtorType.Props] = ScalaComponent.builder[Props]("RestrictedAccessForPort")
     .render_P(props => {
-
       val portsAccessible: Set[PortCode] = allPortsAccessible(props.loggedInUser.roles)
       <.div(^.className := "access-restricted",
         <.span(

--- a/e2e/tests/integration/api-role-access.ts
+++ b/e2e/tests/integration/api-role-access.ts
@@ -273,7 +273,7 @@ describe('Restrict access to endpoint by role', () => {
       shouldBeGranted: false
     },
     {
-      roles: [],
+      roles: ["test"],
       endpoint: "/",
       method: "GET",
       shouldBeGranted: true
@@ -345,7 +345,7 @@ describe('Restrict access to endpoint by role', () => {
       shouldBeGranted: false
     },
     {
-       roles: [],
+       roles: ["test"],
        endpoint: "/#faqs",
        method: "GET",
        shouldBeGranted: true

--- a/e2e/tests/integration/errors.ts
+++ b/e2e/tests/integration/errors.ts
@@ -1,4 +1,3 @@
-
 describe('Global error handler', () => {
 
   interface ErrorResponse {
@@ -28,10 +27,12 @@ describe('Global error handler', () => {
 
   it("should log an error event to the server and popup a confirmation dialog to reload the page", () => {
     preventExceptionFromFailingTest();
-    cy.visit('/');
-    cy.server();
     let pageLoadCount = 1;
-    cy.route("POST", "/logging", {}).as('postLog');
+    cy
+      .asABorderForceOfficer()
+      .visit('/')
+      .server()
+      .route("POST", "/logging", {}).as('postLog');
     cy.on('window:confirm', () => true);
     cy.on("window:before:load", () => {
       pageLoadCount++;
@@ -47,10 +48,12 @@ describe('Global error handler', () => {
 
   it("should not reload the page if the user selects not to", () => {
     preventExceptionFromFailingTest();
-    cy.visit('/');
     let pageLoadCount = 1;
-    cy.on('window:confirm', () => false);
+    cy
+      .asABorderForceOfficer()
+      .visit('/');
 
+    cy.on('window:confirm', () => false);
     cy.on("window:before:load", () => {
       pageLoadCount++;
     });

--- a/e2e/tests/integration/restrict-access-by-port.ts
+++ b/e2e/tests/integration/restrict-access-by-port.ts
@@ -12,53 +12,5 @@ describe('Restrict access by port', () => {
         .asATestPortUser()
         .navigateHome().then(() => cy.contains('.navbar-drt', 'DRT TEST'));
     });
-
-    // it("During business hours I should see only the DRT Team contact address but Out of Hours I should see the Support phone number", () => {
-    //   cy
-    //     .server()
-    //     .route({ method: 'GET', url: 'ooh-status', status: 200, response: { "localTime": "2019-08-12 16:58", "isOoh": true }, delay: 100, })
-    //     .as('getSupportOOH')
-    //     .asANonTestPortUser()
-    //     .navigateHome()
-    //     .wait('@getSupportOOH')
-    //     .assertAccessRestricted()
-    //     .get(".access-restricted")
-    //     .contains("For urgent issues contact our out of hours support team on")
-    //     .get('#alternate-ports')
-    //     .should('not.exist')
-    //     .route({ method: 'GET', url: 'ooh-status', status: 200, response: { "localTime": "2019-08-12 16:58", "isOoh": false }, delay: 100, })
-    //     .as('getSupportInHours')
-    //     .navigateHome()
-    //     .wait('@getSupportInHours')
-    //     .get(".access-restricted")
-    //     .contains("Contact the Dynamic Response Tool service team by email at")
-    //     ;
-    // });
-
-
-    // it("When I only have permission to view LHR I see access restricted page with a link to LHR only", () => {
-    //   cy
-    //     .asAnLHRPortUser()
-    //     .navigateHome()
-    //     .assertAccessRestricted()
-    //     .get('#alternate-ports')
-    //     .should('exist')
-    //     .contains('#LHR-link', 'LHR')
-    //     .get('#LGW-link')
-    //     .should('not.exist');
-    // });
-
-    // it("When I have permission to view LHR and LGW I see access restricted page with a link to both ports", () => {
-    //   cy
-    //     .setRoles(["LHR", "LGW"])
-    //     .navigateHome()
-    //     .assertAccessRestricted()
-    //     .get('#alternate-ports')
-    //     .should('exist')
-    //     .then(() => {
-    //       cy.contains('#LHR-link', 'LHR')
-    //       cy.contains('#LGW-link', 'LGW');
-    //     });
-    // });
   });
 });

--- a/e2e/tests/integration/restrict-access-by-port.ts
+++ b/e2e/tests/integration/restrict-access-by-port.ts
@@ -13,52 +13,52 @@ describe('Restrict access by port', () => {
         .navigateHome().then(() => cy.contains('.navbar-drt', 'DRT TEST'));
     });
 
-    it("During business hours I should see only the DRT Team contact address but Out of Hours I should see the Support phone number", () => {
-      cy.server()
-      cy
-        .route({ method: 'GET', url: 'ooh-status', status: 200, response: { "localTime": "2019-08-12 16:58", "isOoh": true }, delay: 100, })
-        .as('getSupportOOH')
-        .asANonTestPortUser()
-        .navigateHome()
-        .wait('@getSupportOOH')
-        .assertAccessRestricted()
-        .get(".access-restricted")
-        .contains("For urgent issues contact our out of hours support team on")
-        .get('#alternate-ports')
-        .should('not.exist')
-        .route({ method: 'GET', url: 'ooh-status', status: 200, response: { "localTime": "2019-08-12 16:58", "isOoh": false }, delay: 100, })
-        .as('getSupportInHours')
-        .navigateHome()
-        .wait('@getSupportInHours')
-        .get(".access-restricted")
-        .contains("Contact the Dynamic Response Tool service team by email at")
-        ;
-    });
+    // it("During business hours I should see only the DRT Team contact address but Out of Hours I should see the Support phone number", () => {
+    //   cy
+    //     .server()
+    //     .route({ method: 'GET', url: 'ooh-status', status: 200, response: { "localTime": "2019-08-12 16:58", "isOoh": true }, delay: 100, })
+    //     .as('getSupportOOH')
+    //     .asANonTestPortUser()
+    //     .navigateHome()
+    //     .wait('@getSupportOOH')
+    //     .assertAccessRestricted()
+    //     .get(".access-restricted")
+    //     .contains("For urgent issues contact our out of hours support team on")
+    //     .get('#alternate-ports')
+    //     .should('not.exist')
+    //     .route({ method: 'GET', url: 'ooh-status', status: 200, response: { "localTime": "2019-08-12 16:58", "isOoh": false }, delay: 100, })
+    //     .as('getSupportInHours')
+    //     .navigateHome()
+    //     .wait('@getSupportInHours')
+    //     .get(".access-restricted")
+    //     .contains("Contact the Dynamic Response Tool service team by email at")
+    //     ;
+    // });
 
 
-    it("When I only have permission to view LHR I see access restricted page with a link to LHR only", () => {
-      cy
-        .asAnLHRPortUser()
-        .navigateHome()
-        .assertAccessRestricted()
-        .get('#alternate-ports')
-        .should('exist')
-        .contains('#LHR-link', 'LHR')
-        .get('#LGW-link')
-        .should('not.exist');
-    });
+    // it("When I only have permission to view LHR I see access restricted page with a link to LHR only", () => {
+    //   cy
+    //     .asAnLHRPortUser()
+    //     .navigateHome()
+    //     .assertAccessRestricted()
+    //     .get('#alternate-ports')
+    //     .should('exist')
+    //     .contains('#LHR-link', 'LHR')
+    //     .get('#LGW-link')
+    //     .should('not.exist');
+    // });
 
-    it("When I have permission to view LHR and LGW I see access restricted page with a link to both ports", () => {
-      cy
-        .setRoles(["LHR", "LGW"])
-        .navigateHome()
-        .assertAccessRestricted()
-        .get('#alternate-ports')
-        .should('exist')
-        .then(() => {
-          cy.contains('#LHR-link', 'LHR')
-          cy.contains('#LGW-link', 'LGW');
-        });
-    });
+    // it("When I have permission to view LHR and LGW I see access restricted page with a link to both ports", () => {
+    //   cy
+    //     .setRoles(["LHR", "LGW"])
+    //     .navigateHome()
+    //     .assertAccessRestricted()
+    //     .get('#alternate-ports')
+    //     .should('exist')
+    //     .then(() => {
+    //       cy.contains('#LHR-link', 'LHR')
+    //       cy.contains('#LGW-link', 'LGW');
+    //     });
+    // });
   });
 });

--- a/e2e/tests/support/commands.ts
+++ b/e2e/tests/support/commands.ts
@@ -40,14 +40,16 @@ const bfRoles = [
   "desks-and-queues:view",
   "staff-movements:edit",
   "staff-movements:export",
-  "enhanced-api-view"
+  "enhanced-api-view",
+  "test"
 ];
 const bfReadOnlyRoles = [
   "border-force-staff",
   "forecast:view",
   "fixed-points:view",
   "arrivals-and-splits:view",
-  "desks-and-queues:view"
+  "desks-and-queues:view",
+  "test"
 ];
 const bfPlanningRoles = ["staff:edit"];
 const superUserRoles = ["create-alerts", "manage-users"];

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -74,7 +74,7 @@ object Settings {
     val openSaml = "2.6.1"
     val drtBirminghamSchema = "1.2.0"
     val drtCirium = "48"
-    val drtLib = "38"
+    val drtLib = "41"
     val playJson = "2.6.0"
     val playIteratees = "2.6.1"
     val uPickle = "0.6.7"

--- a/server/src/main/resources/config/common.conf
+++ b/server/src/main/resources/config/common.conf
@@ -4,6 +4,9 @@ application.cdn = ${?APPLICATION_CDN}
 portcode = "xxx"
 portcode = ${?PORT_CODE}
 
+base-domain = "localhost"
+base-domain = ${BASE_DOMAIN}
+
 enable-statsd = true
 enable-statsd = ${?ENABLE_STATSD}
 

--- a/server/src/main/resources/config/common.conf
+++ b/server/src/main/resources/config/common.conf
@@ -5,7 +5,7 @@ portcode = "xxx"
 portcode = ${?PORT_CODE}
 
 base-domain = "localhost"
-base-domain = ${BASE_DOMAIN}
+base-domain = ${?BASE_DOMAIN}
 
 enable-statsd = true
 enable-statsd = ${?ENABLE_STATSD}

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -369,7 +369,14 @@ class Application @Inject()(implicit val config: Configuration, env: Environment
 
   def index: Action[AnyContent] = Action { request =>
     val user = ctrl.getLoggedInUser(config, request.headers, request.session)
-    Ok(views.html.index("DRT - BorderForce", portCode.toString, googleTrackingCode, user.id))
+    if (user.hasRole(airportConfig.role))
+      Ok(views.html.index("DRT - BorderForce", portCode.toString, googleTrackingCode, user.id))
+    else {
+      request.connection.secure
+      val baseDomain = config.get[String]("base-domain")
+      val protocol = if (request.connection.secure) "https://" else "http://"
+      Redirect(Call("get", protocol + baseDomain))
+    }
   }
 
   def healthCheck: Action[AnyContent] = Action.async { _ =>

--- a/server/src/main/scala/controllers/application/WithAuth.scala
+++ b/server/src/main/scala/controllers/application/WithAuth.scala
@@ -42,9 +42,9 @@ trait WithAuth {
   def authByRole[A](allowedRole: Role)(action: Action[A]): Action[A] = Action.async(action.parser) { request =>
     val loggedInUser: LoggedInUser = ctrl.getLoggedInUser(config, request.headers, request.session)
     log.debug(s"${loggedInUser.roles}, allowed role $allowedRole")
-    val preventAccess = !loggedInUser.hasRole(allowedRole)
+    val allowAccess = loggedInUser.hasRole(allowedRole)
 
-    if (!preventAccess) {
+    if (allowAccess) {
       auth(action)(request)
     } else {
       log.warning("Unauthorized")

--- a/server/src/test/resources/application.conf
+++ b/server/src/test/resources/application.conf
@@ -3,6 +3,8 @@
 
 portcode = "test"
 
+base-domain = "localhost"
+
 enable-statsd = false
 
 akka {

--- a/shared/src/main/scala/drt/shared/airportconfig/Test.scala
+++ b/shared/src/main/scala/drt/shared/airportconfig/Test.scala
@@ -1,6 +1,6 @@
 package drt.shared.airportconfig
 
-import uk.gov.homeoffice.drt.auth.Roles.TestAccess
+import uk.gov.homeoffice.drt.auth.Roles.TEST
 import drt.shared.PaxTypes.EeaMachineReadable
 import drt.shared.PaxTypesAndQueues._
 import drt.shared.Queues.{EGate, EeaDesk, NonEeaDesk}
@@ -45,7 +45,7 @@ object Test extends AirportConfigLike {
         Queues.NonEeaDesk -> (List(0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), List(8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8))
       )
     ),
-    role = TestAccess,
+    role = TEST,
     terminalPaxTypeQueueAllocation = Map(
       T1 -> (defaultQueueRatios + (EeaMachineReadable -> List(
         EGate -> 0.7968,

--- a/shared/src/main/scala/drt/shared/airportconfig/Test2.scala
+++ b/shared/src/main/scala/drt/shared/airportconfig/Test2.scala
@@ -1,6 +1,6 @@
 package drt.shared.airportconfig
 
-import uk.gov.homeoffice.drt.auth.Roles.Test2Access
+import uk.gov.homeoffice.drt.auth.Roles.TEST2
 import drt.shared.PaxTypes.EeaMachineReadable
 import drt.shared.PaxTypesAndQueues._
 import drt.shared.Queues.{EGate, EeaDesk, FastTrack, NonEeaDesk}
@@ -55,7 +55,7 @@ object Test2 extends AirportConfigLike {
         Queues.FastTrack -> (List(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1), List(2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2))
       )
     ),
-    role = Test2Access,
+    role = TEST2,
     terminalPaxTypeQueueAllocation = Map(
       T1 -> (defaultQueueRatios + (EeaMachineReadable -> List(
         EGate -> 0.7968,


### PR DESCRIPTION
Add the drt domain to configuration
Add `test` port access to some of the e2e tests that didn't already have it to prevent redirection to the registration app]
Redirect to the central app where a user does not have access to the port in question