### PR TITLE
Drtii 871 lhr shows outgoing redirected pax for pre red list dates

### DIFF
--- a/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
+++ b/client/src/main/scala/drt/client/components/FlightsWithSplitsTable.scala
@@ -98,7 +98,7 @@ object FlightsWithSplitsTable {
                     .get(SDate(flightWithSplits.apiFlight.Scheduled).toUtcDate)
                     .flatMap(_.get(ArrivalKey(flightWithSplits.apiFlight)))
                   val isRedListOrigin = props.redListPorts.contains(flightWithSplits.apiFlight.Origin)
-                  val directRedListFlight = redlist.DirectRedListFlight(props.portCode, props.terminal, flightWithSplits.apiFlight.Terminal, isRedListOrigin)
+                  val directRedListFlight = redlist.DirectRedListFlight(props.viewMode.dayEnd.millisSinceEpoch, props.portCode, props.terminal, flightWithSplits.apiFlight.Terminal, isRedListOrigin)
                   val redListPaxInfo = redlist.IndirectRedListPax(props.displayRedListInfo, props.portCode, flightWithSplits, maybePassengerInfo)
                   FlightTableRow.component(FlightTableRow.Props(
                     flightWithSplits = flightWithSplits,

--- a/server/src/test/scala/drt/shared/redlist/RedListSpec.scala
+++ b/server/src/test/scala/drt/shared/redlist/RedListSpec.scala
@@ -5,6 +5,8 @@ import org.specs2.mutable.Specification
 import services.SDate
 import services.graphstages.Crunch
 
+import scala.collection.immutable.Map
+
 class RedListSpec extends Specification{
   val date20210807: SDateLike = SDate("2021-08-07T00:00", Crunch.europeLondonTimeZone)
   val date20210808: SDateLike = SDate("2021-08-08T00:00", Crunch.europeLondonTimeZone)
@@ -21,13 +23,73 @@ class RedListSpec extends Specification{
     }
   }
 
-  "Given a date just before the red list changes on 08/08/2021" >> {
-    val redList20210808 = RedList.countryCodesByName(date20210808.millisSinceEpoch)
-    "The red list should not contain India" >> {
-      val expectedToNotExist = redList20210808.keys.toSet.intersect(countriesRemovedFrom20210808)
-      val expectedToExist = redList20210808.keys.toSet.intersect(countriesAddedFrom20210808)
-
-      expectedToNotExist === Set() && expectedToExist == countriesAddedFrom20210808
+  "Given a date of the red list changes on 08/08/2021" >> {
+    val redList = RedList.countryCodesByName(date20210808.millisSinceEpoch)
+    "The red list should give the correct list as defined by redList20210808" >> {
+      redList.keys === redList20210808.keys
     }
   }
+
+  def redList20210808: Map[String, String] = Map(
+    "Afghanistan" -> "AFG",
+    "Angola" -> "AGO",
+    "Argentina" -> "ARG",
+    "Bangladesh" -> "BGD",
+    "Bolivia" -> "BOL",
+    "Botswana" -> "BWA",
+    "Brazil" -> "BRA",
+    "Burundi" -> "BDI",
+    "Cape Verde" -> "CPV",
+    "Chile" -> "CHL",
+    "Colombia" -> "COL",
+    "Costa Rica" -> "CRI",
+    "Cuba" -> "CUB",
+    "Congo (Kinshasa)" -> "COD",
+    "Dominican Republic" -> "DOM",
+    "Ecuador" -> "ECU",
+    "Egypt" -> "EGY",
+    "Eritrea" -> "ERI",
+    "Eswatini" -> "SWZ",
+    "Ethiopia" -> "ETH",
+    "French Guiana" -> "GUF",
+    "Georgia" -> "GEO",
+    "Guyana" -> "GUY",
+    "Haiti" -> "HTI",
+    "Indonesia" -> "IDN",
+    "Kenya" -> "KEN",
+    "Lesotho" -> "LSO",
+    "Malawi" -> "MWI",
+    "Maldives" -> "MDV",
+    "Mayotte" -> "MYT",
+    "Mexico" -> "MEX",
+    "Mongolia" -> "MNG",
+    "Mozambique" -> "MOZ",
+    "Myanmar" -> "MMR",
+    "Namibia" -> "NAM",
+    "Nepal" -> "NPL",
+    "Oman" -> "OMN",
+    "Pakistan" -> "PAK",
+    "Panama" -> "PAN",
+    "Paraguay" -> "PRY",
+    "Peru" -> "PER",
+    "Philippines" -> "PHL",
+    "Reunion" -> "REU",
+    "Rwanda" -> "RWA",
+    "Seychelles" -> "SYC",
+    "Sierra Leone" -> "SLE",
+    "Somalia" -> "SOM",
+    "South Africa" -> "ZAF",
+    "Sri Lanka" -> "LKA",
+    "Sudan" -> "SDN",
+    "Suriname" -> "SUR",
+    "Tanzania" -> "TZA",
+    "Tunisia" -> "TUN",
+    "Turkey" -> "TUR",
+    "Trinidad and Tobago" -> "TTO",
+    "Uganda" -> "UGA",
+    "Uruguay" -> "URY",
+    "Venezuela" -> "VEN",
+    "Zambia" -> "ZMB",
+    "Zimbabwe" -> "ZWE",
+  )
 }

--- a/shared/src/main/scala/drt/shared/redlist/RedList.scala
+++ b/shared/src/main/scala/drt/shared/redlist/RedList.scala
@@ -5,20 +5,18 @@ import drt.shared.Terminals.{T2, T3, T5, Terminal}
 import drt.shared.api.PassengerInfoSummary
 import drt.shared.{ApiFlightWithSplits, Nationality, PortCode}
 
-import scala.collection.immutable.Map
+import scala.collection.immutable.{Map, SortedMap}
+
+case class RedListUpdate(additions: Map[String, String], removals: List[String])
 
 object RedList {
-  val change20210808 = 1628377200000L
-
   def redListOriginWorkloadExcluded(portCode: PortCode, terminal: Terminal): Boolean =
     portCode == PortCode("LHR") && List(T2, T5).contains(terminal)
 
-  def countryCodesByName(date: MillisSinceEpoch): Map[String, String] = {
-    if (date >= change20210808) Map(
-      "Afghanistan" -> "AFG",
+  val redListChanges: SortedMap[MillisSinceEpoch, RedListUpdate] = SortedMap(
+    1613347200000L -> RedListUpdate(Map( //15 feb
       "Angola" -> "AGO",
       "Argentina" -> "ARG",
-      "Bangladesh" -> "BGD",
       "Bolivia" -> "BOL",
       "Botswana" -> "BWA",
       "Brazil" -> "BRA",
@@ -26,118 +24,92 @@ object RedList {
       "Cape Verde" -> "CPV",
       "Chile" -> "CHL",
       "Colombia" -> "COL",
-      "Costa Rica" -> "CRI",
-      "Cuba" -> "CUB",
-      "Democratic Republic of the Congo" -> "COD",
-      "Dominican Republic" -> "DOM",
+      "Congo (Kinshasa)" -> "COD",
       "Ecuador" -> "ECU",
-      "Egypt" -> "EGY",
-      "Eritrea" -> "ERI",
       "Eswatini" -> "SWZ",
-      "Ethiopia" -> "ETH",
       "French Guiana" -> "GUF",
-      "Georgia" -> "GEO",
       "Guyana" -> "GUY",
-      "Haiti" -> "HTI",
-      "Indonesia" -> "IDN",
-      "Kenya" -> "KEN",
       "Lesotho" -> "LSO",
       "Malawi" -> "MWI",
-      "Maldives" -> "MDV",
-      "Mayotte" -> "MYT",
-      "Mexico" -> "MEX",
-      "Mongolia" -> "MNG",
+      "Mauritius" -> "MUS",
       "Mozambique" -> "MOZ",
-      "Myanmar" -> "MMR",
       "Namibia" -> "NAM",
-      "Nepal" -> "NPL",
-      "Oman" -> "OMN",
-      "Pakistan" -> "PAK",
       "Panama" -> "PAN",
       "Paraguay" -> "PRY",
       "Peru" -> "PER",
-      "Philippines" -> "PHL",
-      "Reunion" -> "REU",
+      "Portugal" -> "PRT",
       "Rwanda" -> "RWA",
       "Seychelles" -> "SYC",
-      "Sierra Leone" -> "SLE",
-      "Somalia" -> "SOM",
       "South Africa" -> "ZAF",
-      "Sri Lanka" -> "LKA",
-      "Sudan" -> "SDN",
       "Suriname" -> "SUR",
       "Tanzania" -> "TZA",
-      "Tunisia" -> "TUN",
-      "Turkey" -> "TUR",
-      "Trinidad and Tobago" -> "TTO",
-      "Uganda" -> "UGA",
-      "Uruguay" -> "URY",
-      "Venezuela" -> "VEN",
-      "Zambia" -> "ZMB",
-      "Zimbabwe" -> "ZWE",
-    ) else Map(
-      "Afghanistan" -> "AFG",
-      "Angola" -> "AGO",
-      "Argentina" -> "ARG",
-      "Bahrain" -> "BHR",
-      "Bangladesh" -> "BGD",
-      "Bolivia" -> "BOL",
-      "Botswana" -> "BWA",
-      "Brazil" -> "BRA",
-      "Burundi" -> "BDI",
-      "Cape Verde" -> "CPV",
-      "Chile" -> "CHL",
-      "Colombia" -> "COL",
-      "Costa Rica" -> "CRI",
-      "Cuba" -> "CUB",
-      "Democratic Republic of the Congo" -> "COD",
-      "Dominican Republic" -> "DOM",
-      "Ecuador" -> "ECU",
-      "Egypt" -> "EGY",
-      "Eritrea" -> "ERI",
-      "Eswatini" -> "SWZ",
-      "Ethiopia" -> "ETH",
-      "French Guiana" -> "GUF",
-      "Guyana" -> "GUY",
-      "Haiti" -> "HTI",
-      "India" -> "IND",
-      "Indonesia" -> "IDN",
-      "Kenya" -> "KEN",
-      "Lesotho" -> "LSO",
-      "Malawi" -> "MWI",
-      "Maldives" -> "MDV",
-      "Mongolia" -> "MNG",
-      "Mozambique" -> "MOZ",
-      "Myanmar" -> "MMR",
-      "Namibia" -> "NAM",
-      "Nepal" -> "NPL",
-      "Oman" -> "OMN",
-      "Pakistan" -> "PAK",
-      "Panama" -> "PAN",
-      "Paraguay" -> "PRY",
-      "Peru" -> "PER",
-      "Philippines" -> "PHL",
-      "Qatar" -> "QAT",
-      "Rwanda" -> "RWA",
-      "Seychelles" -> "SYC",
-      "Sierra Leone" -> "SLE",
-      "Somalia" -> "SOM",
-      "South Africa" -> "ZAF",
-      "Sri Lanka" -> "LKA",
-      "Sudan" -> "SDN",
-      "Suriname" -> "SUR",
-      "Tanzania" -> "TZA",
-      "Tunisia" -> "TUN",
-      "Turkey" -> "TUR",
-      "Trinidad and Tobago" -> "TTO",
-      "Uganda" -> "UGA",
       "United Arab Emirates" -> "ARE",
       "Uruguay" -> "URY",
       "Venezuela" -> "VEN",
       "Zambia" -> "ZMB",
       "Zimbabwe" -> "ZWE",
-    )
-  }
+    ), List()),
+    1616112000000L -> RedListUpdate(Map( //19 march
+      "Ethiopia" -> "ETH",
+      "Oman" -> "OMN",
+      "Qatar" -> "QAT",
+      "Somalia" -> "SOM",
+    ), List("Portugal", "Mauritius")),
+    1617922800000L -> RedListUpdate(Map( // 9 april
+      "Philippines" -> "PHL",
+      "Pakistan" -> "PAK",
+      "Kenya" -> "KEN",
+      "Bangladesh" -> "BGD",
+    ), List()),
+    1619132400000L -> RedListUpdate(Map( // 23 april
+      "India" -> "IND"), List()),
+    1620774000000L -> RedListUpdate(Map( // 12 May
+      "Turkey" -> "TUR",
+      "Maldives" -> "MDV",
+      "Nepal" -> "NPL",
+    ), List()),
+    1623106800000L -> RedListUpdate(Map( // 8 June
+      "Afghanistan" -> "AFG",
+      "Bahrain" -> "BHR",
+      "Costa Rica" -> "CRI",
+      "Egypt" -> "EGY",
+      "Sri Lanka" -> "LKA",
+      "Sudan" -> "SDN",
+      "Trinidad and Tobago" -> "TTO",
+    ), List()),
+    1625007600000L -> RedListUpdate(Map( // 30 June
+      "Dominican Republic" -> "DOM",
+      "Eritrea" -> "ERI",
+      "Haiti" -> "HTI",
+      "Mongolia" -> "MNG",
+      "Tunisia" -> "TUN",
+      "Uganda" -> "UGA",
+    ), List()),
+    1626649200000L -> RedListUpdate(Map( // 19 July
+      "Cuba" -> "CUB",
+      "Indonesia" -> "IDN",
+      "Myanmar" -> "MMR",
+      "Sierra Leone" -> "SLE",
+    ), List()),
+    1628377200000L -> RedListUpdate(Map( // 8 Aug
+      "Georgia" -> "GEO",
+      "Mayotte" -> "MYT",
+      "Mexico" -> "MEX",
+      "Reunion" -> "REU",
+    ), List(
+      "Bahrain",
+      "India",
+      "Qatar",
+      "United Arab Emirates",
+    ))
+  )
+
+  def countryCodesByName(date: MillisSinceEpoch): Map[String, String] =
+    redListChanges
+      .filterKeys(changeDate => changeDate <= date)
+      .foldLeft(Map[String, String]()) {
+        case (acc, (date, updates)) => (acc ++ updates.additions) -- updates.removals
+      }
 }
 
 sealed trait DirectRedListFlight {

--- a/shared/src/main/scala/drt/shared/redlist/RedList.scala
+++ b/shared/src/main/scala/drt/shared/redlist/RedList.scala
@@ -132,8 +132,8 @@ case class DefaultDirectRedListFlight(isRedListOrigin: Boolean) extends DirectRe
 }
 
 object DirectRedListFlight {
-  def apply(portCode: PortCode, displayTerminal: Terminal, flightTerminal: Terminal, isRedListOrigin: Boolean): DirectRedListFlight = {
-    if (portCode == PortCode("LHR")) {
+  def apply(date: MillisSinceEpoch, portCode: PortCode, displayTerminal: Terminal, flightTerminal: Terminal, isRedListOrigin: Boolean): DirectRedListFlight = {
+    if (portCode == PortCode("LHR") && date >= LhrRedListDatesImpl.t3RedListOpeningDate) {
       val greenTerminal = List(T2, T3, T5).contains(displayTerminal)
       val terminalDiversion = displayTerminal != flightTerminal
       val outgoingDiversion = isRedListOrigin && greenTerminal


### PR DESCRIPTION
Implement red list change sets
Add historic change sets so we have the actual red list for a given point in time
Only use `LHRDirectRedListFlights` if the flight in question is scheduled since red list terminals opened