### PR TITLE
DRTII-958 Keep live API when adding historic

### DIFF
--- a/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeskRecs.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeskRecs.scala
@@ -179,7 +179,7 @@ object DynamicRunnableDeskRecs {
           )
         }
 
-        ApiFlightWithSplits(arrival, maybeSplits.toSet)
+        ApiFlightWithSplits(arrival, flight.splits ++ maybeSplits.toSet)
       }
     }
 }


### PR DESCRIPTION
- When live does not meet threshold test, we should add historic rather than replace so that we can still report the live API data we got