### PR TITLE
DRTII-983 Implement clock change aware crunch summaries

### DIFF
--- a/server/src/main/scala/controllers/Application.scala
+++ b/server/src/main/scala/controllers/Application.scala
@@ -200,7 +200,8 @@ class Application @Inject()(implicit val config: Configuration, env: Environment
 
       def forecastWeekSummary(startDay: MillisSinceEpoch,
                               terminal: Terminal): Future[Option[ForecastPeriodWithHeadlines]] = {
-        val (startOfForecast, endOfForecast) = startAndEndForDay(startDay, 7)
+        val numberOfDays = 7
+        val (startOfForecast, endOfForecast) = startAndEndForDay(startDay, numberOfDays)
 
         val portStateFuture = portStateActor.ask(
           GetStateForTerminalDateRange(startOfForecast.millisSinceEpoch, endOfForecast.millisSinceEpoch, terminal)
@@ -211,7 +212,7 @@ class Application @Inject()(implicit val config: Configuration, env: Environment
             case portState: PortState =>
               log.info(s"Sent forecast for week beginning ${SDate(startDay).toISOString()} on $terminal")
               val fp = services.exports.Forecast.forecastPeriod(airportConfig, terminal, startOfForecast, endOfForecast, portState)
-              val hf = services.exports.Forecast.headlineFigures(startOfForecast, endOfForecast, terminal, portState, airportConfig.queuesByTerminal(terminal).toList)
+              val hf = services.exports.Forecast.headlineFigures(startOfForecast, numberOfDays, terminal, portState, airportConfig.queuesByTerminal(terminal).toList)
               Option(ForecastPeriodWithHeadlines(fp, hf))
           }
           .recover {

--- a/server/src/main/scala/services/exports/Forecast.scala
+++ b/server/src/main/scala/services/exports/Forecast.scala
@@ -10,13 +10,12 @@ import uk.gov.homeoffice.drt.time.SDateLike
 
 object Forecast {
   def headlineFigures(startOfForecast: SDateLike,
-                      endOfForecast: SDateLike,
+                      numberOfDays: Int,
                       terminal: Terminal,
                       portState: PortState,
                       queues: List[Queue]): ForecastHeadlineFigures = {
     val dayMillis = 60 * 60 * 24 * 1000
-    val periods = (endOfForecast.millisSinceEpoch - startOfForecast.millisSinceEpoch) / dayMillis
-    val crunchSummaryDaily = portState.crunchSummary(startOfForecast, periods, 1440, terminal, queues)
+    val crunchSummaryDaily = portState.dailyCrunchSummary(startOfForecast, numberOfDays, terminal, queues)
 
     val figures = for {
       (dayMillis, queueMinutes) <- crunchSummaryDaily

--- a/server/src/test/scala/services/ForecastHeadlineFiguresSpec.scala
+++ b/server/src/test/scala/services/ForecastHeadlineFiguresSpec.scala
@@ -16,7 +16,7 @@ class ForecastHeadlineFiguresSpec extends Specification {
       "Then I should see Total Pax of 1 and EEA Pax of 1 and total workload of 2 on 2017-01-02" >> {
       val startMinute = SDate("2017-01-02T00:00Z")
       val ps = PortState(List(), List(CrunchMinute(T1, Queues.EeaDesk, startMinute.millisSinceEpoch, 1, 2, 0, 0)), List())
-      val result = Forecast.headlineFigures(startMinute, startMinute.addDays(1), T1, ps, List(Queues.EeaDesk))
+      val result = Forecast.headlineFigures(startMinute, 1, T1, ps, List(Queues.EeaDesk))
 
       val expected = ForecastHeadlineFigures(Seq(QueueHeadline(startMinute.millisSinceEpoch, Queues.EeaDesk, 1, 2)))
       result === expected
@@ -32,7 +32,7 @@ class ForecastHeadlineFiguresSpec extends Specification {
         CrunchMinute(T2, Queues.EeaDesk, startMinute.millisSinceEpoch, 1, 2, 0, 0)
       ), List())
 
-      val result = Forecast.headlineFigures(startMinute, startMinute.addDays(1), T1, ps, List(Queues.EeaDesk))
+      val result = Forecast.headlineFigures(startMinute, 1, T1, ps, List(Queues.EeaDesk))
       val expected = ForecastHeadlineFigures(Seq(QueueHeadline(startMinute.millisSinceEpoch, Queues.EeaDesk, 1, 2)))
 
       result === expected
@@ -47,7 +47,7 @@ class ForecastHeadlineFiguresSpec extends Specification {
         CrunchMinute(T1, Queues.EeaDesk, startMinute.millisSinceEpoch, 1, 2, 0, 0),
         CrunchMinute(T1, Queues.EGate, startMinute.millisSinceEpoch, 1, 2, 0, 0)
       ), List())
-      val result = Forecast.headlineFigures(startMinute, startMinute.addDays(1), T1, ps, List(Queues.EeaDesk, Queues.EGate))
+      val result = Forecast.headlineFigures(startMinute, 1, T1, ps, List(Queues.EeaDesk, Queues.EGate))
 
       val expected = ForecastHeadlineFigures(Seq(
         QueueHeadline(startMinute.millisSinceEpoch, Queues.EeaDesk, 1, 2),
@@ -70,7 +70,7 @@ class ForecastHeadlineFiguresSpec extends Specification {
         CrunchMinute(T1, Queues.EeaDesk, day2StartMinute.millisSinceEpoch, 1, 2, 0, 0),
         CrunchMinute(T1, Queues.EGate, day2StartMinute.millisSinceEpoch, 1, 2, 0, 0)
       ), List())
-      val result = Forecast.headlineFigures(day1StartMinute, day2StartMinute.addDays(1), T1, ps, List(Queues.EeaDesk, Queues.EGate))
+      val result = Forecast.headlineFigures(day1StartMinute, 2, T1, ps, List(Queues.EeaDesk, Queues.EGate))
 
       val expected = ForecastHeadlineFigures(Seq(
         QueueHeadline(day1StartMinute.millisSinceEpoch, Queues.EeaDesk, 1, 2),

--- a/server/src/test/scala/services/crunch/PortStateSummariesSpec.scala
+++ b/server/src/test/scala/services/crunch/PortStateSummariesSpec.scala
@@ -4,10 +4,12 @@ import drt.shared.CrunchApi.{CrunchMinute, MillisSinceEpoch, StaffMinute}
 import drt.shared._
 import org.specs2.mutable.Specification
 import services.SDate
+import services.graphstages.Crunch
 import uk.gov.homeoffice.drt.arrivals.{ApiFlightWithSplits, UniqueArrival}
 import uk.gov.homeoffice.drt.ports.Queues
-import uk.gov.homeoffice.drt.ports.Queues.Queue
+import uk.gov.homeoffice.drt.ports.Queues.{EeaDesk, Queue}
 import uk.gov.homeoffice.drt.ports.Terminals.T1
+import uk.gov.homeoffice.drt.time.LocalDate
 
 import scala.collection.immutable.SortedMap
 
@@ -102,5 +104,41 @@ class PortStateSummariesSpec extends Specification {
     )
 
     summary === expected
+  }
+
+  "PortState " should {
+    "correctly calculate UTC time days when creating a summary spanning a clock change" in {
+      val summaries = PortState.empty.dailyCrunchSummary(SDate("2022-03-27", Crunch.utcTimeZone), 7, T1, List(EeaDesk))
+      val days = summaries.keys.toList.sorted.map(SDate(_))
+
+      val expected = List(
+        SDate(2022, 3, 27, 0, 0, Crunch.utcTimeZone),
+        SDate(2022, 3, 28, 0, 0, Crunch.utcTimeZone),
+        SDate(2022, 3, 29, 0, 0, Crunch.utcTimeZone),
+        SDate(2022, 3, 30, 0, 0, Crunch.utcTimeZone),
+        SDate(2022, 3, 31, 0, 0, Crunch.utcTimeZone),
+        SDate(2022, 4, 1, 0, 0, Crunch.utcTimeZone),
+        SDate(2022, 4, 2, 0, 0, Crunch.utcTimeZone),
+      )
+
+      days === expected
+    }
+
+    "correctly calculate local time days when creating a summary spanning a clock change" in {
+      val summaries = PortState.empty.dailyCrunchSummary(SDate("2022-03-27", Crunch.europeLondonTimeZone), 7, T1, List(EeaDesk))
+      val days = summaries.keys.toList.sorted.map(SDate(_))
+
+      val expected = List(
+        SDate(2022, 3, 27, 0, 0, Crunch.utcTimeZone),
+        SDate(2022, 3, 27, 23, 0, Crunch.utcTimeZone),
+        SDate(2022, 3, 28, 23, 0, Crunch.utcTimeZone),
+        SDate(2022, 3, 29, 23, 0, Crunch.utcTimeZone),
+        SDate(2022, 3, 30, 23, 0, Crunch.utcTimeZone),
+        SDate(2022, 3, 31, 23, 0, Crunch.utcTimeZone),
+        SDate(2022, 4, 1, 23, 0, Crunch.utcTimeZone),
+      )
+
+      days === expected
+    }
   }
 }


### PR DESCRIPTION
Don't assume days are 1440 minutes
Lean on `addDay` to correctly calculate days across clock changes