### PR TITLE
Drtii 718 divert passengers when queue is shut

### DIFF
--- a/client/src/main/scala/drt/client/components/BigSummaryBoxes.scala
+++ b/client/src/main/scala/drt/client/components/BigSummaryBoxes.scala
@@ -20,10 +20,10 @@ object BigSummaryBoxes {
     start.millisSinceEpoch <= bt && bt <= end.millisSinceEpoch
   }
 
-  def bestFlightSplitPax(bestFlightPax: Arrival => Int): PartialFunction[ApiFlightWithSplits, Double] = {
+  def bestFlightSplitPax: PartialFunction[ApiFlightWithSplits, Double] = {
     case ApiFlightWithSplits(flight, splits, _) =>
       splits.find { case Splits(_, _, _, t) => t == PaxNumbers } match {
-        case None => bestFlightPax(flight)
+        case None => flight.bestPaxEstimate
         case Some(apiSplits) => apiSplits.totalExcludingTransferPax
       }
   }

--- a/client/src/main/scala/drt/client/components/BigSummaryBoxes.scala
+++ b/client/src/main/scala/drt/client/components/BigSummaryBoxes.scala
@@ -96,9 +96,9 @@ object BigSummaryBoxes {
 
   case class Props(flightCount: Int, actPaxCount: Int, bestPaxCount: Int, aggSplits: Map[PaxTypeAndQueue, Int], paxQueueOrder: Seq[PaxTypeAndQueue])
 
-  def GraphComponent(splitTotal: Int, queuePax: Map[PaxTypeAndQueue, Int], paxQueueOrder: Seq[PaxTypeAndQueue]): TagOf[HTMLElement] = {
+  def GraphComponent(splitTotal: Int, queuePax: Map[PaxTypeAndQueue, Int], paxQueueOrder: Iterable[PaxTypeAndQueue]): TagOf[HTMLElement] = {
     val value = Try {
-      val orderedSplitCounts: Seq[(PaxTypeAndQueue, Int)] = paxQueueOrder.map(ptq => ptq -> queuePax.getOrElse(ptq, 0))
+      val orderedSplitCounts: Iterable[(PaxTypeAndQueue, Int)] = paxQueueOrder.map(ptq => ptq -> queuePax.getOrElse(ptq, 0))
       SplitsGraph.splitsGraphComponentColoured(SplitsGraph.Props(splitTotal, orderedSplitCounts))
     }
     val g: Try[TagOf[HTMLElement]] = value recoverWith {

--- a/client/src/main/scala/drt/client/components/DashboardTerminalSummary.scala
+++ b/client/src/main/scala/drt/client/components/DashboardTerminalSummary.scala
@@ -111,7 +111,7 @@ object DashboardTerminalSummary {
                    crunchMinutes: List[CrunchMinute],
                    staffMinutes: List[StaffMinute],
                    terminal: Terminal,
-                   paxTypeAndQueues: Seq[PaxTypeAndQueue],
+                   paxTypeAndQueues: Iterable[PaxTypeAndQueue],
                    queues: Seq[Queue],
                    timeWindowStart: SDateLike,
                    timeWindowEnd: SDateLike,

--- a/client/src/main/scala/drt/client/components/DashboardTerminalSummary.scala
+++ b/client/src/main/scala/drt/client/components/DashboardTerminalSummary.scala
@@ -103,7 +103,7 @@ object DashboardTerminalSummary {
     }
   }
 
-  def aggSplits(pcpPaxFn: Arrival => Int): Seq[ApiFlightWithSplits] => Map[PaxTypeAndQueue, Int] = BigSummaryBoxes.aggregateSplits(pcpPaxFn)
+  def aggSplits: Seq[ApiFlightWithSplits] => Map[PaxTypeAndQueue, Int] = BigSummaryBoxes.aggregateSplits
 
   def paxInPeriod(cms: Seq[CrunchMinute]): Double = cms.map(_.paxLoad).sum
 
@@ -114,8 +114,7 @@ object DashboardTerminalSummary {
                    paxTypeAndQueues: Iterable[PaxTypeAndQueue],
                    queues: Seq[Queue],
                    timeWindowStart: SDateLike,
-                   timeWindowEnd: SDateLike,
-                   pcpPaxFn: Arrival => Int
+                   timeWindowEnd: SDateLike
                   )
 
   val component: Component[Props, Unit, Unit, CtorType.Props] = ScalaComponent.builder[Props]("SummaryBox")
@@ -135,7 +134,7 @@ object DashboardTerminalSummary {
         val pressurePointAvailableStaff = pressureStaffMinute.map(sm => sm.available).getOrElse(0)
         val ragClass = TerminalDesksAndQueuesRow.ragStatus(pressurePoint.deskRec, pressurePointAvailableStaff)
         
-        val splitsForPeriod: Map[PaxTypeAndQueue, Int] = aggSplits(props.pcpPaxFn)(props.flights)
+        val splitsForPeriod: Map[PaxTypeAndQueue, Int] = aggSplits(props.flights)
         val summary: Seq[DashboardSummary] = hourSummary(props.flights, props.crunchMinutes, props.timeWindowStart)
         val queueTotals = totalsByQueue(summary)
 

--- a/client/src/main/scala/drt/client/components/FlightComponents.scala
+++ b/client/src/main/scala/drt/client/components/FlightComponents.scala
@@ -71,7 +71,7 @@ object FlightComponents {
 
   object SplitsGraph {
 
-    case class Props(splitTotal: Int, splits: Seq[(PaxTypeAndQueue, Int)])
+    case class Props(splitTotal: Int, splits: Iterable[(PaxTypeAndQueue, Int)])
 
     def splitsGraphComponentColoured(props: Props): TagOf[Div] = {
       import props._

--- a/client/src/main/scala/drt/client/components/FlightComponents.scala
+++ b/client/src/main/scala/drt/client/components/FlightComponents.scala
@@ -10,12 +10,11 @@ import org.scalajs.dom.html.Div
 
 object FlightComponents {
 
-  def paxComp(pcpPaxFn: Arrival => Int)(flightWithSplits: ApiFlightWithSplits): TagMod = {
-    val pax = pcpPaxFn(flightWithSplits.apiFlight)
+  def paxComp(flightWithSplits: ApiFlightWithSplits): TagMod = {
     <.div(
       ^.title := paxComponentTitle(flightWithSplits.apiFlight),
       ^.className := s"right",
-      pax
+      flightWithSplits.apiFlight.bestPaxEstimate
     )
   }
 

--- a/client/src/main/scala/drt/client/components/FlightTableComponents.scala
+++ b/client/src/main/scala/drt/client/components/FlightTableComponents.scala
@@ -62,10 +62,10 @@ object FlightTableComponents {
     (minutesToDisembark * oneMinuteInMillis).toLong
   }
 
-  def pcpTimeRange(arrival: Arrival, bestPax: Arrival => Int): TagOf[Div] =
+  def pcpTimeRange(arrival: Arrival): TagOf[Div] =
     arrival.PcpTime.map { pcpTime: MillisSinceEpoch =>
       val sdateFrom = SDate(MilliDate(pcpTime))
-      val sdateTo = SDate(MilliDate(pcpTime + millisToDisembark(bestPax(arrival))))
+      val sdateTo = SDate(MilliDate(pcpTime + millisToDisembark(arrival.bestPaxEstimate)))
       <.div(
         sdateLocalTimePopup(sdateFrom),
         " \u2192 ",

--- a/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
+++ b/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
@@ -35,7 +35,6 @@ object FlightsWithSplitsTable {
                    arrivalSources: Option[(UniqueArrival, Pot[List[Option[FeedSourceArrival]]])],
                    loggedInUser: LoggedInUser,
                    viewMode: ViewMode,
-                   pcpPaxFn: Arrival => Int,
                    walkTimes: WalkTimes,
                    defaultWalkTime: Long,
                    hasTransfer: Boolean
@@ -96,7 +95,6 @@ object FlightsWithSplitsTable {
                     idx,
                     timelineComponent = timelineComponent,
                     originMapper = originMapper,
-                    pcpPaxFn = props.pcpPaxFn,
                     splitsGraphComponent = splitsGraphComponent,
                     splitsQueueOrder = props.queueOrder,
                     hasEstChox = props.hasEstChox,
@@ -203,7 +201,6 @@ object FlightTableRow {
                    idx: Int,
                    timelineComponent: Option[Arrival => html_<^.VdomNode],
                    originMapper: OriginMapperF = portCode => portCode.toString,
-                   pcpPaxFn: Arrival => Int,
                    splitsGraphComponent: SplitsGraphComponentFn = (_: SplitsGraph.Props) => <.div(),
                    splitsQueueOrder: Seq[Queue],
                    hasEstChox: Boolean,
@@ -246,7 +243,7 @@ object FlightTableRow {
       val timeIndicatorClass = if (flight.PcpTime.getOrElse(0L) < SDate.now().millisSinceEpoch) "before-now" else "from-now"
 
       val queuePax: Map[Queue, Int] = ApiSplitsToSplitRatio
-        .paxPerQueueUsingBestSplitsAsRatio(flightWithSplits, props.pcpPaxFn).getOrElse(Map())
+        .paxPerQueueUsingBestSplitsAsRatio(flightWithSplits).getOrElse(Map())
 
       val flightCodeClass = if (props.loggedInUser.hasRole(ArrivalSource))
         "arrivals__table__flight-code arrivals__table__flight-code--clickable"
@@ -311,8 +308,8 @@ object FlightTableRow {
       val estCell = List(<.td(localDateTimeWithPopup(flight.EstimatedChox)))
       val lastCells = List[TagMod](
         <.td(localDateTimeWithPopup(flight.ActualChox)),
-        <.td(pcpTimeRange(flight, props.pcpPaxFn)),
-        <.td(FlightComponents.paxComp(props.pcpPaxFn)(flightWithSplits))
+        <.td(pcpTimeRange(flight)),
+        <.td(FlightComponents.paxComp(flightWithSplits))
       )
       val flightFields = if (props.hasEstChox) firstCells ++ estCell ++ lastCells else firstCells ++ lastCells
 

--- a/client/src/main/scala/drt/client/components/PortDashboardPage.scala
+++ b/client/src/main/scala/drt/client/components/PortDashboardPage.scala
@@ -85,19 +85,16 @@ object PortDashboardPage {
                       val terminalQueuesInOrder = Queues.inOrder(queues.getOrElse(terminalName, Seq()))
 
                       portDashboardModel.featureFlags.renderReady(ff => {
-
-                        val pcpPaxFn: Arrival => Int = PcpPax.bestPaxEstimateWithApi
-
                         DashboardTerminalSummary(
-                          DashboardTerminalSummary.Props(scheduledFlightsInTerminal,
+                          DashboardTerminalSummary.Props(
+                            scheduledFlightsInTerminal,
                             terminalCrunchMinutes,
                             terminalStaffMinutes,
                             terminalName,
                             paxTypeAndQueueOrder(terminalName).splits.map(_.paxType),
                             terminalQueuesInOrder,
                             displayPeriod.start,
-                            displayPeriod.end,
-                            pcpPaxFn
+                            displayPeriod.end
                           )
                         )
                       }

--- a/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
@@ -197,7 +197,6 @@ object TerminalContentComponent {
                           props.arrivalSources,
                           props.loggedInUser,
                           props.viewMode,
-                          PcpPax.bestPaxEstimateWithApi,
                           walkTimes,
                           props.airportConfig.defaultWalkTimeMillis(props.terminalPageTab.terminal),
                           props.airportConfig.hasTransfer,

--- a/client/src/main/scala/drt/client/components/TerminalDashboardComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalDashboardComponent.scala
@@ -92,7 +92,6 @@ object TerminalDashboardComponent {
                       None,
                       p.loggedInUser,
                       ViewLive,
-                      PcpPax.bestPaxEstimateWithApi,
                       walkTimes,
                       p.airportConfig.defaultWalkTimeMillis(p.terminalPageTabLoc.terminal),
                       hasTransfer = p.airportConfig.hasTransfer,

--- a/client/src/test/scala/drt/client/components/BigSummaryBoxTests.scala
+++ b/client/src/test/scala/drt/client/components/BigSummaryBoxTests.scala
@@ -219,7 +219,7 @@ object BigSummaryBoxTests extends TestSuite {
 
                 val apiFlightWithSplits = ApiFlightWithSplits(apiFlight1, Set(splits1))
 
-                val pax = bestFlightSplitPax(PcpPax.bestPaxEstimate)(apiFlightWithSplits)
+                val pax = bestFlightSplitPax(apiFlightWithSplits)
 
                 val expectedPax = 23 + 41
 
@@ -238,7 +238,7 @@ object BigSummaryBoxTests extends TestSuite {
 
                   val apiFlightWithSplits = ApiFlightWithSplits(apiFlight1, Set(splits1))
 
-                  val pax = bestFlightSplitPax(PcpPax.bestPaxEstimate)(apiFlightWithSplits)
+                  val pax = bestFlightSplitPax(apiFlightWithSplits)
 
                   val expectedPax = 100
 
@@ -254,7 +254,7 @@ object BigSummaryBoxTests extends TestSuite {
                   val apiFlight1 = apiFlight(schDt = "2017-05-01T12:05Z", terminal = terminal1, actPax = Option(100), pcpTime = Option(mkMillis("2017-05-01T12:05Z")))
                   val apiFlightWithSplits = ApiFlightWithSplits(apiFlight1, Set())
 
-                  val pax = bestFlightSplitPax(PcpPax.bestPaxEstimate)(apiFlightWithSplits)
+                  val pax = bestFlightSplitPax(apiFlightWithSplits)
 
                   val expectedPax = 100
 
@@ -264,7 +264,6 @@ object BigSummaryBoxTests extends TestSuite {
             }
           }
           "DRT-4632 Given we're running for LHR" - {
-            val bestPaxFn = PcpPax.bestPaxEstimate _
             "AND we have a flight " - {
               "AND it has no splits " - {
                 "AND it has 100 act pax AND it has 60 transpax" - {
@@ -272,7 +271,7 @@ object BigSummaryBoxTests extends TestSuite {
                     val apiFlight1 = apiFlight(schDt = "2017-05-01T12:05Z", terminal = terminal1, actPax = Option(100), tranPax = Option(60), pcpTime = Option(mkMillis("2017-05-01T12:05Z")))
                     val apiFlightWithSplits = ApiFlightWithSplits(apiFlight1, Set())
 
-                    val pax = bestFlightSplitPax(bestPaxFn)(apiFlightWithSplits)
+                    val pax = bestFlightSplitPax(apiFlightWithSplits)
 
                     val expectedPax = 40
 
@@ -289,7 +288,7 @@ object BigSummaryBoxTests extends TestSuite {
                   val apiFlight1 = apiFlight(schDt = "2017-05-01T12:05Z", terminal = terminal1, actPax = None, maxPax = Option(134), pcpTime = Option(mkMillis("2017-05-01T12:05Z")))
                   val apiFlightWithSplits = ApiFlightWithSplits(apiFlight1, Set())
 
-                  val pax = bestFlightSplitPax(PcpPax.bestPaxEstimate)(apiFlightWithSplits)
+                  val pax = bestFlightSplitPax(apiFlightWithSplits)
 
                   val expectedPax = 0
 

--- a/client/src/test/scala/drt/client/components/BigSummaryBoxTests.scala
+++ b/client/src/test/scala/drt/client/components/BigSummaryBoxTests.scala
@@ -146,7 +146,7 @@ object BigSummaryBoxTests extends TestSuite {
                 List(ApiFlightWithSplits(apiFlight1, Set(splits1)),
                   ApiFlightWithSplits(apiFlight2, Set(splits2))), List())
 
-              val aggSplits = aggregateSplits(PcpPax.bestPaxEstimateWithApi)(flights.flightsToUpdate)
+              val aggSplits = aggregateSplits(flights.flightsToUpdate)
 
               val expectedAggSplits = Map(
                 PaxTypeAndQueue(PaxTypes.NonVisaNational, Queues.NonEeaDesk) -> (41 + 11),
@@ -171,7 +171,7 @@ object BigSummaryBoxTests extends TestSuite {
                     ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, Queues.EeaDesk, 60, None, None)),
                     SplitSources.Historical, None, Percentage))))
 
-              val aggSplits = aggregateSplits(PcpPax.bestPaxEstimateWithApi)(flights)
+              val aggSplits = aggregateSplits(flights)
 
               val expectedAggSplits = Map(
                 PaxTypeAndQueue(PaxTypes.NonVisaNational, Queues.NonEeaDesk) -> (30 + 40),
@@ -194,7 +194,7 @@ object BigSummaryBoxTests extends TestSuite {
                         ApiPaxTypeAndQueueCount(PaxTypes.Transit, Queues.Transfer, 20, None, None)),
                         SplitSources.Historical, None, PaxNumbers))))
 
-                  val aggSplits = aggregateSplits(PcpPax.bestPaxEstimateWithApi)(flights)
+                  val aggSplits = aggregateSplits(flights)
 
                   val expectedAggSplits = Map(
                     PaxTypeAndQueue(PaxTypes.NonVisaNational, Queues.NonEeaDesk) -> 60,
@@ -219,7 +219,7 @@ object BigSummaryBoxTests extends TestSuite {
 
                 val apiFlightWithSplits = ApiFlightWithSplits(apiFlight1, Set(splits1))
 
-                val pax = bestFlightSplitPax(PcpPax.bestPaxEstimateWithApi)(apiFlightWithSplits)
+                val pax = bestFlightSplitPax(PcpPax.bestPaxEstimate)(apiFlightWithSplits)
 
                 val expectedPax = 23 + 41
 
@@ -238,7 +238,7 @@ object BigSummaryBoxTests extends TestSuite {
 
                   val apiFlightWithSplits = ApiFlightWithSplits(apiFlight1, Set(splits1))
 
-                  val pax = bestFlightSplitPax(PcpPax.bestPaxEstimateWithApi)(apiFlightWithSplits)
+                  val pax = bestFlightSplitPax(PcpPax.bestPaxEstimate)(apiFlightWithSplits)
 
                   val expectedPax = 100
 
@@ -254,7 +254,7 @@ object BigSummaryBoxTests extends TestSuite {
                   val apiFlight1 = apiFlight(schDt = "2017-05-01T12:05Z", terminal = terminal1, actPax = Option(100), pcpTime = Option(mkMillis("2017-05-01T12:05Z")))
                   val apiFlightWithSplits = ApiFlightWithSplits(apiFlight1, Set())
 
-                  val pax = bestFlightSplitPax(PcpPax.bestPaxEstimateWithApi)(apiFlightWithSplits)
+                  val pax = bestFlightSplitPax(PcpPax.bestPaxEstimate)(apiFlightWithSplits)
 
                   val expectedPax = 100
 
@@ -264,7 +264,7 @@ object BigSummaryBoxTests extends TestSuite {
             }
           }
           "DRT-4632 Given we're running for LHR" - {
-            val bestPaxFn = PcpPax.bestPaxEstimateWithApi _
+            val bestPaxFn = PcpPax.bestPaxEstimate _
             "AND we have a flight " - {
               "AND it has no splits " - {
                 "AND it has 100 act pax AND it has 60 transpax" - {
@@ -289,7 +289,7 @@ object BigSummaryBoxTests extends TestSuite {
                   val apiFlight1 = apiFlight(schDt = "2017-05-01T12:05Z", terminal = terminal1, actPax = None, maxPax = Option(134), pcpTime = Option(mkMillis("2017-05-01T12:05Z")))
                   val apiFlightWithSplits = ApiFlightWithSplits(apiFlight1, Set())
 
-                  val pax = bestFlightSplitPax(PcpPax.bestPaxEstimateWithApi)(apiFlightWithSplits)
+                  val pax = bestFlightSplitPax(PcpPax.bestPaxEstimate)(apiFlightWithSplits)
 
                   val expectedPax = 0
 

--- a/client/src/test/scala/drt/client/components/PaxSplitsDisplayTests.scala
+++ b/client/src/test/scala/drt/client/components/PaxSplitsDisplayTests.scala
@@ -225,7 +225,7 @@ object PaxSplitsDisplayTests extends TestSuite {
             ApiPaxTypeAndQueueCount(PaxTypes.EeaNonMachineReadable, Queues.EeaDesk, 15, None, None),
             ApiPaxTypeAndQueueCount(PaxTypes.VisaNational, Queues.FastTrack, 0.3, None, None)), Historical, None, Percentage)
 
-        val result = ApiSplitsToSplitRatio.paxPerQueueUsingBestSplitsAsRatio(ApiFlightWithSplits(flight, Set(splits)), PcpPax.bestPaxEstimateWithApi)
+        val result = ApiSplitsToSplitRatio.paxPerQueueUsingBestSplitsAsRatio(ApiFlightWithSplits(flight, Set(splits)))
 
         val expected = Option(Map(
           Queues.EeaDesk -> 69,

--- a/server/src/main/scala/actors/ArrivalsActor.scala
+++ b/server/src/main/scala/actors/ArrivalsActor.scala
@@ -55,7 +55,7 @@ class ForecastBaseArrivalsActor(initialSnapshotBytesThreshold: Int,
     consumeUpdates(diffsMessage)
   }
 
-  override def handleFeedSuccess(incomingArrivals: Seq[Arrival], createdAt: SDateLike): Unit = {
+  override def handleFeedSuccess(incomingArrivals: Iterable[Arrival], createdAt: SDateLike): Unit = {
     log.info(s"Received arrivals (base)")
     val incomingArrivalsWithKeys = incomingArrivals.map(a => (a.unique, a)).toMap
     val (removals, updates) = Crunch.baseArrivalsRemovalsAndUpdates(incomingArrivalsWithKeys, state.arrivals)
@@ -199,7 +199,7 @@ abstract class ArrivalsActor(now: () => SDateLike,
     persistFeedStatus(FeedStatusFailure(createdAt.millisSinceEpoch, message))
   }
 
-  def handleFeedSuccess(incomingArrivals: Seq[Arrival], createdAt: SDateLike): Unit = {
+  def handleFeedSuccess(incomingArrivals: Iterable[Arrival], createdAt: SDateLike): Unit = {
     log.info(s"Received arrivals")
 
     val updatedArrivals = incomingArrivals.toSet

--- a/server/src/main/scala/actors/DrtSystemInterface.scala
+++ b/server/src/main/scala/actors/DrtSystemInterface.scala
@@ -73,8 +73,6 @@ trait DrtSystemInterface extends UserRoleProviderLike {
   val gateWalkTimesProvider: GateOrStandWalkTime = walkTimeMillisProviderFromCsv(params.gateWalkTimesFilePath)
   val standWalkTimesProvider: GateOrStandWalkTime = walkTimeMillisProviderFromCsv(params.standWalkTimesFilePath)
 
-//  def pcpPaxFn: Arrival => Int = PcpPax.bestPaxEstimate
-
   val alertsActor: ActorRef = system.actorOf(Props(new AlertsActor(now)), name = "alerts-actor")
   val liveBaseArrivalsActor: ActorRef = system.actorOf(Props(new LiveBaseArrivalsActor(params.snapshotMegaBytesLiveArrivals, now, expireAfterMillis)), name = "live-base-arrivals-actor")
   val arrivalsImportActor: ActorRef = system.actorOf(Props(new ArrivalsImportActor()), name = "arrivals-import-actor")

--- a/server/src/main/scala/actors/DrtSystemInterface.scala
+++ b/server/src/main/scala/actors/DrtSystemInterface.scala
@@ -73,7 +73,7 @@ trait DrtSystemInterface extends UserRoleProviderLike {
   val gateWalkTimesProvider: GateOrStandWalkTime = walkTimeMillisProviderFromCsv(params.gateWalkTimesFilePath)
   val standWalkTimesProvider: GateOrStandWalkTime = walkTimeMillisProviderFromCsv(params.standWalkTimesFilePath)
 
-  def pcpPaxFn: Arrival => Int = PcpPax.bestPaxEstimateWithApi
+//  def pcpPaxFn: Arrival => Int = PcpPax.bestPaxEstimate
 
   val alertsActor: ActorRef = system.actorOf(Props(new AlertsActor(now)), name = "alerts-actor")
   val liveBaseArrivalsActor: ActorRef = system.actorOf(Props(new LiveBaseArrivalsActor(params.snapshotMegaBytesLiveArrivals, now, expireAfterMillis)), name = "live-base-arrivals-actor")
@@ -122,7 +122,7 @@ trait DrtSystemInterface extends UserRoleProviderLike {
 
   val optimiser: TryCrunch = if (config.get[Boolean]("crunch.use-legacy-optimiser")) TryRenjin.crunch else Optimiser.crunch
 
-  val portDeskRecs: PortDesksAndWaitsProviderLike = PortDesksAndWaitsProvider(airportConfig, optimiser, pcpPaxFn)
+  val portDeskRecs: PortDesksAndWaitsProviderLike = PortDesksAndWaitsProvider(airportConfig, optimiser)
 
   val deskLimitsProviders: Map[Terminal, TerminalDeskLimitsLike] = if (config.get[Boolean]("crunch.flex-desks"))
     PortDeskLimits.flexed(airportConfig)
@@ -200,7 +200,6 @@ trait DrtSystemInterface extends UserRoleProviderLike {
       initialStaffMovements = initialState[StaffMovements](staffMovementsActor).map(_.movements).getOrElse(Seq[StaffMovement]()),
       refreshArrivalsOnStart = refreshArrivalsOnStart,
       refreshManifestsOnStart = refreshManifestsOnStart,
-      pcpPaxFn = pcpPaxFn,
       adjustEGateUseByUnder12s = params.adjustEGateUseByUnder12s,
       optimiser = optimiser,
       aclPaxAdjustmentDays = aclPaxAdjustmentDays,

--- a/server/src/main/scala/actors/FlightLookups.scala
+++ b/server/src/main/scala/actors/FlightLookups.scala
@@ -21,7 +21,7 @@ import scala.language.postfixOps
 
 trait FlightLookupsLike {
   val system: ActorSystem
-  implicit val ec: ExecutionContext
+  implicit val ec: ExecutionContext = system.dispatcher
   implicit val timeout: Timeout = new Timeout(60 seconds)
 
   val now: () => SDateLike
@@ -50,7 +50,7 @@ case class FlightLookups(system: ActorSystem,
                          now: () => SDateLike,
                          queuesByTerminal: Map[Terminal, Seq[Queue]],
                          updatesSubscriber: ActorRef
-                        )(implicit val ec: ExecutionContext) extends FlightLookupsLike {
+                        ) extends FlightLookupsLike {
   override val requestAndTerminateActor: ActorRef = system.actorOf(Props(new RequestAndTerminateActor()), "flights-lookup-kill-actor")
 
   override val flightsActor: ActorRef = system.actorOf(

--- a/server/src/main/scala/actors/ManifestLookups.scala
+++ b/server/src/main/scala/actors/ManifestLookups.scala
@@ -16,7 +16,7 @@ import scala.language.postfixOps
 
 trait ManifestLookupsLike {
   val system: ActorSystem
-  implicit val ec: ExecutionContext
+  implicit val ec: ExecutionContext = system.dispatcher
   implicit val timeout: Timeout = new Timeout(60 seconds)
 
   val requestAndTerminateActor: ActorRef
@@ -38,7 +38,7 @@ trait ManifestLookupsLike {
 
 }
 
-case class ManifestLookups(system: ActorSystem)(implicit val ec: ExecutionContext) extends ManifestLookupsLike {
+case class ManifestLookups(system: ActorSystem) extends ManifestLookupsLike {
   override val requestAndTerminateActor: ActorRef = system
     .actorOf(Props(new RequestAndTerminateActor()), "manifests-lookup-kill-actor")
 }

--- a/server/src/main/scala/actors/queues/FlightsRouterActor.scala
+++ b/server/src/main/scala/actors/queues/FlightsRouterActor.scala
@@ -67,7 +67,7 @@ object FlightsRouterActor {
         case FlightsWithSplits(flights) =>
           FlightsWithSplits(flights.filter { case (_, fws) =>
             val scheduledMatches = scheduledInRange(start, end, fws.apiFlight.Scheduled)
-            val pcpMatches = pcpFallsInRange(start, end, fws.apiFlight.pcpRange())
+            val pcpMatches = pcpFallsInRange(start, end, fws.apiFlight.pcpRange)
             scheduledMatches || pcpMatches
           })
       }

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -57,22 +57,6 @@ object Router extends autowire.Server[ByteBuffer, Pickler, Pickler] {
 object PaxFlow {
   val log: Logger = LoggerFactory.getLogger(getClass)
 
-//  def makeFlightPaxFlowCalculator(splitRatioForFlight: Arrival => Option[SplitRatios],
-//                                  bestPax: Arrival => Int): Arrival => IndexedSeq[(MillisSinceEpoch, PaxTypeAndQueueCount)] = {
-//    val provider = PaxLoadCalculator.flightPaxFlowProvider(splitRatioForFlight, bestPax)
-//    arrival => {
-//      val pax = bestPax(arrival)
-//      val paxFlow = provider(arrival)
-//      val summedPax = paxFlow.map(_._2.paxSum).sum
-//      val firstPaxTime = paxFlow.headOption.map(pf => SDate(pf._1).toString)
-//      log.debug(s"${Arrival.summaryString(arrival)} pax: $pax, summedFlowPax: $summedPax, deltaPax: ${pax - summedPax}, firstPaxTime: $firstPaxTime")
-//      paxFlow
-//    }
-//  }
-
-//  def splitRatioForFlight(splitsProviders: List[SplitProvider])
-//                         (flight: Arrival): Option[SplitRatios] = SplitsProvider.splitsForFlight(splitsProviders)(flight)
-
   def pcpArrivalTimeForFlight(timeToChoxMillis: MillisSinceEpoch, firstPaxOffMillis: MillisSinceEpoch)
                              (walkTimeProvider: FlightWalkTime)
                              (flight: Arrival): MilliDate = pcpFrom(timeToChoxMillis, firstPaxOffMillis, walkTimeProvider)(flight)

--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -57,21 +57,21 @@ object Router extends autowire.Server[ByteBuffer, Pickler, Pickler] {
 object PaxFlow {
   val log: Logger = LoggerFactory.getLogger(getClass)
 
-  def makeFlightPaxFlowCalculator(splitRatioForFlight: Arrival => Option[SplitRatios],
-                                  bestPax: Arrival => Int): Arrival => IndexedSeq[(MillisSinceEpoch, PaxTypeAndQueueCount)] = {
-    val provider = PaxLoadCalculator.flightPaxFlowProvider(splitRatioForFlight, bestPax)
-    arrival => {
-      val pax = bestPax(arrival)
-      val paxFlow = provider(arrival)
-      val summedPax = paxFlow.map(_._2.paxSum).sum
-      val firstPaxTime = paxFlow.headOption.map(pf => SDate(pf._1).toString)
-      log.debug(s"${Arrival.summaryString(arrival)} pax: $pax, summedFlowPax: $summedPax, deltaPax: ${pax - summedPax}, firstPaxTime: $firstPaxTime")
-      paxFlow
-    }
-  }
+//  def makeFlightPaxFlowCalculator(splitRatioForFlight: Arrival => Option[SplitRatios],
+//                                  bestPax: Arrival => Int): Arrival => IndexedSeq[(MillisSinceEpoch, PaxTypeAndQueueCount)] = {
+//    val provider = PaxLoadCalculator.flightPaxFlowProvider(splitRatioForFlight, bestPax)
+//    arrival => {
+//      val pax = bestPax(arrival)
+//      val paxFlow = provider(arrival)
+//      val summedPax = paxFlow.map(_._2.paxSum).sum
+//      val firstPaxTime = paxFlow.headOption.map(pf => SDate(pf._1).toString)
+//      log.debug(s"${Arrival.summaryString(arrival)} pax: $pax, summedFlowPax: $summedPax, deltaPax: ${pax - summedPax}, firstPaxTime: $firstPaxTime")
+//      paxFlow
+//    }
+//  }
 
-  def splitRatioForFlight(splitsProviders: List[SplitProvider])
-                         (flight: Arrival): Option[SplitRatios] = SplitsProvider.splitsForFlight(splitsProviders)(flight)
+//  def splitRatioForFlight(splitsProviders: List[SplitProvider])
+//                         (flight: Arrival): Option[SplitRatios] = SplitsProvider.splitsForFlight(splitsProviders)(flight)
 
   def pcpArrivalTimeForFlight(timeToChoxMillis: MillisSinceEpoch, firstPaxOffMillis: MillisSinceEpoch)
                              (walkTimeProvider: FlightWalkTime)

--- a/server/src/main/scala/controllers/application/WithSimulations.scala
+++ b/server/src/main/scala/controllers/application/WithSimulations.scala
@@ -71,7 +71,7 @@ trait WithSimulations {
 
     val splitsCalculator = SplitsCalculator(ctrl.paxTypeQueueAllocation, airportConfig.terminalPaxSplits, ctrl.splitAdjustments)
 
-    val portDesksAndWaitsProvider: PortDesksAndWaitsProvider = PortDesksAndWaitsProvider(simulationConfig, Optimiser.crunch, PcpPax.bestPaxEstimateWithApi)
+    val portDesksAndWaitsProvider: PortDesksAndWaitsProvider = PortDesksAndWaitsProvider(simulationConfig, Optimiser.crunch)
     val terminalDeskLimits = PortDeskLimits.fixed(simulationConfig)
 
     val deskRecsProducer = DynamicRunnableDeskRecs.crunchRequestsToQueueMinutes(

--- a/server/src/main/scala/controllers/application/exports/WithFlightsExport.scala
+++ b/server/src/main/scala/controllers/application/exports/WithFlightsExport.scala
@@ -30,13 +30,11 @@ trait WithFlightsExport {
   def csvForUser(user: LoggedInUser): Source[FlightsWithSplits, NotUsed] => Source[String, NotUsed] = {
     if (user.hasRole(ApiView))
       StreamingFlightsExport(
-        ctrl.pcpPaxFn,
         SDate.millisToLocalIsoDateOnly(Crunch.europeLondonTimeZone),
         SDate.millisToLocalHoursAndMinutes(Crunch.europeLondonTimeZone)
       ).toCsvStreamWithActualApi _
     else
       StreamingFlightsExport(
-        ctrl.pcpPaxFn,
         SDate.millisToLocalIsoDateOnly(Crunch.europeLondonTimeZone),
         SDate.millisToLocalHoursAndMinutes(Crunch.europeLondonTimeZone)
       ).toCsvStreamWithoutActualApi _

--- a/server/src/main/scala/drt/chroma/ArrivalsDiffingStage.scala
+++ b/server/src/main/scala/drt/chroma/ArrivalsDiffingStage.scala
@@ -64,8 +64,8 @@ final class ArrivalsDiffingStage(initialKnownArrivals: SortedMap[UniqueArrival, 
     def processFeedResponse(arrivalsFeedResponse: ArrivalsFeedResponse): Option[ArrivalsFeedResponse] = arrivalsFeedResponse match {
       case afs@ArrivalsFeedSuccess(latestArrivals, _) =>
         val maxScheduledMillis = forecastMaxMillis()
-        val incomingArrivals: Seq[(UniqueArrival, Arrival)] = latestArrivals.flights.filter(_.Scheduled <= maxScheduledMillis).map(a => (UniqueArrival(a), a))
-        val newUpdates: Seq[(UniqueArrival, Arrival)] = filterArrivalsWithUpdates(knownArrivals, incomingArrivals)
+        val incomingArrivals: Iterable[(UniqueArrival, Arrival)] = latestArrivals.flights.filter(_.Scheduled <= maxScheduledMillis).map(a => (UniqueArrival(a), a))
+        val newUpdates: Iterable[(UniqueArrival, Arrival)] = filterArrivalsWithUpdates(knownArrivals, incomingArrivals)
         if (newUpdates.nonEmpty) log.info(s"Got ${newUpdates.size} new arrival updates")
         knownArrivals = SortedMap[UniqueArrival, Arrival]() ++ incomingArrivals
         Option(afs.copy(arrivals = latestArrivals.copy(flights = newUpdates.map(_._2))))
@@ -77,7 +77,7 @@ final class ArrivalsDiffingStage(initialKnownArrivals: SortedMap[UniqueArrival, 
         None
     }
 
-    def filterArrivalsWithUpdates(existingArrivals: SortedMap[UniqueArrival, Arrival], newArrivals: Seq[(UniqueArrival, Arrival)]): Seq[(UniqueArrival, Arrival)] = newArrivals
+    def filterArrivalsWithUpdates(existingArrivals: SortedMap[UniqueArrival, Arrival], newArrivals: Iterable[(UniqueArrival, Arrival)]): Iterable[(UniqueArrival, Arrival)] = newArrivals
       .foldLeft(List[(UniqueArrival, Arrival)]()) {
         case (soFar, (key, arrival)) => existingArrivals.get(key) match {
           case None => (key, arrival) :: soFar

--- a/server/src/main/scala/drt/server/feeds/FeedResponse.scala
+++ b/server/src/main/scala/drt/server/feeds/FeedResponse.scala
@@ -18,7 +18,7 @@ case class StoreFeedImportArrivals(arrivals: Flights)
 case object GetFeedImportArrivals
 
 case class ArrivalsFeedSuccess(arrivals: Flights, createdAt: SDateLike) extends ArrivalsFeedResponse {
-  override val length: Int = arrivals.flights.length
+  override val length: Int = arrivals.flights.size
 }
 case object ArrivalsFeedSuccessAck
 

--- a/server/src/main/scala/drt/server/feeds/chroma/ChromaFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/chroma/ChromaFeed.scala
@@ -31,7 +31,7 @@ case class ChromaLiveFeed(chromaFetcher: ChromaFetcher[ChromaLiveFlight]) {
     }
   }
 
-  def correctEdiTerminals(afs: ArrivalsFeedSuccess): Seq[Arrival] = afs.arrivals.flights
+  def correctEdiTerminals(afs: ArrivalsFeedSuccess): Iterable[Arrival] = afs.arrivals.flights
     .map(csf => csf.copy(Terminal = A1))
 
   def chromaVanillaFlights(frequency: FiniteDuration)(implicit ec: ExecutionContext): Source[ArrivalsFeedResponse, Cancellable] = {

--- a/server/src/main/scala/drt/server/feeds/common/ArrivalFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/common/ArrivalFeed.scala
@@ -18,7 +18,7 @@ case class ArrivalFeed(arrivalsActor: ActorRef)(implicit timeout: Timeout) {
     arrivalsActor.ask(GetFeedImportArrivals)
       .map {
         case Some(Flights(arrivals)) =>
-          log.info(s"Got ${arrivals.length} port arrivals")
+          log.info(s"Got ${arrivals.size} port arrivals")
           ArrivalsFeedSuccess(Flights(arrivals), SDate.now())
         case x =>
           log.info(s"Got no port arrivals: $x")

--- a/server/src/main/scala/drt/server/feeds/lhr/LHRFlightFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/lhr/LHRFlightFeed.scala
@@ -6,7 +6,7 @@ import akka.stream.scaladsl.Source
 import drt.server.feeds.Implicits._
 import drt.server.feeds.lhr.LHRFlightFeed.{emptyStringToOption, parseDateTime}
 import drt.shared.FlightsApi.Flights
-import drt.shared.LiveFeedSource
+import drt.shared.{FlightCode, LiveFeedSource}
 import drt.shared.Terminals.Terminal
 import drt.shared.api.Arrival
 import org.apache.commons.csv.{CSVFormat, CSVParser, CSVRecord}

--- a/server/src/main/scala/queueus/PaxTypeAllocator.scala
+++ b/server/src/main/scala/queueus/PaxTypeAllocator.scala
@@ -2,12 +2,11 @@ package queueus
 
 import drt.shared.PaxType
 import drt.shared.PaxTypes._
-import manifests.passengers.{BestAvailableManifest, ManifestPassengerProfile}
+import manifests.passengers.ManifestPassengerProfile
 import passengersplits.core.PassengerTypeCalculator.{isB5JPlus, isEea, isVisaNational}
 import passengersplits.core.PassengerTypeCalculatorValues.DocumentType
 
 trait PaxTypeAllocator {
-
   val b5JPlus: PartialFunction[ManifestPassengerProfile, PaxType] = {
     case ManifestPassengerProfile(country, _, Some(age), _, _) if isB5JPlus(country) && age.isUnder(12) => B5JPlusNationalBelowEGateAge
     case ManifestPassengerProfile(country, _, _, _, _) if isB5JPlus(country) => B5JPlusNational
@@ -33,30 +32,24 @@ trait PaxTypeAllocator {
 }
 
 case object DefaultPaxTypeAllocator extends PaxTypeAllocator {
-
   override def apply(manifestPassengerProfile: ManifestPassengerProfile): PaxType =
     noTransit(manifestPassengerProfile)
 }
 
 case object DefaultWithTransitPaxTypeAllocator extends PaxTypeAllocator {
-
   override def apply(manifestPassengerProfile: ManifestPassengerProfile): PaxType = withTransit(manifestPassengerProfile)
 }
 
 case object B5JPlusTypeAllocator extends PaxTypeAllocator {
-
   val withB5JPlus: PartialFunction[ManifestPassengerProfile, PaxType] = b5JPlus orElse countryAndDocumentTypes
 
   override def apply(manifestPassengerProfile: ManifestPassengerProfile): PaxType =
-      withB5JPlus(manifestPassengerProfile)
-
+    withB5JPlus(manifestPassengerProfile)
 }
 
 case object B5JPlusWithTransitTypeAllocator extends PaxTypeAllocator {
-
   val withTransitAndB5JPlus: PartialFunction[ManifestPassengerProfile, PaxType] = transit orElse b5JPlus orElse countryAndDocumentTypes
 
   override def apply(manifestPassengerProfile: ManifestPassengerProfile): PaxType =
     withTransitAndB5JPlus(manifestPassengerProfile)
-
 }

--- a/server/src/main/scala/queueus/PaxTypeQueueAllocation.scala
+++ b/server/src/main/scala/queueus/PaxTypeQueueAllocation.scala
@@ -7,7 +7,7 @@ import manifests.passengers.{ManifestLike, ManifestPassengerProfile}
 
 case class PaxTypeQueueAllocation(paxTypeAllocator: PaxTypeAllocator, queueAllocator: QueueAllocator) {
   def toQueues(terminal: Terminal, manifest: ManifestLike): Map[Queue, Iterable[(Queue, PaxType, ManifestPassengerProfile, Double)]] = {
-    val queueAllocatorForFlight = queueAllocator(terminal, manifest) _
+    val queueAllocatorForFlight: PaxType => Seq[(Queue, Double)] = queueAllocator.forTerminalAndManifest(terminal, manifest)
     val paxTypeAllocatorForFlight = paxTypeAllocator
     manifest.uniquePassengers.flatMap(mpp => {
       val paxType = paxTypeAllocatorForFlight(mpp)

--- a/server/src/main/scala/queueus/QueueAllocator.scala
+++ b/server/src/main/scala/queueus/QueueAllocator.scala
@@ -33,16 +33,16 @@ trait QueueAllocator {
     B5JPlusNational -> List(Queues.EGate -> 0.4, Queues.EeaDesk -> 0.6)
   )
 
-  def apply(terminal: Terminal, manifest: ManifestLike)(paxType: PaxType): Seq[(Queue, Double)]
+  def forTerminalAndManifest(terminal: Terminal, manifest: ManifestLike)(paxType: PaxType): Seq[(Queue, Double)]
 }
 
 case class TerminalQueueAllocator(queueRatios: Map[Terminal, Map[PaxType, Seq[(Queue, Double)]]]) extends QueueAllocator {
-  override def apply(terminal: Terminal, manifest: ManifestLike)(paxType: PaxType): Seq[(Queue, Double)] =
+  override def forTerminalAndManifest(terminal: Terminal, manifest: ManifestLike)(paxType: PaxType): Seq[(Queue, Double)] =
     queueRatio(terminal, paxType)
 }
 
 case class TerminalQueueAllocatorWithFastTrack(queueRatios: Map[Terminal, Map[PaxType, Seq[(Queue, Double)]]]) extends QueueAllocator {
-  override def apply(terminal: Terminal, manifest: ManifestLike)(paxType: PaxType): Seq[(Queue, Double)] =
+  override def forTerminalAndManifest(terminal: Terminal, manifest: ManifestLike)(paxType: PaxType): Seq[(Queue, Double)] =
     if (paxType == NonVisaNational || paxType == VisaNational)
       FastTrackFromCSV.fastTrackCarriers
         .find(ftc => ftc.iataCode == manifest.carrierCode || ftc.icaoCode == manifest.carrierCode)

--- a/server/src/main/scala/queueus/QueueAllocator.scala
+++ b/server/src/main/scala/queueus/QueueAllocator.scala
@@ -13,26 +13,6 @@ trait QueueAllocator {
 
   def queueRatio(terminal: Terminal, paxType: PaxType): Seq[(Queue, Double)] = queueRatios.getOrElse(terminal, Map()).getOrElse(paxType, Seq())
 
-  //this is where we'd put an eGates service
-
-  val defaultRatios: Map[PaxType, Seq[(Queue, Double)]] = Map(
-    EeaMachineReadable -> List(Queues.EGate -> 1.0),
-    EeaNonMachineReadable -> List(Queues.EeaDesk -> 1.0),
-    Transit -> List(Queues.Transfer -> 1.0),
-    NonVisaNational -> List(Queues.NonEeaDesk -> 1.0),
-    VisaNational -> List(Queues.NonEeaDesk -> 1.0),
-    B5JPlusNational -> List(Queues.NonEeaDesk -> 1)
-  )
-
-  val b5JPlusRatios: Map[PaxType, Seq[(Queue, Double)]] = Map(
-    EeaMachineReadable -> List(Queues.EGate -> 1.0),
-    EeaNonMachineReadable -> List(Queues.EeaDesk -> 1.0),
-    Transit -> List(Queues.Transfer -> 1.0),
-    NonVisaNational -> List(Queues.NonEeaDesk -> 1.0),
-    VisaNational -> List(Queues.NonEeaDesk -> 1.0),
-    B5JPlusNational -> List(Queues.EGate -> 0.4, Queues.EeaDesk -> 0.6)
-  )
-
   def forTerminalAndManifest(terminal: Terminal, manifest: ManifestLike)(paxType: PaxType): Seq[(Queue, Double)]
 }
 

--- a/server/src/main/scala/services/PcpArrival.scala
+++ b/server/src/main/scala/services/PcpArrival.scala
@@ -2,6 +2,7 @@ package services
 
 import drt.shared.CrunchApi.MillisSinceEpoch
 import drt.shared.MilliDate
+import drt.shared.MilliTimes.timeToNearestMinute
 import drt.shared.Terminals.Terminal
 import drt.shared.api.{Arrival, WalkTime}
 import org.slf4j.{Logger, LoggerFactory}
@@ -64,7 +65,6 @@ object PcpArrival {
   }
 
   import Math.round
-  def timeToNearestMinute(t: MillisSinceEpoch): MillisSinceEpoch = round(t / 60000d) * 60000
 
   type GateOrStand = String
   type GateOrStandWalkTime = (GateOrStand, Terminal) => Option[MillisSinceEpoch]

--- a/server/src/main/scala/services/crunch/CrunchSystem.scala
+++ b/server/src/main/scala/services/crunch/CrunchSystem.scala
@@ -18,7 +18,6 @@ import services.graphstages._
 
 import scala.collection.immutable.SortedMap
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
 
 
 case class CrunchSystem[FR](shifts: SourceQueueWithComplete[ShiftAssignments],
@@ -56,7 +55,6 @@ case class CrunchProps[FR](
                             initialLiveBaseArrivals: SortedMap[UniqueArrival, Arrival] = SortedMap[UniqueArrival, Arrival](),
                             initialLiveArrivals: SortedMap[UniqueArrival, Arrival] = SortedMap[UniqueArrival, Arrival](),
                             arrivalsForecastBaseSource: Source[ArrivalsFeedResponse, FR], arrivalsForecastSource: Source[ArrivalsFeedResponse, FR],
-                            pcpPaxFn: Arrival => Int,
                             arrivalsLiveBaseSource: Source[ArrivalsFeedResponse, FR],
                             arrivalsLiveSource: Source[ArrivalsFeedResponse, FR],
                             passengersActorProvider: () => ActorRef,

--- a/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeskRecs.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeskRecs.scala
@@ -33,7 +33,7 @@ object DynamicRunnableDeskRecs {
 
   type LoadsToQueueMinutes = (NumericRange[MillisSinceEpoch], Map[TQM, Crunch.LoadMinute], Map[Terminal, TerminalDeskLimitsLike]) => PortStateQueueMinutes
 
-  type FlightsToLoads = (FlightsWithSplits, MillisSinceEpoch) => Map[TQM, Crunch.LoadMinute]
+  type FlightsToLoads = FlightsWithSplits => Map[TQM, Crunch.LoadMinute]
 
   def crunchRequestsToQueueMinutes(arrivalsProvider: CrunchRequest => Future[Source[List[Arrival], NotUsed]],
                                    liveManifestsProvider: CrunchRequest => Future[Source[VoyageManifests, NotUsed]],
@@ -68,7 +68,7 @@ object DynamicRunnableDeskRecs {
       .map { case (crunchDay, flights) =>
         log.info(s"Crunching ${flights.size} flights, ${crunchDay.durationMinutes} minutes (${crunchDay.start.toISOString()} to ${crunchDay.end.toISOString()})")
         timeLogger.time({
-          val loadsFromFlights: Map[TQM, Crunch.LoadMinute] = flightsToLoads(FlightsWithSplits(flights), crunchDay.start.millisSinceEpoch)
+          val loadsFromFlights: Map[TQM, Crunch.LoadMinute] = flightsToLoads(FlightsWithSplits(flights))
           loadsToQueueMinutes(crunchDay.minutesInMillis, loadsFromFlights, maxDesksProviders)
         })
       }

--- a/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProvider.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProvider.scala
@@ -94,7 +94,7 @@ object PortDesksAndWaitsProvider {
   def apply(airportConfig: AirportConfig, tryCrunch: TryCrunch): PortDesksAndWaitsProvider = {
     val calculator = DynamicWorkloadCalculator(
       airportConfig.terminalProcessingTimes,
-      airportConfig.queueStatusProvider(millis => SDate(millis, europeLondonTimeZone)))
+      airportConfig.queueStatusProvider)
 
     PortDesksAndWaitsProvider(
       queuesByTerminal = airportConfig.queuesByTerminal,

--- a/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProvider.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProvider.scala
@@ -24,8 +24,7 @@ case class PortDesksAndWaitsProvider(queuesByTerminal: SortedMap[Terminal, Seq[Q
                                      minutesToCrunch: Int,
                                      crunchOffsetMinutes: Int,
                                      eGateBankSize: Int,
-                                     tryCrunch: TryCrunch,
-                                     pcpPaxFn: Arrival => Int
+                                     tryCrunch: TryCrunch
                                     ) extends PortDesksAndWaitsProviderLike {
   val log: Logger = LoggerFactory.getLogger(getClass)
 
@@ -45,7 +44,7 @@ case class PortDesksAndWaitsProvider(queuesByTerminal: SortedMap[Terminal, Seq[Q
     deskrecs.TerminalDesksAndWaitsProvider(slas, flexedQueuesPriority, tryCrunch, eGateBankSize)
 
   def queueLoadsFromFlights(flights: FlightsWithSplits): Map[TQM, LoadMinute] = WorkloadCalculator
-    .flightLoadMinutes(flights, terminalProcessingTimes, pcpPaxFn).minutes
+    .flightLoadMinutes(flights, terminalProcessingTimes).minutes
     .groupBy {
       case (TQM(t, q, m), _) => val finalQueueName = divertedQueues.getOrElse(q, q)
         TQM(t, finalQueueName, m)
@@ -95,7 +94,7 @@ case class PortDesksAndWaitsProvider(queuesByTerminal: SortedMap[Terminal, Seq[Q
 }
 
 object PortDesksAndWaitsProvider {
-  def apply(airportConfig: AirportConfig, tryCrunch: TryCrunch, pcpPaxFn: Arrival => Int): PortDesksAndWaitsProvider =
+  def apply(airportConfig: AirportConfig, tryCrunch: TryCrunch): PortDesksAndWaitsProvider =
     PortDesksAndWaitsProvider(
       airportConfig.queuesByTerminal,
       airportConfig.divertedQueues,
@@ -106,7 +105,6 @@ object PortDesksAndWaitsProvider {
       airportConfig.minutesToCrunch,
       airportConfig.crunchOffsetMinutes,
       airportConfig.eGateBankSize,
-      tryCrunch,
-      pcpPaxFn
+      tryCrunch
     )
 }

--- a/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProvider.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProvider.scala
@@ -2,7 +2,7 @@ package services.crunch.deskrecs
 
 import drt.shared.CrunchApi.{DeskRecMinute, DeskRecMinutes, MillisSinceEpoch}
 import drt.shared.FlightsApi.FlightsWithSplits
-import drt.shared.Queues.{Closed, Open, Queue, Transfer}
+import drt.shared.Queues.{Closed, Open, Queue, QueueFallbacks, Transfer}
 import drt.shared.Terminals.Terminal
 import drt.shared._
 import org.slf4j.{Logger, LoggerFactory}
@@ -94,7 +94,9 @@ object PortDesksAndWaitsProvider {
   def apply(airportConfig: AirportConfig, tryCrunch: TryCrunch): PortDesksAndWaitsProvider = {
     val calculator = DynamicWorkloadCalculator(
       airportConfig.terminalProcessingTimes,
-      airportConfig.queueStatusProvider)
+      airportConfig.queueStatusProvider,
+      QueueFallbacks(airportConfig.queuesByTerminal)
+    )
 
     PortDesksAndWaitsProvider(
       queuesByTerminal = airportConfig.queuesByTerminal,

--- a/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProviderLike.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProviderLike.scala
@@ -4,7 +4,7 @@ import drt.shared.CrunchApi.{DeskRecMinutes, MillisSinceEpoch}
 import drt.shared.FlightsApi.FlightsWithSplits
 import drt.shared.Queues.{EGate, Queue, QueueStatus}
 import drt.shared.Terminals.Terminal
-import drt.shared.{SimulationMinute, SimulationMinutes, TQM}
+import drt.shared.{Queues, SimulationMinute, SimulationMinutes, TQM}
 import services.crunch.desklimits.TerminalDeskLimitsLike
 import services.crunch.deskrecs.RunnableOptimisation.CrunchRequest
 import services.graphstages.Crunch.LoadMinute
@@ -14,11 +14,10 @@ import scala.collection.immutable.{Map, NumericRange}
 trait PortDesksAndWaitsProviderLike {
   val minutesToCrunch: Int
   val crunchOffsetMinutes: Int
-  val queueStatusAt: (Terminal, Queue, MillisSinceEpoch) => QueueStatus
 
   def flightsToLoads(flights: FlightsWithSplits): Map[TQM, LoadMinute]
 
-//  def flightsToDynamicLoads(flights: FlightsWithSplits): Map[TQM, LoadMinute]
+  //  def flightsToDynamicLoads(flights: FlightsWithSplits): Map[TQM, LoadMinute]
 
   def loadsToDesks(minuteMillis: NumericRange[MillisSinceEpoch],
                    loads: Map[TQM, LoadMinute],

--- a/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProviderLike.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProviderLike.scala
@@ -17,8 +17,6 @@ trait PortDesksAndWaitsProviderLike {
 
   def flightsToLoads(flights: FlightsWithSplits): Map[TQM, LoadMinute]
 
-  //  def flightsToDynamicLoads(flights: FlightsWithSplits): Map[TQM, LoadMinute]
-
   def loadsToDesks(minuteMillis: NumericRange[MillisSinceEpoch],
                    loads: Map[TQM, LoadMinute],
                    deskLimitProviders: Map[Terminal, TerminalDeskLimitsLike]): DeskRecMinutes

--- a/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProviderLike.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProviderLike.scala
@@ -2,9 +2,11 @@ package services.crunch.deskrecs
 
 import drt.shared.CrunchApi.{DeskRecMinutes, MillisSinceEpoch}
 import drt.shared.FlightsApi.FlightsWithSplits
+import drt.shared.Queues.{EGate, Queue, QueueStatus}
 import drt.shared.Terminals.Terminal
 import drt.shared.{SimulationMinute, SimulationMinutes, TQM}
 import services.crunch.desklimits.TerminalDeskLimitsLike
+import services.crunch.deskrecs.RunnableOptimisation.CrunchRequest
 import services.graphstages.Crunch.LoadMinute
 
 import scala.collection.immutable.{Map, NumericRange}
@@ -12,9 +14,11 @@ import scala.collection.immutable.{Map, NumericRange}
 trait PortDesksAndWaitsProviderLike {
   val minutesToCrunch: Int
   val crunchOffsetMinutes: Int
+  val queueStatusAt: (Terminal, Queue, MillisSinceEpoch) => QueueStatus
 
-  def flightsToLoads(flights: FlightsWithSplits,
-                     crunchStartMillis: MillisSinceEpoch): Map[TQM, LoadMinute]
+  def flightsToLoads(flights: FlightsWithSplits): Map[TQM, LoadMinute]
+
+//  def flightsToDynamicLoads(flights: FlightsWithSplits): Map[TQM, LoadMinute]
 
   def loadsToDesks(minuteMillis: NumericRange[MillisSinceEpoch],
                    loads: Map[TQM, LoadMinute],

--- a/server/src/main/scala/services/exports/StreamingFlightsExport.scala
+++ b/server/src/main/scala/services/exports/StreamingFlightsExport.scala
@@ -46,7 +46,7 @@ case class StreamingFlightsExport(millisToDateStringFn: MillisSinceEpoch => Stri
   def fwsToCsv(fws: FlightsWithSplits, csvRowFn: ApiFlightWithSplits => String): String =
     uniqueArrivalsWithCodeShares(fws.flights.values.toSeq)
       .sortBy {
-        case (fws, _) => fws.apiFlight.PcpTime
+        case (fws, _) => (fws.apiFlight.PcpTime, fws.apiFlight.VoyageNumber.numeric, fws.apiFlight.Origin.iata)
       }
       .map {
         case (fws, _) => csvRowFn(fws) + "\n"

--- a/server/src/main/scala/services/exports/StreamingFlightsExport.scala
+++ b/server/src/main/scala/services/exports/StreamingFlightsExport.scala
@@ -12,11 +12,8 @@ import drt.shared.api.Arrival
 import drt.shared.splits.ApiSplitsToSplitRatio
 import services.exports.flights.ArrivalToCsv
 
-case class StreamingFlightsExport(
-                                   pcpPaxFn: Arrival => Int,
-                                   millisToDateStringFn: MillisSinceEpoch => String,
-                                   millisToTimeStringFn: MillisSinceEpoch => String
-                                 ) {
+case class StreamingFlightsExport(millisToDateStringFn: MillisSinceEpoch => String,
+                                  millisToTimeStringFn: MillisSinceEpoch => String) {
 
   val queueNames: Seq[Queue] = ApiSplitsToSplitRatio.queuesFromPaxTypeAndQueue(PaxTypesAndQueues.inOrder)
 
@@ -97,7 +94,7 @@ case class StreamingFlightsExport(
       millisToDateStringFn,
       millisToTimeStringFn
     ) ++
-      List(pcpPaxFn(fws.apiFlight).toString) ++ splitsForSources
+      List(fws.apiFlight.bestPaxEstimate.toString) ++ splitsForSources
   }
 
   def queueSplits(queueNames: Seq[Queue],
@@ -109,7 +106,7 @@ case class StreamingFlightsExport(
     fws
       .splits
       .find(_.source == splitSource)
-      .map(splits => ApiSplitsToSplitRatio.flightPaxPerQueueUsingSplitsAsRatio(splits, fws.apiFlight, pcpPaxFn))
+      .map(splits => ApiSplitsToSplitRatio.flightPaxPerQueueUsingSplitsAsRatio(splits, fws.apiFlight))
       .getOrElse(Map())
 
   val uniqueArrivalsWithCodeShares: Seq[ApiFlightWithSplits] => List[(ApiFlightWithSplits, Set[Arrival])] = CodeShares

--- a/server/src/main/scala/services/graphstages/ArrivalsGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/ArrivalsGraphStage.scala
@@ -230,11 +230,7 @@ class ArrivalsGraphStage(name: String = "",
       val isValidSuffix = !flight.FlightCodeSuffix.exists(fcs => fcs.suffix == "P" || fcs.suffix == "F")
       val validTerminal = validPortTerminals.contains(flight.Terminal)
       val isDomestic = !flight.Origin.isDomestic
-      val isRelevant = validTerminal && isDomestic && isValidSuffix
-      if (!isRelevant) {
-        println(s"Filtering out ($validTerminal && $isDomestic && $isValidSuffix): $flight")
-      }
-      isRelevant
+      validTerminal && isDomestic && isValidSuffix
     }
 
     def pushIfAvailable(arrivalsToPush: Option[ArrivalsDiff], outlet: Outlet[ArrivalsDiff]): Unit = {

--- a/server/src/main/scala/services/graphstages/ArrivalsGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/ArrivalsGraphStage.scala
@@ -228,7 +228,13 @@ class ArrivalsGraphStage(name: String = "",
 
     def isFlightRelevant(flight: Arrival): Boolean = {
       val isValidSuffix = !flight.FlightCodeSuffix.exists(fcs => fcs.suffix == "P" || fcs.suffix == "F")
-      validPortTerminals.contains(flight.Terminal) && !flight.Origin.isDomestic && isValidSuffix
+      val validTerminal = validPortTerminals.contains(flight.Terminal)
+      val isDomestic = !flight.Origin.isDomestic
+      val isRelevant = validTerminal && isDomestic && isValidSuffix
+      if (!isRelevant) {
+        println(s"Filtering out ($validTerminal && $isDomestic && $isValidSuffix): $flight")
+      }
+      isRelevant
     }
 
     def pushIfAvailable(arrivalsToPush: Option[ArrivalsDiff], outlet: Outlet[ArrivalsDiff]): Unit = {

--- a/server/src/main/scala/services/graphstages/Crunch.scala
+++ b/server/src/main/scala/services/graphstages/Crunch.scala
@@ -22,7 +22,7 @@ object Crunch {
   class SplitMinutes {
     val minutes: mutable.Map[TQM, LoadMinute] = mutable.Map()
 
-    def ++=(incoming: Seq[FlightSplitMinute]): Unit = {
+    def ++=(incoming: Iterable[FlightSplitMinute]): Unit = {
       incoming.foreach(fsm => +=(LoadMinute(fsm.terminalName, fsm.queueName, fsm.paxLoad, fsm.workLoad, fsm.minute)))
     }
 

--- a/server/src/main/scala/services/graphstages/DynamicWorkloadCalculator.scala
+++ b/server/src/main/scala/services/graphstages/DynamicWorkloadCalculator.scala
@@ -1,0 +1,91 @@
+package services.graphstages
+
+import drt.shared.CrunchApi.MillisSinceEpoch
+import drt.shared.FlightsApi.FlightsWithSplits
+import drt.shared.Terminals.Terminal
+import drt.shared._
+import drt.shared.api.Arrival
+import org.slf4j.{Logger, LoggerFactory}
+import services.graphstages.Crunch.{FlightSplitMinute, SplitMinutes}
+import services.workloadcalculator.PaxLoadCalculator.Load
+
+import scala.collection.immutable.Map
+
+trait WorkloadCalculatorLike {
+  val defaultProcTimes: Map[Terminal, Map[PaxTypeAndQueue, Double]]
+
+  def flightLoadMinutes(flights: FlightsWithSplits): SplitMinutes
+
+  def combineCodeShares(flights: Iterable[ApiFlightWithSplits]): Iterable[ApiFlightWithSplits] = {
+    val uniqueFlights: Iterable[ApiFlightWithSplits] = flights
+      .toList
+      .sortBy(_.apiFlight.ActPax.getOrElse(0))
+      .map { fws => (CodeShareKeyOrderedBySchedule(fws), fws) }
+      .toMap.values
+    uniqueFlights
+  }
+
+  def flightsWithPcpWorkload(flights: Iterable[ApiFlightWithSplits]): Iterable[ApiFlightWithSplits] = flights
+    .filter { fws =>
+      !fws.apiFlight.isCancelled &&
+        defaultProcTimes.contains(fws.apiFlight.Terminal) &&
+        !fws.apiFlight.Origin.isCta
+    }
+}
+
+
+case class DynamicWorkloadCalculator(defaultProcTimes: Map[Terminal, Map[PaxTypeAndQueue, Double]]) extends WorkloadCalculatorLike {
+  val log: Logger = LoggerFactory.getLogger(getClass)
+
+  override def flightLoadMinutes(flights: FlightsWithSplits): SplitMinutes = {
+    val minutes = new SplitMinutes
+
+    flightsWithPcpWorkload(combineCodeShares(flights.flights.values))
+      .foreach(incoming => minutes ++= flightToFlightSplitMinutes(incoming))
+
+    minutes
+  }
+
+  def flightToFlightSplitMinutes(flightWithSplits: ApiFlightWithSplits): Iterable[FlightSplitMinute] =
+    defaultProcTimes.get(flightWithSplits.apiFlight.Terminal) match {
+      case None => Iterable()
+      case Some(procTimes) =>
+        val flight = flightWithSplits.apiFlight
+
+        flightWithSplits.bestSplits.map(splitsToUse => {
+          val splitRatios: Set[ApiPaxTypeAndQueueCount] = splitsToUse.splitStyle match {
+            case UndefinedSplitStyle => splitsToUse.splits.map(qc => qc.copy(paxCount = 0))
+            case PaxNumbers =>
+              val splitsWithoutTransit = splitsToUse.splits.filter(_.queueType != Queues.Transfer)
+              val totalSplitsPax: Load = splitsWithoutTransit.toList.map(_.paxCount).sum
+              if (totalSplitsPax == 0.0)
+                splitsWithoutTransit
+              else
+                splitsWithoutTransit.map(qc => qc.copy(paxCount = qc.paxCount / totalSplitsPax))
+            case _ => splitsToUse.splits.map(qc => qc.copy(paxCount = qc.paxCount / 100))
+          }
+
+          val splitsWithoutTransit = splitRatios.filterNot(_.queueType == Queues.Transfer)
+
+          flight.paxDeparturesByMinute(20)
+            .flatMap {
+              case (minuteMillis, flightPaxInMinute) =>
+                splitsWithoutTransit
+                  .map(split => flightSplitMinute(flight, procTimes, minuteMillis, flightPaxInMinute, split))
+            }
+        }).getOrElse(Seq())
+    }
+
+  def flightSplitMinute(arrival: Arrival,
+                        procTimes: Map[PaxTypeAndQueue, Load],
+                        minuteMillis: MillisSinceEpoch,
+                        flightPaxInMinute: Int,
+                        apiSplitRatio: ApiPaxTypeAndQueueCount
+                       ): FlightSplitMinute = {
+    val splitPaxInMinute = apiSplitRatio.paxCount * flightPaxInMinute
+    val paxTypeQueueProcTime = procTimes.getOrElse(PaxTypeAndQueue(apiSplitRatio.passengerType, apiSplitRatio.queueType), 0d)
+    val defaultWorkload = splitPaxInMinute * paxTypeQueueProcTime
+
+    FlightSplitMinute(CodeShareKeyOrderedBySchedule(arrival), apiSplitRatio.passengerType, arrival.Terminal, apiSplitRatio.queueType, splitPaxInMinute, defaultWorkload, minuteMillis)
+  }
+}

--- a/server/src/main/scala/services/graphstages/DynamicWorkloadCalculator.scala
+++ b/server/src/main/scala/services/graphstages/DynamicWorkloadCalculator.scala
@@ -103,6 +103,10 @@ case class DynamicWorkloadCalculator(defaultProcTimes: Map[Terminal, Map[PaxType
                             findAlternativeQueue(EGate, Iterable(EeaDesk, NonEeaDesk))
                           case (EGate, VisaNational | NonVisaNational | B5JPlusNational | B5JPlusNationalBelowEGateAge) =>
                             findAlternativeQueue(EGate, Iterable(NonEeaDesk, EeaDesk))
+                          case (EeaDesk, _) =>
+                            findAlternativeQueue(EeaDesk, Iterable(NonEeaDesk))
+                          case (NonEeaDesk, _) =>
+                            findAlternativeQueue(NonEeaDesk, Iterable(EeaDesk))
                         }
                         ptqc.copy(queueType = newQueue)
                       case Open =>

--- a/server/src/main/scala/services/graphstages/WorkloadCalculator.scala
+++ b/server/src/main/scala/services/graphstages/WorkloadCalculator.scala
@@ -2,6 +2,7 @@ package services.graphstages
 
 import drt.shared.CrunchApi.MillisSinceEpoch
 import drt.shared.FlightsApi.FlightsWithSplits
+import drt.shared.QueueStatusProviders.QueuesAlwaysOpen
 import drt.shared.Queues.Open
 import drt.shared.Terminals.Terminal
 import drt.shared._
@@ -15,7 +16,7 @@ import scala.collection.immutable.Map
 case class WorkloadCalculator(defaultProcTimes: Map[Terminal, Map[PaxTypeAndQueue, Double]]) extends WorkloadCalculatorLike {
   val log: Logger = LoggerFactory.getLogger(getClass)
 
-  override val queueStatusAt: (Terminal, Queues.Queue, MillisSinceEpoch) => Queues.QueueStatus = (_, _, _) => Open
+  override val queueStatusProvider: QueueStatusProviders.QueueStatusProvider = QueuesAlwaysOpen
 
   override def flightLoadMinutes(flights: FlightsWithSplits): SplitMinutes = {
     val minutes = new SplitMinutes

--- a/server/src/main/scala/services/workloadcalculator/PaxLoadCalculator.scala
+++ b/server/src/main/scala/services/workloadcalculator/PaxLoadCalculator.scala
@@ -15,32 +15,5 @@ object PaxLoadCalculator {
 
   case class PaxTypeAndQueueCount(paxAndQueueType: PaxTypeAndQueue, paxSum: Load)
 
-  def flightPaxFlowProvider(splitRatioProvider: Arrival => Option[SplitRatios],
-                            bestPax: Arrival => Int): Arrival => IndexedSeq[(MillisSinceEpoch, PaxTypeAndQueueCount)] = {
-    voyagePaxSplitsFlowOverTime(splitRatioProvider, bestPax)
-  }
-
-  def voyagePaxSplitsFlowOverTime(splitsRatioProvider: Arrival => Option[SplitRatios], bestPax: Arrival => Int)
-                                 (flight: Arrival): IndexedSeq[(MillisSinceEpoch, PaxTypeAndQueueCount)] = {
-    val pcpStartTimeMillis = MilliDate(flight.PcpTime.getOrElse(0L)).millisSinceEpoch
-    //TODO fix this get
-    val splits = splitsRatioProvider(flight).get.splits
-    val splitsOverTime: IndexedSeq[(MillisSinceEpoch, PaxTypeAndQueueCount)] = minutesForHours(pcpStartTimeMillis, 1)
-      .zip(paxDeparturesPerMinutes(bestPax(flight), paxOffFlowRate))
-      .flatMap {
-        case (m, paxInMinute) =>
-          splits.map(splitRatio => (m, PaxTypeAndQueueCount(splitRatio.paxType, splitRatio.ratio * paxInMinute)))
-      }
-
-    splitsOverTime
-  }
-
   def minutesForHours(timesMin: MillisSinceEpoch, hours: Int): NumericRange[MillisSinceEpoch] = timesMin until (timesMin + oneMinute * 60 * hours) by oneMinute
-
-  def paxDeparturesPerMinutes(remainingPax: Int, departRate: Int): List[Int] = {
-    if (remainingPax % departRate != 0)
-      List.fill(remainingPax / departRate)(departRate) ::: remainingPax % departRate :: Nil
-    else
-      List.fill(remainingPax / departRate)(departRate)
-  }
 }

--- a/server/src/main/scala/test/TestFlightLookups.scala
+++ b/server/src/main/scala/test/TestFlightLookups.scala
@@ -15,8 +15,7 @@ import scala.concurrent.{ExecutionContext, Future}
 case class TestFlightLookups(system: ActorSystem,
                              now: () => SDateLike,
                              queuesByTerminal: Map[Terminal, Seq[Queue]],
-                             updatesSubscriber: ActorRef)
-                            (implicit val ec: ExecutionContext) extends FlightLookupsLike {
+                             updatesSubscriber: ActorRef) extends FlightLookupsLike {
   override val requestAndTerminateActor: ActorRef = system.actorOf(Props(new RequestAndTerminateActor()), "test-flights-lookup-kill-actor")
 
   val resetFlightsData: (Terminal, UtcDate) => Future[Unit] = (terminal: Terminal, date: UtcDate) => {

--- a/server/src/test/scala/actors/flights/StreamingFlightsByDaySpec.scala
+++ b/server/src/test/scala/actors/flights/StreamingFlightsByDaySpec.scala
@@ -1,14 +1,12 @@
 package actors.flights
 
 import actors.ArrivalGenerator
-import actors.minutes.MockFlightsLookup
-import actors.queues.{DateRange, FlightsRouterActor}
 import actors.queues.FlightsRouterActor._
-import akka.stream.scaladsl.Sink
+import actors.queues.{DateRange, FlightsRouterActor}
+import drt.shared.ApiFlightWithSplits
 import drt.shared.CrunchApi.MillisSinceEpoch
 import drt.shared.FlightsApi.FlightsWithSplits
 import drt.shared.Terminals.{T1, Terminal}
-import drt.shared.ApiFlightWithSplits
 import drt.shared.dates.UtcDate
 import services.SDate
 import services.crunch.CrunchTestLike
@@ -48,7 +46,7 @@ class StreamingFlightsByDaySpec extends CrunchTestLike {
     "When I ask if its pcp range falls within 2020-09-28" >> {
       "Then I should get a true response" >> {
         val flight = ApiFlightWithSplits(ArrivalGenerator.arrival(schDt = "2020-09-29T12:00Z", pcpDt = "2020-09-28T12:00Z", actPax = Option(100)), Set())
-        val result = FlightsRouterActor.pcpFallsInRange(SDate(2020, 9, 28), SDate(2020, 9, 28, 23, 59), flight.apiFlight.pcpRange())
+        val result = FlightsRouterActor.pcpFallsInRange(SDate(2020, 9, 28), SDate(2020, 9, 28, 23, 59), flight.apiFlight.pcpRange)
         result === true
       }
     }
@@ -58,7 +56,7 @@ class StreamingFlightsByDaySpec extends CrunchTestLike {
     "When I ask if its pcp range falls within 2020-09-28" >> {
       "Then I should get a true response" >> {
         val flight = ApiFlightWithSplits(ArrivalGenerator.arrival(schDt = "2020-09-27T12:00Z", pcpDt = "2020-09-28T12:00Z", actPax = Option(100)), Set())
-        val result = FlightsRouterActor.pcpFallsInRange(SDate(2020, 9, 28), SDate(2020, 9, 28, 23, 59), flight.apiFlight.pcpRange())
+        val result = FlightsRouterActor.pcpFallsInRange(SDate(2020, 9, 28), SDate(2020, 9, 28, 23, 59), flight.apiFlight.pcpRange)
         result === true
       }
     }

--- a/server/src/test/scala/drt/shared/FlightsWithSplitsSpec.scala
+++ b/server/src/test/scala/drt/shared/FlightsWithSplitsSpec.scala
@@ -6,7 +6,6 @@ import org.specs2.mutable.Specification
 import services.SDate
 
 class FlightsWithSplitsSpec extends Specification{
-
   "When filtering flights by Scheduled date" >> {
     "Given a flight with Splits containing flights inside and outside the range" >> {
       "Then I should only get flights scheduled inside the range" >> {
@@ -29,59 +28,4 @@ class FlightsWithSplitsSpec extends Specification{
       }
     }
   }
-
-  "When filtering flights by Scheduled date or PCP Date Window" >> {
-    "Given a flight with a scheduled date outside the range but a PCP date inside the range" >> {
-      "Then I should get the flight back" >> {
-        val fws = ApiFlightWithSplits(
-          ArrivalGenerator.arrival(schDt = "2020-09-22T23:00", pcpDt = "2020-09-23T00:30"),
-          Set()
-        )
-        val flightsWithSplits = FlightsWithSplits(Map(fws.unique -> fws))
-
-        val start = SDate("2020-09-23T10:00").getUtcLastMidnight
-        val end = start.addDays(1)
-        val result = flightsWithSplits.window(start.millisSinceEpoch, end.millisSinceEpoch)
-
-        result === flightsWithSplits
-      }
-    }
-    "Given a flight with a scheduled date inside the range but a PCP date outside the range" >> {
-      "Then I should get the flight back" >> {
-        val fws = ApiFlightWithSplits(
-          ArrivalGenerator.arrival(schDt = "2020-09-22T23:00", pcpDt = "2020-09-23T00:30"),
-          Set()
-        )
-        val flightsWithSplits = FlightsWithSplits(Map(fws.unique -> fws))
-
-        val start = SDate("2020-09-22T10:00").getUtcLastMidnight
-        val end = start.addDays(1)
-        val result = flightsWithSplits.window(start.millisSinceEpoch, end.millisSinceEpoch)
-
-        result === flightsWithSplits
-      }
-    }
-
-    "Given a flight with Splits containing flights inside and outside the range" >> {
-      "Then I should only get flights scheduled inside the range" >> {
-        val fws1 = ArrivalGenerator.flightWithSplitsForDayAndTerminal(SDate("2020-09-22T10:00"))
-        val fws2 = ArrivalGenerator.flightWithSplitsForDayAndTerminal(SDate("2020-09-21T10:00"))
-        val fws3 = ArrivalGenerator.flightWithSplitsForDayAndTerminal(SDate("2020-09-23T11:00"))
-        val flightsWithSplits = FlightsWithSplits(Map(
-          fws1.unique -> fws1,
-          fws2.unique -> fws2,
-          fws3.unique -> fws3
-        ))
-
-        val start = SDate("2020-09-21T10:00").getUtcLastMidnight
-        val end = start.addDays(1)
-        val result = flightsWithSplits.window(start.millisSinceEpoch, end.millisSinceEpoch)
-
-        val expected = FlightsWithSplits(Map(fws2.unique -> fws2))
-
-        result === expected
-      }
-    }
-  }
-
 }

--- a/server/src/test/scala/feeds/mag/MagFeedSpec.scala
+++ b/server/src/test/scala/feeds/mag/MagFeedSpec.scala
@@ -72,7 +72,7 @@ class MagFeedSpec extends CrunchTestLike {
       case _ => List()
     }
 
-    result.length === 1
+    result.size === 1
   }
 
   "Given a mock json response containing a single valid flight with 0 for passenger count and max pax " +

--- a/server/src/test/scala/scenarios/ArrivalsSimlationSpec.scala
+++ b/server/src/test/scala/scenarios/ArrivalsSimlationSpec.scala
@@ -42,7 +42,6 @@ class ArrivalsSimlationSpec extends CrunchTestLike {
 
   def fwsToCsv(flights: Seq[ApiFlightWithSplits]): String =
     StreamingFlightsExport(
-      PcpPax.bestPaxEstimateWithApi,
       (millis: MillisSinceEpoch) => SDate(millis).toISODateOnly,
       (millis: MillisSinceEpoch) => SDate(millis).toHoursAndMinutes
     ).toCsvWithActualApi(List(FlightsWithSplits(flights)))
@@ -129,7 +128,7 @@ class ArrivalsSimlationSpec extends CrunchTestLike {
     val fws = FlightsWithSplits(flightsWithSplits.map(f => f.unique -> f).toMap)
 
     val portStateActor = system.actorOf(Props(new ArrivalCrunchSimulationActor(fws)))
-    val dawp = PortDesksAndWaitsProvider(lhrHalved, Optimiser.crunch, PcpPax.bestPaxEstimateWithApi)
+    val dawp = PortDesksAndWaitsProvider(lhrHalved, Optimiser.crunch)
 
     val terminalDeskLimits = PortDeskLimits.fixed(lhrHalved)
 

--- a/server/src/test/scala/services/ArrivalSpec.scala
+++ b/server/src/test/scala/services/ArrivalSpec.scala
@@ -9,7 +9,7 @@ class ArrivalSpec extends Specification {
     "When I ask for the minimum value of the pcp range" >> {
       "I should get zero" >> {
         val arrival = ArrivalGenerator.arrival(actPax = Option(-1))
-        val result = arrival.pcpRange().min
+        val result = arrival.pcpRange.min
         result === 0
       }
     }
@@ -39,7 +39,7 @@ class ArrivalSpec extends Specification {
     val pcpTime = "2019-01-01T12:00"
     val arrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = "2019-01-01T12:00", actPax = Option(100), pcpDt = "2019-01-01T12:00")
 
-    val pcpRange = arrival.pcpRange()
+    val pcpRange = arrival.pcpRange
 
     "When I ask how many minutes I should see 5" >> {
       pcpRange.length === 5
@@ -64,7 +64,7 @@ class ArrivalSpec extends Specification {
     val pcpTime = "2019-01-01T12:00"
     val arrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = "2019-01-01T12:00", actPax = Option(99), pcpDt = "2019-01-01T12:00")
 
-    val pcpRange = arrival.pcpRange()
+    val pcpRange = arrival.pcpRange
 
     "When I ask how many minutes I should see 5" >> {
       pcpRange.length === 5
@@ -89,7 +89,7 @@ class ArrivalSpec extends Specification {
     val pcpTime = "2019-01-01T12:00"
     val arrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = "2019-01-01T12:00", actPax = Option(101), pcpDt = "2019-01-01T12:00")
 
-    val pcpRange = arrival.pcpRange()
+    val pcpRange = arrival.pcpRange
 
     "When I ask how many minutes I should see 6" >> {
       pcpRange.length === 6

--- a/server/src/test/scala/services/arrivals/FlightCodeSpec.scala
+++ b/server/src/test/scala/services/arrivals/FlightCodeSpec.scala
@@ -19,16 +19,4 @@ class FlightCodeSpec extends CrunchTestLike {
     FlightCode("RYR836", "") === FlightCode(CarrierCode("RYR"), VoyageNumber("836"), None)
     FlightCode("RYR836F", "") === FlightCode(CarrierCode("RYR"), VoyageNumber("836"), Option(FlightCodeSuffix("F")))
   }
-
-  "Voyage Number should be padded to 4 digits" >> {
-    "3 digits should pad to 4" in {
-      PcpPax.padTo4Digits("123") === "0123"
-    }
-    "4 digits should remain 4 " in {
-      PcpPax.padTo4Digits("0123") === "0123"
-    }
-    "we think 5 is invalid, but we should return unharmed" in {
-      PcpPax.padTo4Digits("45123") === "45123"
-    }
-  }
 }

--- a/server/src/test/scala/services/arrivals/PcpPaxSpec.scala
+++ b/server/src/test/scala/services/arrivals/PcpPaxSpec.scala
@@ -11,7 +11,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 50 PCP pax" >> {
       val a = arrival(actPax = Option(50), apiPax = Option(100), feedSources = Set(LiveFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 50
 
       result === expected
@@ -21,7 +21,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 50 PCP pax" >> {
       val a = arrival(actPax = Option(50), apiPax = None, feedSources = Set(LiveFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 50
 
       result === expected
@@ -31,7 +31,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 100 PCP pax" >> {
       val a = arrival(actPax = None, apiPax = Option(100), feedSources = Set(LiveFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 100
 
       result === expected
@@ -41,7 +41,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 100 PCP pax" >> {
       val a = arrival(actPax = Option(100), tranPax = None, feedSources = Set(LiveFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 100
 
       result === expected
@@ -51,7 +51,7 @@ class PcpPaxSpec extends Specification {
       "Then we should get 0 PCP Pax " >> {
       val a = arrival(actPax = Option(50), tranPax = Option(100), maxPax = Option(150), feedSources = Set(LiveFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 0
 
       result === expected
@@ -61,7 +61,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 100 PCP pax" >> {
       val a = arrival(actPax = Option(100), tranPax = Option(0), feedSources = Set(LiveFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 100
 
       result === expected
@@ -71,7 +71,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 0 PCP pax" >> {
       val a = arrival(actPax = Option(0), tranPax = Option(0), maxPax = Option(130), feedSources = Set(LiveFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 0
 
       result === expected
@@ -81,7 +81,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 90 PCP pax" >> {
       val a = arrival(actPax = Option(100), tranPax = Option(10), feedSources = Set(LiveFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 90
 
       result === expected
@@ -91,7 +91,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 0 PCP pax" >> {
       val a = arrival(actPax = None, tranPax = None, maxPax = Option(130), feedSources = Set(LiveFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 0
 
       result === expected
@@ -104,7 +104,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 100 PCP pax - API trumps ACL numbers" >> {
       val a = arrival(actPax = Option(50), apiPax = Option(100), feedSources = Set(AclFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 100
 
       result === expected
@@ -114,7 +114,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 50 PCP pax" >> {
       val a = arrival(actPax = Option(50), apiPax = None, feedSources = Set(AclFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 50
 
       result === expected
@@ -124,7 +124,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 100 PCP pax" >> {
       val a = arrival(actPax = None, apiPax = Option(100), feedSources = Set(AclFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 100
 
       result === expected
@@ -134,7 +134,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 100 PCP pax" >> {
       val a = arrival(actPax = Option(100), tranPax = None, feedSources = Set(AclFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 100
 
       result === expected
@@ -144,7 +144,7 @@ class PcpPaxSpec extends Specification {
       "Then we should get 0 PCP Pax " >> {
       val a = arrival(actPax = Option(50), tranPax = Option(100), maxPax = Option(150), feedSources = Set(AclFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 0
 
       result === expected
@@ -154,7 +154,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 100 PCP pax" >> {
       val a = arrival(actPax = Option(100), tranPax = Option(0), feedSources = Set(AclFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 100
 
       result === expected
@@ -164,7 +164,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 0 PCP pax" >> {
       val a = arrival(actPax = Option(0), tranPax = Option(0), maxPax = Option(130), feedSources = Set(AclFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 0
 
       result === expected
@@ -174,7 +174,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 90 PCP pax" >> {
       val a = arrival(actPax = Option(100), tranPax = Option(10), feedSources = Set(AclFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 90
 
       result === expected
@@ -184,7 +184,7 @@ class PcpPaxSpec extends Specification {
       "Then I should expect 0 PCP pax" >> {
       val a = arrival(actPax = None, tranPax = None, maxPax = Option(130), feedSources = Set(AclFeedSource))
 
-      val result = PcpPax.bestPaxEstimateWithApi(a)
+      val result = PcpPax.bestPaxEstimate(a)
       val expected = 0
 
       result === expected

--- a/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
+++ b/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
@@ -182,7 +182,7 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
       }
     }
   }
-  
+
   "Given an ACL arrival and a cirium arrival scheduled within 5 minutes of each other" >> {
     "When they have matching number, terminal & origin and are scheduled within the next 24 hours" >> {
       "I should see cirium arrival's data merged" >> {

--- a/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
+++ b/server/src/test/scala/services/crunch/ArrivalsGraphStageSpec.scala
@@ -15,12 +15,8 @@ import server.feeds._
 import services.SDate
 
 import scala.collection.immutable.List
-import scala.concurrent.duration._
 
 class ArrivalsGraphStageSpec extends CrunchTestLike {
-  sequential
-  isolated
-
   private val date = "2017-01-01"
   private val hour = "00:25"
   val scheduled = s"${date}T${hour}Z"
@@ -34,34 +30,21 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
 
   "Given and Arrivals Graph Stage" should {
     val airportConfig = defaultAirportConfig.copy(queuesByTerminal = defaultAirportConfig.queuesByTerminal.filterKeys(_ == T1))
+    implicit val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(TestConfig(airportConfig = airportConfig, now = () => dateNow))
 
     "a third arrival with an update to the chox time will change the arrival" >> {
-      val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(TestConfig(airportConfig = airportConfig, now = () => dateNow))
       val arrival_v3_with_an_update_to_chox_time: Arrival = arrival_v2_with_chox_time.copy(ActualChox = Option(SDate(scheduled).millisSinceEpoch), Stand = Option("I will update"))
 
-      offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(Seq(arrival_v2_with_chox_time))))
+      offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(Iterable(arrival_v2_with_chox_time))))
+      expectArrivals(Iterable(arrival_v2_with_chox_time))
 
-      crunch.portStateTestProbe.fishForMessage(1 seconds) {
-        case ps: PortState =>
-          val arrivals = ps.flights.values.map(_.apiFlight)
-          arrivals == Iterable(arrival_v2_with_chox_time)
-      }
-
-      offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(Seq(arrival_v3_with_an_update_to_chox_time))))
-
-      val expectedArrivals: List[Arrival] = List(arrival_v3_with_an_update_to_chox_time)
-
-      crunch.portStateTestProbe.fishForMessage(1 seconds) {
-        case ps: PortState =>
-          val arrivals = ps.flights.values.map(_.apiFlight)
-          arrivals == expectedArrivals
-      }
+      offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(Iterable(arrival_v3_with_an_update_to_chox_time))))
+      expectArrivals(Iterable(arrival_v3_with_an_update_to_chox_time))
 
       success
     }
 
     "once an API (advanced passenger information) input arrives for the flight, it will update the arrivals FeedSource so that it has a LiveFeed and a ApiFeed" >> {
-      val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(TestConfig(airportConfig = airportConfig, now = () => dateNow))
       val voyageManifests: ManifestsFeedResponse = ManifestsFeedSuccess(DqManifests("", Set(
         VoyageManifest(EventTypes.DC, PortCode("STN"), PortCode("JFK"), VoyageNumber("0001"), CarrierCode("BA"), ManifestDateOfArrival(date), ManifestTimeOfArrival(hour), List(
           PassengerInfoJson(Option(DocumentType("P")), Nationality("GBR"), EeaFlag("EEA"), Option(PaxAge(22)), Option(PortCode("LHR")), InTransit("N"), Option(Nationality("GBR")), Option(Nationality("GBR")), None)
@@ -69,68 +52,36 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
       )))
 
       offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(Seq(arrival_v2_with_chox_time))))
-
-      crunch.portStateTestProbe.fishForMessage(1 second) {
-        case PortState(flights, _, _) => flights.values.exists(_.apiFlight == arrival_v2_with_chox_time)
-      }
+      expectArrivals(Iterable(arrival_v2_with_chox_time))
 
       offerAndWait(crunch.manifestsLiveInput, voyageManifests)
-
-      val expected = Set(LiveFeedSource, ApiFeedSource)
-
-      crunch.portStateTestProbe.fishForMessage(1 seconds) {
-        case ps: PortState =>
-          val portStateSources = ps.flights.values.flatMap(_.apiFlight.FeedSources).toSet
-          portStateSources == expected
-      }
+      expectFeedSources(Set(LiveFeedSource, ApiFeedSource))
 
       success
     }
 
     "once an acl and a forecast input arrives for the flight, it will update the arrivals FeedSource so that it has ACLFeed and ForecastFeed" >> {
-      val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(TestConfig(airportConfig = airportConfig, now = () => dateNow))
       val forecastScheduled = "2017-01-01T10:25Z"
+      val aclFlight = arrival(iata = "BA0002", schDt = forecastScheduled, actPax = Option(10), feedSources = Set(AclFeedSource))
+      val forecastArrival = arrival(schDt = forecastScheduled, iata = "BA0002", terminal = T1, actPax = Option(21), feedSources = Set(ForecastFeedSource))
 
-      val aclFlight: Flights = Flights(List(
-        ArrivalGenerator.arrival(iata = "BA0002", schDt = forecastScheduled, actPax = Option(10), feedSources = Set(AclFeedSource))
-      ))
+      offerAndWait(crunch.aclArrivalsInput, ArrivalsFeedSuccess(Flights(Seq(aclFlight))))
+      offerAndWait(crunch.forecastArrivalsInput, ArrivalsFeedSuccess(Flights(List(forecastArrival))))
 
-      offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(Seq(arrival_v2_with_chox_time))))
-
-      offerAndWait(crunch.aclArrivalsInput, ArrivalsFeedSuccess(aclFlight))
-
-      val forecastArrival: Arrival = arrival(schDt = forecastScheduled, iata = "BA0002", terminal = T1, actPax = Option(21), feedSources = Set(ForecastFeedSource))
-      val forecastArrivals: ArrivalsFeedResponse = ArrivalsFeedSuccess(Flights(List(forecastArrival)))
-
-      offerAndWait(crunch.forecastArrivalsInput, forecastArrivals)
-
-      val expected = Set(ForecastFeedSource, AclFeedSource)
-
-      crunch.portStateTestProbe.fishForMessage(1 seconds) {
-        case ps: PortState =>
-          val portStateSources = ps.flights.get(forecastArrival.unique).map(_.apiFlight.FeedSources).getOrElse(Set())
-
-          portStateSources == expected
-      }
+      expectFeedSources(Set(ForecastFeedSource, AclFeedSource))
 
       success
     }
 
     "Given 2 arrivals, one international and the other domestic " >> {
       "I should only see the international arrival in the port state" >> {
-        val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(TestConfig(airportConfig = airportConfig, now = () => dateNow))
         val scheduled = "2017-01-01T10:25Z"
-
         val arrivalInt: Arrival = ArrivalGenerator.arrival(iata = "BA0002", origin = PortCode("JFK"), schDt = scheduled, actPax = Option(10), feedSources = Set(AclFeedSource))
         val arrivalDom: Arrival = ArrivalGenerator.arrival(iata = "BA0003", origin = PortCode("BHX"), schDt = scheduled, actPax = Option(10), feedSources = Set(AclFeedSource))
 
-        val aclFlight: Flights = Flights(List(arrivalInt, arrivalDom))
-
-        offerAndWait(crunch.aclArrivalsInput, ArrivalsFeedSuccess(aclFlight))
-
-        crunch.portStateTestProbe.fishForMessage(1 seconds) {
-          case ps: PortState => flightExists(arrivalInt, ps) && !flightExists(arrivalDom, ps)
-        }
+        offerAndWait(crunch.aclArrivalsInput, ArrivalsFeedSuccess(Flights(List(arrivalInt, arrivalDom))))
+        expectUniqueArrival(arrivalInt.unique)
+        expectNoUniqueArrival(arrivalDom.unique)
 
         success
       }
@@ -138,9 +89,7 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
 
     "Given 3 arrivals, one international, one domestic and one CTA " >> {
       "I should only see the international and CTA arrivals in the port state" >> {
-        val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(TestConfig(airportConfig = airportConfig, now = () => dateNow))
         val scheduled = "2017-01-01T10:25Z"
-
         val arrivalInt: Arrival = ArrivalGenerator.arrival(iata = "BA0002", origin = PortCode("JFK"), schDt = scheduled, actPax = Option(10), feedSources = Set(AclFeedSource))
         val arrivalDom: Arrival = ArrivalGenerator.arrival(iata = "BA0003", origin = PortCode("BHX"), schDt = scheduled, actPax = Option(10), feedSources = Set(AclFeedSource))
         val arrivalCta: Arrival = ArrivalGenerator.arrival(iata = "BA0004", origin = PortCode("IOM"), schDt = scheduled, actPax = Option(10), feedSources = Set(AclFeedSource))
@@ -148,10 +97,9 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
         val aclFlight: Flights = Flights(List(arrivalInt, arrivalDom, arrivalCta))
 
         offerAndWait(crunch.aclArrivalsInput, ArrivalsFeedSuccess(aclFlight))
-
-        crunch.portStateTestProbe.fishForMessage(1 seconds) {
-          case ps: PortState => flightExists(arrivalInt, ps) && flightExists(arrivalCta, ps) && !flightExists(arrivalDom, ps)
-        }
+        expectUniqueArrival(arrivalInt.unique)
+        expectUniqueArrival(arrivalCta.unique)
+        expectNoUniqueArrival(arrivalDom.unique)
 
         success
       }
@@ -159,122 +107,81 @@ class ArrivalsGraphStageSpec extends CrunchTestLike {
 
     "Given 3 arrivals, one international, one domestic and one CTA " >> {
       "I should only see the international flight's passengers and NOT and domestic or CTA pax" >> {
-        val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(TestConfig(airportConfig = airportConfig, now = () => dateNow))
         val scheduled = "2017-01-01T00:05Z"
-
         val arrivalInt: Arrival = ArrivalGenerator.arrival(iata = "BA0002", origin = PortCode("JFK"), schDt = scheduled, actPax = Option(15), feedSources = Set(AclFeedSource))
         val arrivalDom: Arrival = ArrivalGenerator.arrival(iata = "BA0003", origin = PortCode("BHX"), schDt = scheduled, actPax = Option(11), feedSources = Set(AclFeedSource))
         val arrivalCta: Arrival = ArrivalGenerator.arrival(iata = "BA0004", origin = PortCode("IOM"), schDt = scheduled, actPax = Option(12), feedSources = Set(AclFeedSource))
 
-        val aclFlight: Flights = Flights(List(arrivalInt, arrivalDom, arrivalCta))
+        offerAndWait(crunch.aclArrivalsInput, ArrivalsFeedSuccess(Flights(List(arrivalInt, arrivalDom, arrivalCta))))
+        expectPaxNos(15)
+
+        success
+      }
+    }
+
+    "Given an empty PortState I should only see arrivals without a suffix in the port state" >> {
+      val withSuffixP: Arrival = ArrivalGenerator.arrival(iata = "BA0001P", origin = PortCode("JFK"), schDt = "2017-01-01T10:25Z", actPax = Option(10), feedSources = Set(AclFeedSource))
+      val withSuffixF: Arrival = ArrivalGenerator.arrival(iata = "BA0002F", origin = PortCode("JFK"), schDt = "2017-01-01T11:25Z", actPax = Option(10), feedSources = Set(AclFeedSource))
+      val withoutSuffix: Arrival = ArrivalGenerator.arrival(iata = "BA0003", origin = PortCode("JFK"), schDt = "2017-01-01T12:25Z", actPax = Option(10), feedSources = Set(AclFeedSource))
+
+      "Given 3 international ACL arrivals, one with suffix F, another with P, and another with no suffix" >> {
+        val aclFlight: Flights = Flights(List(withSuffixP, withSuffixF, withoutSuffix))
 
         offerAndWait(crunch.aclArrivalsInput, ArrivalsFeedSuccess(aclFlight))
+        expectArrivals(Iterable(withoutSuffix))
 
-        crunch.portStateTestProbe.fishForMessage(1 seconds) {
-          case ps: PortState =>
-            val totalPax = ps.crunchMinutes.values.map(_.paxLoad).sum
-            totalPax == 15
-        }
+        success
+      }
+
+      "Given 3 international live arrivals, one with suffix F, another with P, and another with no suffix" >> {
+        val aclFlight: Flights = Flights(List(withSuffixP, withSuffixF, withoutSuffix))
+
+        offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(aclFlight))
+        expectUniqueArrival(withoutSuffix.unique)
 
         success
       }
     }
-  }
 
-  "Given an empty PortState I should only see arrivals without a suffix in the port state" >> {
-    val withSuffixP: Arrival = ArrivalGenerator.arrival(iata = "BA0001P", origin = PortCode("JFK"), schDt = "2017-01-01T10:25Z", actPax = Option(10), feedSources = Set(AclFeedSource))
-    val withSuffixF: Arrival = ArrivalGenerator.arrival(iata = "BA0002F", origin = PortCode("JFK"), schDt = "2017-01-01T11:25Z", actPax = Option(10), feedSources = Set(AclFeedSource))
-    val withoutSuffix: Arrival = ArrivalGenerator.arrival(iata = "BA0003", origin = PortCode("JFK"), schDt = "2017-01-01T12:25Z", actPax = Option(10), feedSources = Set(AclFeedSource))
+    "Given a live arrival and a cirium arrival" >> {
+      "When they have matching number, schedule, terminal and origin" >> {
+        "I should see the live arrival with the cirium arrival's status merged" >> {
+          val liveArrival = ArrivalGenerator.arrival("AA0001", schDt = scheduled, terminal = T1, origin = PortCode("AAA"))
+          val ciriumArrival = ArrivalGenerator.arrival("AA0001", schDt = scheduled, terminal = T1, origin = PortCode("AAA"), estDt = scheduled)
 
-    "Given 3 international ACL arrivals, one with suffix F, another with P, and another with no suffix" >> {
-      val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(TestConfig(now = () => dateNow))
-      val aclFlight: Flights = Flights(List(withSuffixP, withSuffixF, withoutSuffix))
+          offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(List(liveArrival))))
+          expectUniqueArrival(liveArrival.unique)
 
-      offerAndWait(crunch.aclArrivalsInput, ArrivalsFeedSuccess(aclFlight))
+          offerAndWait(crunch.ciriumArrivalsInput, ArrivalsFeedSuccess(Flights(List(ciriumArrival))))
+          expectArrivals(Iterable(liveArrival.copy(
+            Estimated = Option(SDate(scheduled).millisSinceEpoch),
+            FeedSources = Set(LiveFeedSource, LiveBaseFeedSource))))
 
-      crunch.portStateTestProbe.fishForMessage(1 seconds) {
-        case ps: PortState =>
-          val numberOfFlights = ps.flights.size
-          numberOfFlights == 1 && flightExists(withoutSuffix, ps)
+          success
+        }
       }
 
+      "When they have matching number, schedule, terminal but different origins" >> {
+        "I should see the live arrival without the cirium arrival's status merged" >> {
+          val liveArrival = ArrivalGenerator.arrival("AA0002", schDt = scheduled, terminal = T1, origin = PortCode("AAA"))
+          val ciriumArrival = ArrivalGenerator.arrival("AA0002", schDt = scheduled, terminal = T1, origin = PortCode("BBB"), estDt = scheduled)
+          val updatedArrival = liveArrival.copy(ActualChox = Option(SDate(scheduled).millisSinceEpoch))
+
+          offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(List(liveArrival))))
+          expectUniqueArrival(liveArrival.unique)
+
+          offerAndWait(crunch.ciriumArrivalsInput, ArrivalsFeedSuccess(Flights(List(ciriumArrival))))
+          expectArrivals(Iterable(liveArrival.copy(FeedSources = Set(LiveFeedSource, LiveBaseFeedSource))))
+
+          offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(List(updatedArrival))))
+          expectArrivals(Iterable(updatedArrival.copy(FeedSources = Set(LiveFeedSource, LiveBaseFeedSource))))
+
+          success
+        }
+      }
+
+      crunch.shutdown()
       success
     }
-
-    "Given 3 international live arrivals, one with suffix F, another with P, and another with no suffix" >> {
-      val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(TestConfig(now = () => dateNow))
-      val aclFlight: Flights = Flights(List(withSuffixP, withSuffixF, withoutSuffix))
-
-      offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(aclFlight))
-
-      crunch.portStateTestProbe.fishForMessage(1 seconds) {
-        case ps: PortState =>
-          val numberOfFlights = ps.flights.size
-          numberOfFlights == 1 && flightExists(withoutSuffix, ps)
-      }
-
-      success
-    }
-  }
-
-  "Given a live arrival and a cirium arrival" >> {
-    "When they have matching number, schedule, terminal and origin" >> {
-      "I should see the live arrival with the cirium arrival's status merged" >> {
-        val scheduled = "2021-06-01T12:00"
-        val liveArrival = ArrivalGenerator.arrival("AA0001", schDt = scheduled, terminal = T1, origin = PortCode("AAA"))
-        val ciriumArrival = ArrivalGenerator.arrival("AA0001", schDt = scheduled, terminal = T1, origin = PortCode("AAA"), estDt = scheduled)
-
-        val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(TestConfig(now = () => SDate(scheduled)))
-
-        offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(List(liveArrival))))
-
-        crunch.portStateTestProbe.fishForMessage(1 second) {
-          case PortState(flights, _, _) => flights.nonEmpty
-        }
-
-        offerAndWait(crunch.ciriumArrivalsInput, ArrivalsFeedSuccess(Flights(List(ciriumArrival))))
-
-        crunch.portStateTestProbe.fishForMessage(1 second) {
-          case PortState(flights, _, _) => flights.values.exists(_.apiFlight.Estimated == Option(SDate(scheduled).millisSinceEpoch))
-        }
-
-        success
-      }
-    }
-
-    "When they have matching number, schedule, terminal and origin" >> {
-      "I should see the live arrival without the cirium arrival's status merged" >> {
-        val scheduled = "2021-06-01T12:00"
-        val liveArrival = ArrivalGenerator.arrival("AA0002", schDt = scheduled, terminal = T1, origin = PortCode("AAA"))
-        val ciriumArrival = ArrivalGenerator.arrival("AA0002", schDt = scheduled, terminal = T1, origin = PortCode("BBB"), estDt = scheduled)
-
-        val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(TestConfig(now = () => SDate(scheduled)))
-
-        offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(List(liveArrival))))
-
-        crunch.portStateTestProbe.fishForMessage(1 second) {
-          case PortState(flights, _, _) => flights.nonEmpty
-        }
-
-        offerAndWait(crunch.ciriumArrivalsInput, ArrivalsFeedSuccess(Flights(List(ciriumArrival))))
-
-        Thread.sleep(500)
-
-        val updatedChox = Option(SDate(scheduled).millisSinceEpoch)
-        offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(List(liveArrival.copy(ActualChox = updatedChox)))))
-
-        crunch.portStateTestProbe.fishForMessage(1 second) {
-          case PortState(flights, _, _) => flights.values.exists { fws =>
-            fws.apiFlight.ActualChox == updatedChox && fws.apiFlight.Estimated.isEmpty
-          }
-        }
-
-        success
-      }
-    }
-  }
-
-  private def flightExists(withoutSuffix: Arrival, ps: PortState) = {
-    ps.flights.contains(UniqueArrival(withoutSuffix))
   }
 }

--- a/server/src/test/scala/services/crunch/CrunchTestLike.scala
+++ b/server/src/test/scala/services/crunch/CrunchTestLike.scala
@@ -275,9 +275,15 @@ class CrunchTestLike
           .map {
             case (queue, mins) => (queue, mins.map(_.paxLoad).sum)
           }
-        val asExpected = paxByQueue == paxByQueueToExpect
-        if (!asExpected) println(s"\nNo match yet\ngot: $paxByQueue\nexp: $paxByQueueToExpect")
-        asExpected
+          .filter {
+            case (_, mins) => mins > 0
+          }
+        val nonZerosToExpect = paxByQueueToExpect
+          .filter {
+            case (_, mins) => mins > 0
+          }
+
+        paxByQueue == nonZerosToExpect
     }
 
   def paxLoadsFromPortState(portState: PortState,

--- a/server/src/test/scala/services/crunch/CrunchTestLike.scala
+++ b/server/src/test/scala/services/crunch/CrunchTestLike.scala
@@ -187,7 +187,7 @@ object TestDefaults {
 
   def testProbe(name: String)(implicit system: ActorSystem): TestProbe = TestProbe(name = name)
 
-  val pcpPaxFn: Arrival => Int = PcpPax.bestPaxEstimateWithApi
+  val pcpPaxFn: Arrival => Int = PcpPax.bestPaxEstimate
 }
 
 class CrunchTestLike

--- a/server/src/test/scala/services/crunch/PCPPaxNosSpec.scala
+++ b/server/src/test/scala/services/crunch/PCPPaxNosSpec.scala
@@ -43,7 +43,7 @@ class PCPPaxNosSpec extends CrunchTestLike {
         terminalProcessingTimes = procTimes,
         queuesByTerminal = SortedMap(T1 -> Seq(Queues.EeaDesk))
       ),
-      pcpPaxFn = PcpPax.bestPaxEstimateExcludingApi))
+      pcpPaxFn = PcpPax.bestPaxEstimate))
 
     offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(flights))
     offerAndWait(crunch.manifestsLiveInput, manifests)

--- a/server/src/test/scala/services/crunch/QueueDiversionSpec.scala
+++ b/server/src/test/scala/services/crunch/QueueDiversionSpec.scala
@@ -56,7 +56,7 @@ class QueueDiversionSpec extends CrunchTestLike {
       val liveArrival = ArrivalGenerator.arrival("AA0002", schDt = scheduled, terminal = T1, origin = PortCode("AAA"), actPax = Option(pax))
 
       offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(List(liveArrival))))
-      expectPaxByQueue(Map(EeaDesk -> 100))
+      expectPaxByQueue(Map(EeaDesk -> 100, EGate -> 0))
 
       success
     }

--- a/server/src/test/scala/services/crunch/QueueDiversionSpec.scala
+++ b/server/src/test/scala/services/crunch/QueueDiversionSpec.scala
@@ -1,0 +1,64 @@
+package services.crunch
+
+import controllers.ArrivalGenerator
+import drt.shared.FlightsApi.Flights
+import drt.shared.PaxTypes.EeaMachineReadable
+import drt.shared.Queues.{EGate, EeaDesk, Queue}
+import drt.shared.Terminals.{T1, Terminal}
+import drt.shared.{PaxTypeAndQueue, PortCode, SDateLike}
+import server.feeds.ArrivalsFeedSuccess
+import services.SDate
+import services.crunch.TestDefaults.airportConfigForSplits
+
+import scala.collection.immutable.List
+
+class QueueDiversionSpec extends CrunchTestLike {
+  private val date = "2017-01-01"
+  private val hour = "00:25"
+  val scheduled = s"${date}T${hour}Z"
+
+  val dateNow: SDateLike = SDate(date + "T00:00Z")
+
+  "Concerning queue diversions" >> {
+    val deskRatios = Map(EeaDesk -> 0.75, EGate -> 0.25)
+    val splits = Map(PaxTypeAndQueue(EeaMachineReadable, EeaDesk) -> deskRatios(EeaDesk), PaxTypeAndQueue(EeaMachineReadable, EGate) -> deskRatios(EGate))
+
+    val config = airportConfigForSplits(splits)
+    val allQueuesOpen: Map[Terminal, Map[Queue, (List[Int], List[Int])]] = Map(T1 -> Map(
+      EeaDesk -> (List.fill[Int](24)(1), List.fill[Int](24)(20)),
+      EGate -> (List.fill[Int](24)(1), List.fill[Int](24)(20)),
+    ))
+    val egatesQueueClosed: Map[Terminal, Map[Queue, (List[Int], List[Int])]] = Map(T1 -> Map(
+      EeaDesk -> (List.fill[Int](24)(1), List.fill[Int](24)(20)),
+      EGate -> (List.fill[Int](24)(0), List.fill[Int](24)(0)),
+    ))
+
+    "Given an arrival, I should see pax headed to all queues in the default splits" >> {
+      implicit val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(TestConfig(
+        airportConfig = config.copy(minMaxDesksByTerminalQueue24Hrs = allQueuesOpen),
+        now = () => dateNow))
+
+      val pax = 100
+      val liveArrival = ArrivalGenerator.arrival("AA0002", schDt = scheduled, terminal = T1, origin = PortCode("AAA"), actPax = Option(pax))
+
+      offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(List(liveArrival))))
+      expectPaxByQueue(Map(EeaDesk -> 75, EGate -> 25))
+
+      success
+    }
+
+    "Given an arrival, and zero max egates, I should see pax headed only to the desks" >> {
+      implicit val crunch: CrunchGraphInputsAndProbes = runCrunchGraph(TestConfig(
+        airportConfig = config.copy(minMaxDesksByTerminalQueue24Hrs = egatesQueueClosed),
+        now = () => dateNow))
+
+      val pax = 100
+      val liveArrival = ArrivalGenerator.arrival("AA0002", schDt = scheduled, terminal = T1, origin = PortCode("AAA"), actPax = Option(pax))
+
+      offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(Flights(List(liveArrival))))
+      expectPaxByQueue(Map(EeaDesk -> 100))
+
+      success
+    }
+  }
+}

--- a/server/src/test/scala/services/crunch/TestDrtActor.scala
+++ b/server/src/test/scala/services/crunch/TestDrtActor.scala
@@ -96,7 +96,7 @@ class TestDrtActor extends Actor {
 
       tc.initialPortState.foreach(ps => portStateActor ! ps)
 
-      val portDeskRecs = PortDesksAndWaitsProvider(tc.airportConfig, tc.cruncher, tc.pcpPaxFn)
+      val portDeskRecs = PortDesksAndWaitsProvider(tc.airportConfig, tc.cruncher)
 
       val deskLimitsProviders: Map[Terminal, TerminalDeskLimitsLike] = if (tc.flexDesks)
         PortDeskLimits.flexed(tc.airportConfig)
@@ -214,7 +214,6 @@ class TestDrtActor extends Actor {
         initialStaffMovements = tc.initialStaffMovements,
         refreshArrivalsOnStart = tc.refreshArrivalsOnStart,
         refreshManifestsOnStart = tc.refreshManifestsOnStart,
-        pcpPaxFn = tc.pcpPaxFn,
         adjustEGateUseByUnder12s = false,
         optimiser = tc.cruncher,
         aclPaxAdjustmentDays = aclPaxAdjustmentDays,

--- a/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeploymentsSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeploymentsSpec.scala
@@ -31,11 +31,10 @@ class RunnableDynamicDeploymentsSpec extends CrunchTestLike {
 
   val maxDesksProvider: Map[Terminal, TerminalDeskLimitsLike] = PortDeskLimits.flexed(airportConfig)
   val mockCrunch: TryCrunch = CrunchMocks.mockCrunch
-  val pcpPaxCalcFn: Arrival => Int = PcpPax.bestPaxEstimateWithApi
+  val pcpPaxCalcFn: Arrival => Int = PcpPax.bestPaxEstimate
 
   val staffToDeskLimits: StaffToDeskLimits = PortDeskLimits.flexedByAvailableStaff(airportConfig)
-  val desksAndWaitsProvider: PortDesksAndWaitsProvider =
-    PortDesksAndWaitsProvider(airportConfig, mockCrunch, pcpPaxCalcFn)
+  val desksAndWaitsProvider: PortDesksAndWaitsProvider = PortDesksAndWaitsProvider(airportConfig, mockCrunch)
 
   def setupGraphAndCheckQueuePax(minutes: MinutesContainer[CrunchMinute, TQM],
                                  expectedQueuePax: PartialFunction[Any, Boolean]): Any = {

--- a/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeskRecsSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeskRecsSpec.scala
@@ -106,14 +106,14 @@ class RunnableDynamicDeskRecsSpec extends CrunchTestLike {
 
   val maxDesksProvider: Map[Terminal, TerminalDeskLimitsLike] = PortDeskLimits.flexed(airportConfig)
   val mockCrunch: TryCrunch = CrunchMocks.mockCrunch
-  val pcpPaxCalcFn: Arrival => Int = PcpPax.bestPaxEstimateWithApi
+  val pcpPaxCalcFn: Arrival => Int = PcpPax.bestPaxEstimate
 
   val ptqa: PaxTypeQueueAllocation = PaxTypeQueueAllocation(
     B5JPlusTypeAllocator,
     TerminalQueueAllocator(airportConfig.terminalPaxTypeQueueAllocation))
   val splitsCalculator: SplitsCalculator = manifests.queues.SplitsCalculator(ptqa, airportConfig.terminalPaxSplits, AdjustmentsNoop)
 
-  val desksAndWaitsProvider: PortDesksAndWaitsProvider = PortDesksAndWaitsProvider(airportConfig, mockCrunch, pcpPaxCalcFn)
+  val desksAndWaitsProvider: PortDesksAndWaitsProvider = PortDesksAndWaitsProvider(airportConfig, mockCrunch)
   val mockSplitsSink: ActorRef = system.actorOf(Props(new MockSplitsSinkActor))
 
   def setupGraphAndCheckQueuePax(arrival: Arrival,

--- a/server/src/test/scala/services/crunch/deskrecs/RunnableDeskRecsSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/RunnableDeskRecsSpec.scala
@@ -89,7 +89,7 @@ class RunnableDeskRecsSpec extends CrunchTestLike {
   val nowFromSDate: () => SDateLike = () => SDate.now()
 
   val flexDesks = false
-  val pcpPaxCalcFn: Arrival => Int = PcpPax.bestPaxEstimateWithApi
+  val pcpPaxCalcFn: Arrival => Int = PcpPax.bestPaxEstimate
   val mockSplitsSink: ActorRef = system.actorOf(Props(new MockSplitsSinkActor))
 
   private def getDeskRecsGraph(mockPortStateActor: ActorRef, historicManifests: HistoricManifestsProvider, airportConfig: AirportConfig = defaultAirportConfig) = {
@@ -98,7 +98,7 @@ class RunnableDeskRecsSpec extends CrunchTestLike {
       TerminalQueueAllocator(airportConfig.terminalPaxTypeQueueAllocation))
 
     val splitsCalc = SplitsCalculator(paxAllocation, airportConfig.terminalPaxSplits, AdjustmentsNoop)
-    val desksAndWaitsProvider = PortDesksAndWaitsProvider(airportConfig, mockCrunch, pcpPaxCalcFn)
+    val desksAndWaitsProvider = PortDesksAndWaitsProvider(airportConfig, mockCrunch)
 
     implicit val timeout: Timeout = new Timeout(50 milliseconds)
     val deskRecsProducer = DynamicRunnableDeskRecs.crunchRequestsToQueueMinutes(

--- a/server/src/test/scala/services/crunch/workload/WorkloadSpec.scala
+++ b/server/src/test/scala/services/crunch/workload/WorkloadSpec.scala
@@ -3,7 +3,6 @@ package services.crunch.workload
 import controllers.ArrivalGenerator
 import drt.shared.SplitRatiosNs.SplitSources
 import drt.shared._
-import drt.shared.api.Arrival
 import org.specs2.mutable.Specification
 import services.SDate
 import services.graphstages.WorkloadCalculator
@@ -18,8 +17,6 @@ class WorkloadSpec extends Specification {
     Nationality("FRA") -> fraSeconds,
     Nationality("ZAR") -> zaSeconds
   )
-
-  def pcpPaxFn: Arrival => Int = PcpPax.bestPaxEstimateWithApi
 
   "Given an arrival with 1 pax and 1 split containing 1 pax with no nationality data " +
     "When I ask for the workload for this arrival " +
@@ -39,8 +36,7 @@ class WorkloadSpec extends Specification {
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
         emptyNatProcTimes,
-        true,
-        pcpPaxFn
+        useNationalityBasedProcTimes = true
       )
       .toList
       .map(_.workLoad)
@@ -64,8 +60,9 @@ class WorkloadSpec extends Specification {
       .flightToFlightSplitMinutes(
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
-        Map()
-        , false, pcpPaxFn)
+        Map(),
+        useNationalityBasedProcTimes = false
+      )
       .toList
 
     val startTime = SDate(flightSplitMinutes.head.minute).toISOString()
@@ -90,8 +87,7 @@ class WorkloadSpec extends Specification {
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
         natProcTimes,
-        true,
-        pcpPaxFn
+        useNationalityBasedProcTimes = true
       )
       .toList
       .map(_.workLoad)
@@ -116,8 +112,7 @@ class WorkloadSpec extends Specification {
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
         natProcTimes,
-        true,
-        pcpPaxFn
+        useNationalityBasedProcTimes = true
       )
       .toList
       .map(_.workLoad)
@@ -142,8 +137,7 @@ class WorkloadSpec extends Specification {
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
         natProcTimes,
-        true,
-        pcpPaxFn
+        useNationalityBasedProcTimes = true
       )
       .toList
       .map(_.workLoad)
@@ -168,8 +162,7 @@ class WorkloadSpec extends Specification {
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
         natProcTimes,
-        true,
-        pcpPaxFn
+        useNationalityBasedProcTimes = true
       )
       .toList
       .map(_.workLoad)
@@ -202,8 +195,7 @@ class WorkloadSpec extends Specification {
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
         natProcTimes,
-        true,
-        pcpPaxFn
+        useNationalityBasedProcTimes = true
       )
       .toList
       .map(_.workLoad)
@@ -244,8 +236,7 @@ class WorkloadSpec extends Specification {
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
         natProcTimes,
-        true,
-        pcpPaxFn
+        useNationalityBasedProcTimes = true
       )
       .toList
       .map(_.workLoad)
@@ -286,8 +277,7 @@ class WorkloadSpec extends Specification {
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
         natProcTimes,
-        true,
-        pcpPaxFn
+        useNationalityBasedProcTimes = true
       )
       .map(m => (m.paxType, m.queueName, m.workLoad))
 
@@ -319,8 +309,7 @@ class WorkloadSpec extends Specification {
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
         emptyNatProcTimes,
-        true,
-        PcpPax.bestPaxEstimateWithApi
+        useNationalityBasedProcTimes = true
       )
       .toList
       .map(_.workLoad)
@@ -346,8 +335,7 @@ class WorkloadSpec extends Specification {
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
         emptyNatProcTimes,
-        true,
-        PcpPax.bestPaxEstimateWithApi
+        useNationalityBasedProcTimes = true
       )
       .toList
       .map(_.workLoad)

--- a/server/src/test/scala/services/crunch/workload/WorkloadSpec.scala
+++ b/server/src/test/scala/services/crunch/workload/WorkloadSpec.scala
@@ -2,6 +2,7 @@ package services.crunch.workload
 
 import controllers.ArrivalGenerator
 import drt.shared.SplitRatiosNs.SplitSources
+import drt.shared.Terminals.T1
 import drt.shared._
 import org.specs2.mutable.Specification
 import services.SDate
@@ -30,12 +31,12 @@ class WorkloadSpec extends Specification {
         Option(EventTypes.DC),
         PaxNumbers))
     val procTimes = Map(PaxTypeAndQueue(PaxTypes.EeaMachineReadable, Queues.EeaDesk) -> 1.5)
-    val emptyNatProcTimes: Map[Nationality, Double] = Map()
-    val workloads = WorkloadCalculator
+
+    val workloads = WorkloadCalculator(Map(T1 -> procTimes))
       .flightToFlightSplitMinutes(
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
-        emptyNatProcTimes,
+        Map(),
         useNationalityBasedProcTimes = true
       )
       .toList
@@ -56,7 +57,7 @@ class WorkloadSpec extends Specification {
         PaxNumbers))
     val procTimes = Map(PaxTypeAndQueue(PaxTypes.EeaMachineReadable, Queues.EeaDesk) -> 1.5)
 
-    val flightSplitMinutes = WorkloadCalculator
+    val workloads = WorkloadCalculator(Map(T1 -> procTimes))
       .flightToFlightSplitMinutes(
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
@@ -65,7 +66,7 @@ class WorkloadSpec extends Specification {
       )
       .toList
 
-    val startTime = SDate(flightSplitMinutes.head.minute).toISOString()
+    val startTime = SDate(workloads.head.minute).toISOString()
 
     startTime === "2018-08-28T17:07:00Z"
   }
@@ -82,7 +83,8 @@ class WorkloadSpec extends Specification {
         Option(EventTypes.DC),
         PaxNumbers))
     val procTimes = Map(PaxTypeAndQueue(PaxTypes.EeaMachineReadable, Queues.EeaDesk) -> 1.5)
-    val workloads = WorkloadCalculator
+
+    val workloads = WorkloadCalculator(Map(T1 -> procTimes))
       .flightToFlightSplitMinutes(
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
@@ -107,7 +109,8 @@ class WorkloadSpec extends Specification {
         Option(EventTypes.DC),
         PaxNumbers))
     val procTimes = Map(PaxTypeAndQueue(PaxTypes.EeaMachineReadable, Queues.EeaDesk) -> 1.5)
-    val workloads = WorkloadCalculator
+
+    val workloads = WorkloadCalculator(Map(T1 -> procTimes))
       .flightToFlightSplitMinutes(
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
@@ -132,7 +135,8 @@ class WorkloadSpec extends Specification {
         Option(EventTypes.DC),
         PaxNumbers))
     val procTimes = Map(PaxTypeAndQueue(PaxTypes.EeaMachineReadable, Queues.EeaDesk) -> 1.5)
-    val workloads = WorkloadCalculator
+
+    val workloads = WorkloadCalculator(Map(T1 -> procTimes))
       .flightToFlightSplitMinutes(
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
@@ -157,7 +161,8 @@ class WorkloadSpec extends Specification {
         Option(EventTypes.DC),
         PaxNumbers))
     val procTimes = Map(PaxTypeAndQueue(PaxTypes.EeaMachineReadable, Queues.EeaDesk) -> 1.5)
-    val workloads = WorkloadCalculator
+
+    val workloads = WorkloadCalculator(Map(T1 -> procTimes))
       .flightToFlightSplitMinutes(
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
@@ -190,7 +195,7 @@ class WorkloadSpec extends Specification {
       PaxTypeAndQueue(PaxTypes.EeaMachineReadable, Queues.EeaDesk) -> 1.5,
       PaxTypeAndQueue(PaxTypes.VisaNational, Queues.NonEeaDesk) -> 5.5
     )
-    val workloads = WorkloadCalculator
+    val workloads = WorkloadCalculator(Map(T1 -> procTimes))
       .flightToFlightSplitMinutes(
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
@@ -231,7 +236,8 @@ class WorkloadSpec extends Specification {
       Nationality("ZBW") -> zbwSeconds,
       Nationality("ZAR") -> zaSeconds
     )
-    val workloads = WorkloadCalculator
+
+    val workloads = WorkloadCalculator(Map(T1 -> procTimes))
       .flightToFlightSplitMinutes(
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
@@ -272,7 +278,7 @@ class WorkloadSpec extends Specification {
       Nationality("ZBW") -> zbwSeconds,
       Nationality("ZAR") -> zaSeconds
     )
-    val workloads = WorkloadCalculator
+    val workloads = WorkloadCalculator(Map(T1 -> procTimes))
       .flightToFlightSplitMinutes(
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
@@ -304,7 +310,7 @@ class WorkloadSpec extends Specification {
         PaxNumbers))
     val procTimes = Map(PaxTypeAndQueue(PaxTypes.EeaMachineReadable, Queues.EeaDesk) -> 1.5)
     val emptyNatProcTimes: Map[Nationality, Double] = Map()
-    val workloads = WorkloadCalculator
+    val workloads = WorkloadCalculator(Map(T1 -> procTimes))
       .flightToFlightSplitMinutes(
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,
@@ -330,7 +336,7 @@ class WorkloadSpec extends Specification {
         PaxNumbers))
     val procTimes = Map(PaxTypeAndQueue(PaxTypes.EeaMachineReadable, Queues.EeaDesk) -> 1.5)
     val emptyNatProcTimes: Map[Nationality, Double] = Map()
-    val workloads = WorkloadCalculator
+    val workloads = WorkloadCalculator(Map(T1 -> procTimes))
       .flightToFlightSplitMinutes(
         ApiFlightWithSplits(arrival, splits, None),
         procTimes,

--- a/server/src/test/scala/services/export/StreamingFlightsExportSpec.scala
+++ b/server/src/test/scala/services/export/StreamingFlightsExportSpec.scala
@@ -204,8 +204,8 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
 
     val expected =
       """|IATA,ICAO,Origin,Gate/Stand,Status,Scheduled Date,Scheduled Time,Est Arrival,Act Arrival,Est Chox,Act Chox,Est PCP,Total Pax,PCP Pax,API e-Gates,API EEA,API Non-EEA,API Fast Track,Historical e-Gates,Historical EEA,Historical Non-EEA,Historical Fast Track,Terminal Average e-Gates,Terminal Average EEA,Terminal Average Non-EEA,Terminal Average Fast Track
-         |SA0325,SA0325,JHC,/,UNK,2017-01-01,20:00,20:00,,,,20:00,100,100,30,60,10,,,,,,,,,
          |SA0324,SA0324,JHB,/,UNK,2017-01-01,20:00,20:00,,,,20:00,98,98,7,15,32,44,11,23,29,35,,,,
+         |SA0325,SA0325,JHC,/,UNK,2017-01-01,20:00,20:00,,,,20:00,100,100,30,60,10,,,,,,,,,
          |SA0326,SA0326,JHD,/,UNK,2017-01-01,20:00,20:00,,,,20:00,100,100,30,60,10,,,,,,,,,
          |""".stripMargin
 
@@ -317,8 +317,8 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
 
     val expected =
       s"""|IATA,ICAO,Origin,Gate/Stand,Status,Scheduled Date,Scheduled Time,Est Arrival,Act Arrival,Est Chox,Act Chox,Est PCP,Total Pax,PCP Pax,API e-Gates,API EEA,API Non-EEA,API Fast Track,Historical e-Gates,Historical EEA,Historical Non-EEA,Historical Fast Track,Terminal Average e-Gates,Terminal Average EEA,Terminal Average Non-EEA,Terminal Average Fast Track,API Actual - B5JSSK to Desk,API Actual - B5JSSK to eGates,API Actual - EEA (Machine Readable),API Actual - EEA (Non Machine Readable),API Actual - Fast Track (Non Visa),API Actual - Fast Track (Visa),API Actual - Non EEA (Non Visa),API Actual - Non EEA (Visa),API Actual - Transfer,API Actual - eGates
-          |SA0325,SA0325,JHC,/,UNK,2017-01-01,20:00,20:00,,,,20:00,100,100,30,60,10,,,,,,,,,,0.0,0.0,3.0,3.0,0.0,0.0,1.0,0.0,0.0,3.0
           |SA0324,SA0324,JHB,/,UNK,2017-01-01,20:00,20:00,,,,20:00,,100,7,15,32,46,12,23,30,35,,,,,0.0,0.0,1.0,3.0,6.0,7.0,4.0,5.0,0.0,2.0
+          |SA0325,SA0325,JHC,/,UNK,2017-01-01,20:00,20:00,,,,20:00,100,100,30,60,10,,,,,,,,,,0.0,0.0,3.0,3.0,0.0,0.0,1.0,0.0,0.0,3.0
           |SA0326,SA0326,JHD,/,UNK,2017-01-01,20:00,20:00,,,,20:00,100,100,30,60,10,,,,,,,,,,0.0,0.0,30.0,30.0,0.0,0.0,10.0,0.0,0.0,30.0
           |""".stripMargin
 

--- a/server/src/test/scala/services/export/StreamingFlightsExportSpec.scala
+++ b/server/src/test/scala/services/export/StreamingFlightsExportSpec.scala
@@ -195,7 +195,6 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
   "Given a list of arrivals with splits we should get back a CSV of arrival data using live feed numbers when available" >> {
 
     val resultStream = StreamingFlightsExport(
-      PcpPax.bestPaxEstimateWithApi,
       SDate.millisToLocalIsoDateOnly(Crunch.europeLondonTimeZone),
       SDate.millisToLocalHoursAndMinutes(Crunch.europeLondonTimeZone)
     )
@@ -231,7 +230,6 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
     )
 
     val resultStream = StreamingFlightsExport(
-      PcpPax.bestPaxEstimateWithApi,
       SDate.millisToLocalIsoDateOnly(Crunch.europeLondonTimeZone),
       SDate.millisToLocalHoursAndMinutes(Crunch.europeLondonTimeZone)
     )
@@ -252,7 +250,6 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
   "Given a list of arrivals with splits we should get back a CSV of arrival data with unique entry for code Share Arrival flight" >> {
 
     val resultStream = StreamingFlightsExport(
-      PcpPax.bestPaxEstimateWithApi,
       SDate.millisToLocalIsoDateOnly(Crunch.europeLondonTimeZone),
       SDate.millisToLocalHoursAndMinutes(Crunch.europeLondonTimeZone)
     )
@@ -272,7 +269,6 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
   "Given a list of arrivals with splits and with live passenger numbers, we should use live passenger PCP numbers" >> {
 
     val resultStream = StreamingFlightsExport(
-      PcpPax.bestPaxEstimateWithApi,
       SDate.millisToLocalIsoDateOnly(Crunch.europeLondonTimeZone),
       SDate.millisToLocalHoursAndMinutes(Crunch.europeLondonTimeZone)
     )
@@ -292,7 +288,6 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
 
     "Given a list of Flights With Splits then I should get Api Split data for each flight" >> {
       val exporter = StreamingFlightsExport(
-        PcpPax.bestPaxEstimateWithApi,
         SDate.millisToLocalIsoDateOnly(Crunch.europeLondonTimeZone),
         SDate.millisToLocalHoursAndMinutes(Crunch.europeLondonTimeZone)
       )
@@ -313,7 +308,6 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
 
   "Given a list of Flights With Splits then I should get all the data for with API numbers when live numbers are missing" >> {
     val resultStream = StreamingFlightsExport(
-      PcpPax.bestPaxEstimateWithApi,
       SDate.millisToLocalIsoDateOnly(Crunch.europeLondonTimeZone),
       SDate.millisToLocalHoursAndMinutes(Crunch.europeLondonTimeZone)
     )
@@ -333,7 +327,6 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
 
   "Given a list of Flights With Splits then I should get all the data with unique entry for code Share Arrival flight including API numbers" >> {
     val resultStream = StreamingFlightsExport(
-      PcpPax.bestPaxEstimateWithApi,
       SDate.millisToLocalIsoDateOnly(Crunch.europeLondonTimeZone),
       SDate.millisToLocalHoursAndMinutes(Crunch.europeLondonTimeZone)
     )
@@ -352,7 +345,6 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
 
   "Given a source of flights containing empty days and days with flights, then I should still get a CSV result" >> {
     val resultStream = StreamingFlightsExport(
-      PcpPax.bestPaxEstimateWithApi,
       SDate.millisToLocalIsoDateOnly(Crunch.europeLondonTimeZone),
       SDate.millisToLocalHoursAndMinutes(Crunch.europeLondonTimeZone)
     )

--- a/server/src/test/scala/services/graphstages/ArrivalsGraphStagePaxNosSpec.scala
+++ b/server/src/test/scala/services/graphstages/ArrivalsGraphStagePaxNosSpec.scala
@@ -133,7 +133,7 @@ class ArrivalsGraphStagePaxNosSpec extends CrunchTestLike {
     "Given an arrival with a zero pax, undefined trans pax, and max pax of 100" >> {
       val arrival = ArrivalGenerator.arrival(actPax = Option(0), tranPax = None, maxPax = Option(100))
       "When I ask for the best pax" >> {
-        val bestPax = PcpPax.bestPaxEstimateWithApi(arrival)
+        val bestPax = PcpPax.bestPaxEstimate(arrival)
         "I should see 0" >> {
           bestPax === 0
         }

--- a/server/src/test/scala/services/graphstages/DynamicWorkloadCalculatorSpec.scala
+++ b/server/src/test/scala/services/graphstages/DynamicWorkloadCalculatorSpec.scala
@@ -12,7 +12,7 @@ import services.crunch.CrunchTestLike
 
 class DynamicWorkloadCalculatorSpec extends CrunchTestLike {
   def calcForConfig(config: AirportConfig): DynamicWorkloadCalculator = {
-    DynamicWorkloadCalculator(config.terminalProcessingTimes, config.queueStatusProvider)
+    DynamicWorkloadCalculator(config.terminalProcessingTimes, config.queueStatusProvider, QueueFallbacks(config.queuesByTerminal))
   }
 
   "Given a dynamic workload calculator" >> {

--- a/server/src/test/scala/services/graphstages/DynamicWorkloadCalculatorSpec.scala
+++ b/server/src/test/scala/services/graphstages/DynamicWorkloadCalculatorSpec.scala
@@ -1,0 +1,101 @@
+package services.graphstages
+
+import controllers.ArrivalGenerator
+import drt.shared.FlightsApi.FlightsWithSplits
+import drt.shared.PaxTypes.{B5JPlusNational, EeaMachineReadable}
+import drt.shared.Queues.{EGate, EeaDesk, NonEeaDesk, Queue}
+import drt.shared.SplitRatiosNs.SplitSources.TerminalAverage
+import drt.shared.Terminals.{T1, Terminal}
+import drt.shared.{AirportConfig, ApiFlightWithSplits, ApiPaxTypeAndQueueCount, Splits}
+import services.SDate
+import services.crunch.CrunchTestLike
+import services.graphstages.Crunch.europeLondonTimeZone
+
+class DynamicWorkloadCalculatorSpec extends CrunchTestLike {
+  def calcForConfig(config: AirportConfig): DynamicWorkloadCalculator = {
+    DynamicWorkloadCalculator(config.terminalProcessingTimes, config.queueStatusProvider(millis => SDate(millis, europeLondonTimeZone)))
+  }
+
+  "Given a dynamic workload calculator" >> {
+    val arrival = ArrivalGenerator.arrival("BA0001", schDt = "2021-06-01T00:10", actPax = Option(100))
+    val allEgateSplit = ApiPaxTypeAndQueueCount(EeaMachineReadable, EGate, 100, None, None)
+    val allEgatePaxFlight = ApiFlightWithSplits(arrival, Set(Splits(Set(allEgateSplit), TerminalAverage, None)))
+    val allB5JSSKSplit = ApiPaxTypeAndQueueCount(B5JPlusNational, EGate, 100, None, None)
+    val allB5JSSKPaxFlight = ApiFlightWithSplits(arrival, Set(Splits(Set(allB5JSSKSplit), TerminalAverage, None)))
+
+    "When I ask for the workload of a flight with only egate passengers" >> {
+      val calc = calcForConfig(defaultAirportConfig)
+
+      "I should see the workload for those passengers in the egate queue" >> {
+        val loads = calc.flightLoadMinutes(FlightsWithSplits(Iterable(allEgatePaxFlight)))
+
+        val byQueue = loads.minutes.values
+          .groupBy(_.queue)
+          .mapValues(_.map(_.paxLoad).sum)
+
+        byQueue === Map(EGate -> 100)
+      }
+    }
+
+    "When I ask for the workload of a flight with only egate passengers at a time when the egates are closed" >> {
+      val egatesClosed: Map[Terminal, Map[Queue, (List[Int], List[Int])]] = Map(T1 -> Map(
+        EGate -> (List.fill(24)(0), List.fill(24)(0)),
+        EeaDesk -> (List.fill(24)(1), List.fill(24)(10)),
+        NonEeaDesk -> (List.fill(24)(1), List.fill(24)(10)),
+      ))
+
+      val calc = calcForConfig(defaultAirportConfig.copy(minMaxDesksByTerminalQueue24Hrs = egatesClosed))
+
+      "I should see the workload for those passengers diverted to the eea queue" >> {
+        val loads = calc.flightLoadMinutes(FlightsWithSplits(Iterable(allEgatePaxFlight)))
+
+        val byQueue = loads.minutes.values
+          .groupBy(_.queue)
+          .mapValues(_.map(_.paxLoad).sum)
+
+        byQueue === Map(EeaDesk -> 100)
+      }
+    }
+
+    "When I ask for the workload of a flight with only egate passengers at a time when the egates and eea queue are closed" >> {
+      val egatesClosed: Map[Terminal, Map[Queue, (List[Int], List[Int])]] = Map(T1 -> Map(
+        EGate -> (List.fill(24)(0), List.fill(24)(0)),
+        EeaDesk -> (List.fill(24)(0), List.fill(24)(0)),
+        NonEeaDesk -> (List.fill(24)(1), List.fill(24)(10)),
+      ))
+
+      val calc = calcForConfig(defaultAirportConfig.copy(minMaxDesksByTerminalQueue24Hrs = egatesClosed))
+
+      "I should see the workload for those passengers diverted to the non-eea queue" >> {
+        val loads = calc.flightLoadMinutes(FlightsWithSplits(Iterable(allEgatePaxFlight)))
+
+        val byQueue = loads.minutes.values
+          .groupBy(_.queue)
+          .mapValues(_.map(_.paxLoad).sum)
+
+        byQueue === Map(NonEeaDesk -> 100)
+      }
+    }
+
+    "When I ask for the workload of a flight with only B5JSSK+ passengers at a time when the egates are closed" >> {
+      val egatesClosed: Map[Terminal, Map[Queue, (List[Int], List[Int])]] = Map(T1 -> Map(
+        EGate -> (List.fill(24)(0), List.fill(24)(0)),
+        EeaDesk -> (List.fill(24)(1), List.fill(24)(10)),
+        NonEeaDesk -> (List.fill(24)(1), List.fill(24)(10)),
+      ))
+
+      val calc = calcForConfig(defaultAirportConfig.copy(minMaxDesksByTerminalQueue24Hrs = egatesClosed))
+
+      "I should see the workload for those passengers diverted to the non-eea queue" >> {
+        val loads = calc.flightLoadMinutes(FlightsWithSplits(Iterable(allB5JSSKPaxFlight)))
+
+        val byQueue = loads.minutes.values
+          .groupBy(_.queue)
+          .mapValues(_.map(_.paxLoad).sum)
+
+        byQueue === Map(NonEeaDesk -> 100)
+      }
+    }
+  }
+
+}

--- a/shared/src/main/scala/drt/shared/Api.scala
+++ b/shared/src/main/scala/drt/shared/Api.scala
@@ -710,7 +710,7 @@ object DataUpdates {
 
 object FlightsApi {
 
-  case class Flights(flights: Seq[Arrival])
+  case class Flights(flights: Iterable[Arrival])
 
   case class FlightsWithSplits(flights: Map[UniqueArrival, ApiFlightWithSplits]) {
     def scheduledSince(sinceMillis: MillisSinceEpoch): FlightsWithSplits = FlightsWithSplits(flights.filter {

--- a/shared/src/main/scala/drt/shared/Api.scala
+++ b/shared/src/main/scala/drt/shared/Api.scala
@@ -18,6 +18,7 @@ import uk.gov.homeoffice.drt.auth.LoggedInUser
 import uk.gov.homeoffice.drt.auth.Roles.Role
 import upickle.default._
 
+import java.lang.Math.round
 import java.util.UUID
 import scala.collection.immutable.{Map => IMap, SortedMap => ISortedMap}
 import scala.concurrent.Future
@@ -500,8 +501,8 @@ object ArrivalsDiff {
 }
 
 case class ArrivalsDiff(toUpdate: ISortedMap[UniqueArrival, Arrival], toRemove: Iterable[Arrival]) extends FlightUpdates {
-  private val minutesFromUpdate: Iterable[MillisSinceEpoch] = toUpdate.values.flatMap(_.pcpRange())
-  private val minutesFromRemoval: Iterable[MillisSinceEpoch] = toRemove.flatMap(_.pcpRange())
+  private val minutesFromUpdate: Iterable[MillisSinceEpoch] = toUpdate.values.flatMap(_.pcpRange)
+  private val minutesFromRemoval: Iterable[MillisSinceEpoch] = toRemove.flatMap(_.pcpRange)
   val updateMinutes: Iterable[MillisSinceEpoch] = minutesFromUpdate ++ minutesFromRemoval
 
   def diffWith(flights: FlightsWithSplits, nowMillis: MillisSinceEpoch): FlightsWithSplitsDiff = {
@@ -717,16 +718,6 @@ object FlightsApi {
       case (UniqueArrival(_, _, scheduledMillis), _) => scheduledMillis >= sinceMillis
     })
 
-    def window(startMillis: MillisSinceEpoch, endMillis: MillisSinceEpoch): FlightsWithSplits = {
-      val inWindow = flights.filter {
-        case (_, fws) =>
-          val pcpRange = fws.apiFlight.pcpRange()
-          (startMillis <= pcpRange.min && pcpRange.max <= endMillis) ||
-            (startMillis <= fws.apiFlight.Scheduled && fws.apiFlight.Scheduled <= endMillis)
-      }
-      FlightsWithSplits(inWindow)
-    }
-
     def scheduledWindow(startMillis: MillisSinceEpoch, endMillis: MillisSinceEpoch): FlightsWithSplits = {
       val inWindow = flights.filter {
         case (_, fws) => startMillis <= fws.apiFlight.Scheduled && fws.apiFlight.Scheduled <= endMillis
@@ -806,7 +797,7 @@ object FlightsApi {
 
     def nonEmpty: Boolean = !isEmpty
 
-    val updateMinutes: Iterable[MillisSinceEpoch] = flightsToUpdate.flatMap(_.apiFlight.pcpRange())
+    val updateMinutes: Iterable[MillisSinceEpoch] = flightsToUpdate.flatMap(_.apiFlight.pcpRange)
 
     def applyTo(flightsWithSplits: FlightsWithSplits,
                 nowMillis: MillisSinceEpoch): (FlightsWithSplits, Iterable[MillisSinceEpoch]) = {
@@ -816,18 +807,18 @@ object FlightsApi {
       val asMap: IMap[UniqueArrival, ApiFlightWithSplits] = flightsWithSplits.flights
 
       val minutesFromRemovalsInExistingState: Iterable[MillisSinceEpoch] = arrivalsToRemove
-        .flatMap(r => asMap.get(r).map(_.apiFlight.pcpRange().toList).getOrElse(List()))
+        .flatMap(r => asMap.get(r).map(_.apiFlight.pcpRange).getOrElse(List()))
 
       val minutesFromExistingStateUpdatedFlights = flightsToUpdate
         .flatMap { fws =>
           asMap.get(fws.unique) match {
             case None => List()
-            case Some(f) => f.apiFlight.pcpRange()
+            case Some(f) => f.apiFlight.pcpRange
           }
         }
 
       val removalMinutes: Iterable[MillisSinceEpoch] = arrivalsToRemove.flatMap(ua => {
-        asMap.get(ua).toList.flatMap(_.apiFlight.pcpRange())
+        asMap.get(ua).toList.flatMap(_.apiFlight.pcpRange)
       })
 
       val updatedMinutesFromFlights = removalMinutes ++ minutesFromRemovalsInExistingState ++ updateMinutes ++
@@ -882,6 +873,8 @@ object MilliTimes {
   val oneHourMillis: Int = 60 * oneMinuteMillis
   val oneDayMillis: Int = 24 * oneHourMillis
   val minutesInADay: Int = 60 * 24
+
+  def timeToNearestMinute(t: MillisSinceEpoch): MillisSinceEpoch = round(t / 60000d) * 60000
 }
 
 object CrunchApi {

--- a/shared/src/main/scala/drt/shared/HasAirportConfig.scala
+++ b/shared/src/main/scala/drt/shared/HasAirportConfig.scala
@@ -93,8 +93,8 @@ object Queues {
 
   case class QueueFallbacks(queues: Map[Terminal, Seq[Queue]]) {
     val fallbacks: PartialFunction[(Queue, PaxType), Seq[Queue]] = {
-      case (EGate, _: EeaPaxType) => Seq(EeaDesk, NonEeaDesk, QueueDesk)
-      case (EGate, _: NonEeaPaxType) => Seq(NonEeaDesk, EeaDesk, QueueDesk)
+      case (EGate, _: EeaPaxType) => Seq(EeaDesk, QueueDesk, NonEeaDesk)
+      case (EGate, _: NonEeaPaxType) => Seq(NonEeaDesk, QueueDesk, EeaDesk)
       case (EeaDesk, _: PaxType) => Seq(EeaDesk, QueueDesk)
       case (NonEeaDesk, _: PaxType) => Seq(EeaDesk, QueueDesk)
       case (_, _) => Seq()

--- a/shared/src/main/scala/drt/shared/HasAirportConfig.scala
+++ b/shared/src/main/scala/drt/shared/HasAirportConfig.scala
@@ -80,6 +80,12 @@ object Terminals {
 
 object Queues {
 
+  sealed trait QueueStatus
+
+  case object Open extends QueueStatus
+
+  case object Closed extends QueueStatus
+
   sealed trait Queue extends ClassNameForToString with Ordered[Queue] {
     override def compare(that: Queue): Int = toString.compareTo(that.toString)
   }

--- a/shared/src/main/scala/drt/shared/PcpPax.scala
+++ b/shared/src/main/scala/drt/shared/PcpPax.scala
@@ -5,32 +5,12 @@ import drt.shared.api.Arrival
 object PcpPax {
   val defaultPax = 0
 
-  def bestPaxEstimateWithApi(flight: Arrival): Int =
-      (flight.ApiPax, flight.ActPax, flight.TranPax, flight.MaxPax) match {
-        case (Some(apiPax), _, _, _) if !flight.FeedSources.contains(LiveFeedSource) => apiPax
-        case (_, Some(actPax), Some(tranPax), _) if (actPax - tranPax) >= 0 => actPax - tranPax
-        case (_, Some(actPax), None, _) => actPax
-        case (Some(apiPax), _, _, _) => apiPax
-        case _ => defaultPax
-      }
-
-  def bestPaxEstimateExcludingApi(flight: Arrival): Int =
-      (flight.ActPax, flight.TranPax, flight.MaxPax) match {
-        case (Some(actPax), Some(tranPax), _) if (actPax - tranPax) >= 0 => actPax - tranPax
-        case (Some(actPax), None, _) => actPax
-        case (_, _, Some(maxPax)) if maxPax > 0 => maxPax
-        case _ => defaultPax
-      }
-
-  def padTo4Digits(voyageNumber: String): String = {
-    val prefix = voyageNumber.length match {
-      case 4 => ""
-      case 3 => "0"
-      case 2 => "00"
-      case 1 => "000"
-      case _ => ""
+  def bestPaxEstimate(flight: Arrival): Int =
+    (flight.ApiPax, flight.ActPax, flight.TranPax, flight.MaxPax) match {
+      case (Some(apiPax), _, _, _) if !flight.FeedSources.contains(LiveFeedSource) => apiPax
+      case (_, Some(actPax), Some(tranPax), _) if (actPax - tranPax) >= 0 => actPax - tranPax
+      case (_, Some(actPax), None, _) => actPax
+      case (Some(apiPax), _, _, _) => apiPax
+      case _ => defaultPax
     }
-    prefix + voyageNumber
-  }
-
 }

--- a/shared/src/main/scala/drt/shared/SplitRatiosNs.scala
+++ b/shared/src/main/scala/drt/shared/SplitRatiosNs.scala
@@ -1,9 +1,11 @@
 package drt.shared
+
 import drt.shared.SplitRatiosNs.SplitSources.{AdvPaxInfo, ApiSplitsWithHistoricalEGateAndFTPercentages, ApiSplitsWithHistoricalEGateAndFTPercentages_Old, Historical, InvalidSource, PredictedSplitsWithHistoricalEGateAndFTPercentages, TerminalAverage}
 import upickle.default.{ReadWriter, macroRW}
 
 object SplitRatiosNs {
-  case class SplitRatios(splits: List[SplitRatio]=Nil, origin: SplitSource)
+
+  case class SplitRatios(splits: Iterable[SplitRatio] = Nil, origin: SplitSource)
 
   sealed trait SplitSource extends ClassNameForToString
 
@@ -22,22 +24,35 @@ object SplitRatiosNs {
   }
 
   object SplitSources {
+
     object AdvPaxInfo extends SplitSource
+
     object ApiSplitsWithHistoricalEGateAndFTPercentages_Old extends SplitSource
+
     object ApiSplitsWithHistoricalEGateAndFTPercentages extends SplitSource
+
     object PredictedSplitsWithHistoricalEGateAndFTPercentages extends SplitSource
+
     object Historical extends SplitSource
+
     object TerminalAverage extends SplitSource
+
     object InvalidSource extends SplitSource
+
   }
 
   object SplitRatios {
     def apply(origin: SplitSource, ratios: SplitRatio*): SplitRatios = SplitRatios(ratios.toList, origin)
+
     def apply(origin: SplitSource, ratios: List[SplitRatio]): SplitRatios = SplitRatios(ratios, origin)
+
     implicit val rw: ReadWriter[SplitRatios] = macroRW
   }
+
   case class SplitRatio(paxType: PaxTypeAndQueue, ratio: Double)
+
   object SplitRatio {
     implicit val rw: ReadWriter[SplitRatio] = macroRW
   }
+
 }

--- a/shared/src/main/scala/drt/shared/airportconfig/Bfs.scala
+++ b/shared/src/main/scala/drt/shared/airportconfig/Bfs.scala
@@ -1,11 +1,12 @@
 package drt.shared.airportconfig
 
+import drt.shared.CrunchApi.MillisSinceEpoch
 import uk.gov.homeoffice.drt.auth.Roles.BFS
 import drt.shared.PaxTypes.{B5JPlusNational, EeaMachineReadable}
 import drt.shared.PaxTypesAndQueues._
-import drt.shared.Queues.{EeaDesk, NonEeaDesk}
+import drt.shared.Queues.{EeaDesk, NonEeaDesk, Open, Queue, QueueStatus}
 import drt.shared.SplitRatiosNs.{SplitRatio, SplitRatios, SplitSources}
-import drt.shared.Terminals.T1
+import drt.shared.Terminals.{T1, Terminal}
 import drt.shared._
 
 import scala.collection.immutable.SortedMap

--- a/shared/src/main/scala/drt/shared/api/Arrival.scala
+++ b/shared/src/main/scala/drt/shared/api/Arrival.scala
@@ -6,7 +6,7 @@ import drt.shared.Terminals.Terminal
 import drt.shared._
 import upickle.default.{ReadWriter, macroRW}
 
-import scala.collection.immutable.NumericRange
+import scala.collection.immutable.{List, NumericRange}
 import scala.util.matching.Regex
 
 case class FlightCodeSuffix(suffix: String)
@@ -57,7 +57,7 @@ case class Arrival(Operator: Option[Operator],
 
   def hasPcpDuring(start: SDateLike, end: SDateLike): Boolean = {
     val firstPcpMilli = PcpTime.getOrElse(0L)
-    val lastPcpMilli = firstPcpMilli + millisToDisembark(ActPax.getOrElse(0))
+    val lastPcpMilli = firstPcpMilli + millisToDisembark(ActPax.getOrElse(0), 20)
     val firstInRange = start.millisSinceEpoch <= firstPcpMilli && firstPcpMilli <= end.millisSinceEpoch
     val lastInRange = start.millisSinceEpoch <= lastPcpMilli && lastPcpMilli <= end.millisSinceEpoch
     firstInRange || lastInRange
@@ -66,22 +66,34 @@ case class Arrival(Operator: Option[Operator],
   def isRelevantToPeriod(rangeStart: SDateLike, rangeEnd: SDateLike): Boolean =
     Arrival.isRelevantToPeriod(rangeStart, rangeEnd)(this)
 
-  def millisToDisembark(pax: Int): Long = {
-    val minutesToDisembark = (pax.toDouble / 20).ceil
+  def millisToDisembark(pax: Int, paxPerMinute: Int): Long = {
+    val minutesToDisembark = (pax.toDouble / paxPerMinute).ceil
     val oneMinuteInMillis = 60 * 1000
     (minutesToDisembark * oneMinuteInMillis).toLong
   }
 
-  lazy val pax: Int = ActPax.getOrElse(0)
+  val bestPaxEstimate: Int = PcpPax.bestPaxEstimate(this)
 
-  lazy val minutesOfPaxArrivals: Int =
-    if (pax <= 0) 0
-    else (pax.toDouble / paxOffPerMinute).ceil.toInt - 1
+  def minutesOfPaxArrivals: Int = {
+    val totalPax = bestPaxEstimate
+    if (totalPax <= 0) 0
+    else (totalPax.toDouble / paxOffPerMinute).ceil.toInt - 1
+  }
 
-  def pcpRange(): NumericRange[MillisSinceEpoch] = {
-    val pcpStart = PcpTime.getOrElse(0L)
+  lazy val pcpRange: NumericRange[MillisSinceEpoch] = {
+    val pcpStart = MilliTimes.timeToNearestMinute(PcpTime.getOrElse(0L))
     val pcpEnd = pcpStart + oneMinuteMillis * minutesOfPaxArrivals
     pcpStart to pcpEnd by oneMinuteMillis
+  }
+
+  def paxDeparturesByMinute(departRate: Int): Iterable[(MillisSinceEpoch, Int)] = {
+    val totalPax = bestPaxEstimate
+    val maybeRemainingPax = totalPax % departRate match {
+      case 0 => None
+      case someLeftovers => Option(someLeftovers)
+    }
+    val paxByMinute = List.fill(totalPax / departRate)(departRate) ::: maybeRemainingPax.toList
+    pcpRange.zip(paxByMinute)
   }
 
   lazy val unique: UniqueArrival = UniqueArrival(VoyageNumber.numeric, Terminal, Scheduled)
@@ -97,7 +109,7 @@ case class Arrival(Operator: Option[Operator],
 object Arrival {
   val flightCodeRegex: Regex = "^([A-Z0-9]{2,3}?)([0-9]{1,4})([A-Z]*)$".r
 
-  def isInRange(rangeStart: MillisSinceEpoch, rangeEnd: MillisSinceEpoch)(needle: MillisSinceEpoch) =
+  def isInRange(rangeStart: MillisSinceEpoch, rangeEnd: MillisSinceEpoch)(needle: MillisSinceEpoch): Boolean =
     rangeStart < needle && needle < rangeEnd
 
   def isRelevantToPeriod(rangeStart: SDateLike, rangeEnd: SDateLike)(arrival: Arrival): Boolean = {

--- a/shared/src/main/scala/drt/shared/splits/ApiSplitsToSplitRatio.scala
+++ b/shared/src/main/scala/drt/shared/splits/ApiSplitsToSplitRatio.scala
@@ -18,20 +18,13 @@ object ApiSplitsToSplitRatio {
       }
     })
 
-  def paxPerQueueUsingBestSplitsAsRatio(
-                                         flightWithSplits: ApiFlightWithSplits,
-                                         pcpPaxFn: Arrival => Int
-                                       ): Option[Map[Queue, Int]] =
+  def paxPerQueueUsingBestSplitsAsRatio(flightWithSplits: ApiFlightWithSplits): Option[Map[Queue, Int]] =
     flightWithSplits.bestSplits.map(s =>
-      flightPaxPerQueueUsingSplitsAsRatio(s, flightWithSplits.apiFlight, pcpPaxFn)
+      flightPaxPerQueueUsingSplitsAsRatio(s, flightWithSplits.apiFlight)
     )
 
-  def flightPaxPerQueueUsingSplitsAsRatio(
-                                           splits: Splits,
-                                           flight: Arrival,
-                                           pcpPaxFn: Arrival => Int
-                                         ): Map[Queue, Int] = queueTotals(
-    applyPaxSplitsToFlightPax(splits, pcpPaxFn(flight))
+  def flightPaxPerQueueUsingSplitsAsRatio(splits: Splits, flight: Arrival): Map[Queue, Int] = queueTotals(
+    applyPaxSplitsToFlightPax(splits, flight.bestPaxEstimate)
       .splits
       .map(ptqc => PaxTypeAndQueue(ptqc.passengerType, ptqc.queueType) -> ptqc.paxCount.toInt)
       .toMap


### PR DESCRIPTION
Add queue diversion to prioritised fallbacks:
 - Egates
   - EEA -> 1st: EEA Desk, 2nd: Non-EEA Desk
   - Non-EEA -> 1st: Non-EEA Desk, 2nd: EEA Desk
 - EEA Desk
   - Non-EEA Desk
 - Non-EEA Desk
   - Eea Desk

Simple new schedulers available
 - Hourly: specify by hour when a queue is open or closed for new pax
 - Always open: open 24 hrs a day

All ports configured with the always open scheduler until we've confirmed a solid scheduled of closed EGates