### PR TITLE
DRTII-982 Send manifestfeedsuccess on no new data

### DIFF
--- a/server/src/main/scala/drt/server/feeds/api/ApiFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/api/ApiFeed.scala
@@ -31,7 +31,10 @@ case class ApiFeedImpl(arrivalKeyProvider: ManifestArrivalKeys,
         }
       }
       .throttle(1, throttle)
-      .map { case (_, keys) => keys }
+      .map { case (marker, keys) =>
+        if (keys.isEmpty) manifestProcessor.reportNoNewData(marker)
+        keys
+      }
       .mapConcat(identity)
       .mapAsync(1) {
         case (uniqueArrivalKey, processedAt) =>

--- a/server/src/test/scala/drt/server/feeds/api/ApiFeedImplTest.scala
+++ b/server/src/test/scala/drt/server/feeds/api/ApiFeedImplTest.scala
@@ -27,10 +27,14 @@ case class MockManifestArrivalKeys(keysWithProcessedAts: List[Iterable[(UniqueAr
 }
 
 case class MockManifestProcessor(probe: ActorRef) extends ManifestProcessor {
+  override def reportNoNewData(processedAt: MillisSinceEpoch): Future[Done] =
+    Future.successful(Done)
+
   override def process(uniqueArrivalKey: UniqueArrivalKey, processedAt: MillisSinceEpoch): Future[Done] = {
     probe ! (uniqueArrivalKey, processedAt)
     Future.successful(Done)
   }
+
 }
 
 class ApiFeedImplTest extends CrunchTestLike {


### PR DESCRIPTION
Send an empty `ManifestFeedSuccess` when there are no new manifests to process