### PR TITLE
Drtii 941 improve arrivals export

### DIFF
--- a/server/src/main/scala/services/exports/flights/templates/FlightsWithSplitsExport.scala
+++ b/server/src/main/scala/services/exports/flights/templates/FlightsWithSplitsExport.scala
@@ -3,14 +3,14 @@ package services.exports.flights.templates
 import drt.shared.ApiFlightWithSplits
 import drt.shared.CrunchApi.MillisSinceEpoch
 import passengersplits.parsing.VoyageManifestParser.VoyageManifest
-import uk.gov.homeoffice.drt.ports.{PaxTypeAndQueue, Queues}
 import uk.gov.homeoffice.drt.ports.PaxTypes._
 import uk.gov.homeoffice.drt.ports.Queues._
 import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSource
+import uk.gov.homeoffice.drt.ports.{PaxTypeAndQueue, Queues}
 
 
 trait FlightsWithSplitsExport extends FlightsExport {
-  val arrivalHeadings = "IATA,ICAO,Origin,Gate/Stand,Status,Scheduled Date,Scheduled Time,Est Arrival,Act Arrival,Est Chox,Act Chox,Est PCP,Total Pax"
+  val arrivalHeadings = "IATA,ICAO,Origin,Gate/Stand,Status,Scheduled Date,Scheduled Time,Est Arrival,Act Arrival,Est Chox,Act Chox,Minutes from scheduled,Est PCP,Total Pax"
 
   val actualApiHeadings: Seq[String] = List(
     PaxTypeAndQueue(B5JPlusNational, EeaDesk),
@@ -38,7 +38,8 @@ trait FlightsWithSplitsExport extends FlightsExport {
       headingsForSplitSource(queueNames, "Terminal Average")
 
 
-  def flightWithSplitsToCsvFields(fws: ApiFlightWithSplits, millisToDateOnly: MillisSinceEpoch => String,
+  def flightWithSplitsToCsvFields(fws: ApiFlightWithSplits,
+                                  millisToDateOnly: MillisSinceEpoch => String,
                                   millisToHoursAndMinutes: MillisSinceEpoch => String): List[String] =
     List(fws.apiFlight.flightCodeString,
       fws.apiFlight.flightCodeString,
@@ -51,6 +52,7 @@ trait FlightsWithSplitsExport extends FlightsExport {
       fws.apiFlight.Actual.map(millisToHoursAndMinutes(_)).getOrElse(""),
       fws.apiFlight.EstimatedChox.map(millisToHoursAndMinutes(_)).getOrElse(""),
       fws.apiFlight.ActualChox.map(millisToHoursAndMinutes(_)).getOrElse(""),
+      fws.apiFlight.differenceFromScheduled.map(_.toMinutes.toString).getOrElse(""),
       fws.apiFlight.PcpTime.map(millisToHoursAndMinutes(_)).getOrElse(""),
       fws.totalPax.map(_.toString).getOrElse(""),
     )

--- a/server/src/test/scala/controllers/ArrivalGenerator.scala
+++ b/server/src/test/scala/controllers/ArrivalGenerator.scala
@@ -1,10 +1,9 @@
 package controllers
 
-import uk.gov.homeoffice.drt.ports.Terminals.{T1, Terminal}
-import drt.shared.api.Arrival
 import drt.shared._
-import org.springframework.util.StringUtils
+import drt.shared.api.Arrival
 import services.SDate
+import uk.gov.homeoffice.drt.ports.Terminals.{T1, Terminal}
 import uk.gov.homeoffice.drt.ports.{FeedSource, PortCode}
 
 object ArrivalGenerator {
@@ -41,10 +40,10 @@ object ArrivalGenerator {
       Origin = origin,
       Operator = operator,
       Status = status,
-      Estimated = if (!StringUtils.isEmpty(estDt)) Option(SDate.parseString(estDt).millisSinceEpoch) else None,
-      Actual = if (!StringUtils.isEmpty(actDt)) Option(SDate.parseString(actDt).millisSinceEpoch) else None,
-      EstimatedChox = if (!StringUtils.isEmpty(estChoxDt)) Option(SDate.parseString(estChoxDt).millisSinceEpoch) else None,
-      ActualChox = if (!StringUtils.isEmpty(actChoxDt)) Option(SDate.parseString(actChoxDt).millisSinceEpoch) else None,
+      Estimated = if (estDt.nonEmpty) Option(SDate.parseString(estDt).millisSinceEpoch) else None,
+      Actual = if (actDt.nonEmpty) Option(SDate.parseString(actDt).millisSinceEpoch) else None,
+      EstimatedChox = if (estChoxDt.nonEmpty) Option(SDate.parseString(estChoxDt).millisSinceEpoch) else None,
+      ActualChox = if (actChoxDt.nonEmpty) Option(SDate.parseString(actChoxDt).millisSinceEpoch) else None,
       Gate = gate,
       Stand = stand,
       MaxPax = maxPax,
@@ -53,7 +52,7 @@ object ArrivalGenerator {
       BaggageReclaimId = baggageReclaimId,
       AirportID = airportId,
       PcpTime = pcpTime,
-      Scheduled = if (!StringUtils.isEmpty(schDt)) SDate(schDt).millisSinceEpoch else 0,
+      Scheduled = if (schDt.nonEmpty) SDate(schDt).millisSinceEpoch else 0,
       FeedSources = feedSources,
       ApiPax = apiPax
     )

--- a/server/src/test/scala/services/ArrivalSpec.scala
+++ b/server/src/test/scala/services/ArrivalSpec.scala
@@ -5,6 +5,8 @@ import drt.shared.ArrivalStatus
 import drt.shared.api.Arrival
 import org.specs2.mutable.Specification
 
+import scala.concurrent.duration.DurationInt
+
 class ArrivalSpec extends Specification {
   "Given an arrival with negative passengers" >> {
     "When I ask for the minimum value of the pcp range" >> {
@@ -257,6 +259,11 @@ class ArrivalSpec extends Specification {
     "Arrivals should not be considered equal if the only difference is their PCP time" >> {
       val arrivalWithDifferentPcp = arrivalWithPcp.copy(PcpTime = arrivalWithPcp.PcpTime.map(_ + 60000))
       arrivalWithDifferentPcp.isEqualTo(arrivalWithPcp) === false
+    }
+  }
+  "Difference from scheduled time" >> {
+    "Given an arrival scheduled at 12:00, and landing at 12:10 I expect the difference to be 10 minutes" >> {
+      ArrivalGenerator.arrival(schDt = "2021-08-08T12:00", actDt = "2021-08-08T12:10").differenceFromScheduled === Option(10.minutes)
     }
   }
 }

--- a/server/src/test/scala/services/ArrivalSpec.scala
+++ b/server/src/test/scala/services/ArrivalSpec.scala
@@ -265,5 +265,8 @@ class ArrivalSpec extends Specification {
     "Given an arrival scheduled at 12:00, and landing at 12:10 I expect the difference to be 10 minutes" >> {
       ArrivalGenerator.arrival(schDt = "2021-08-08T12:00", actDt = "2021-08-08T12:10").differenceFromScheduled === Option(10.minutes)
     }
+    "Given an arrival scheduled at 12:00, and landing at 11:50 I expect the difference to be -10 minutes" >> {
+      ArrivalGenerator.arrival(schDt = "2021-08-08T12:00", actDt = "2021-08-08T11:50").differenceFromScheduled === Option(-10.minutes)
+    }
   }
 }

--- a/server/src/test/scala/services/ArrivalSpec.scala
+++ b/server/src/test/scala/services/ArrivalSpec.scala
@@ -268,5 +268,8 @@ class ArrivalSpec extends Specification {
     "Given an arrival scheduled at 12:00, and landing at 11:50 I expect the difference to be -10 minutes" >> {
       ArrivalGenerator.arrival(schDt = "2021-08-08T12:00", actDt = "2021-08-08T11:50").differenceFromScheduled === Option(-10.minutes)
     }
+    "Given an arrival scheduled at 12:00 but no landing time I expect None for the differenceFromScheduled" >> {
+      ArrivalGenerator.arrival(schDt = "2021-08-08T12:00").differenceFromScheduled === None
+    }
   }
 }

--- a/shared/src/main/scala/drt/shared/api/Arrival.scala
+++ b/shared/src/main/scala/drt/shared/api/Arrival.scala
@@ -8,6 +8,7 @@ import uk.gov.homeoffice.drt.ports.{FeedSource, PortCode}
 import upickle.default.{ReadWriter, macroRW}
 
 import scala.collection.immutable.{List, NumericRange}
+import scala.concurrent.duration.{DurationLong, FiniteDuration}
 import scala.util.matching.Regex
 
 case class FlightCodeSuffix(suffix: String)
@@ -39,6 +40,8 @@ case class Arrival(Operator: Option[Operator],
                    ScheduledDeparture: Option[MillisSinceEpoch],
                    RedListPax: Option[Int],
                   ) extends WithUnique[UniqueArrival] {
+  lazy val differenceFromScheduled: Option[FiniteDuration] = Actual.map(a => (a - Scheduled).milliseconds)
+
   val paxOffPerMinute = 20
 
   def suffixString: String = FlightCodeSuffix match {


### PR DESCRIPTION
Add `Difference from scheduled` column to the non-cedat arrivals exports, giving the minutes difference between the landing time and the scheduled time