### PR TITLE
Drtii 797 refactor total pax

### DIFF
--- a/client/src/main/scala/drt/client/components/BigSummaryBoxes.scala
+++ b/client/src/main/scala/drt/client/components/BigSummaryBoxes.scala
@@ -60,7 +60,7 @@ object BigSummaryBoxes {
         splits.find { case Splits(_, _, _, t) => t == Percentage } match {
           case None => Set()
           case Some(apiSplits) => apiSplits.splits.map {
-            s => (PaxTypeAndQueue(s.passengerType, s.queueType), s.paxCount / 100 * fws.pcpPaxEstimate.pax)
+            s => (PaxTypeAndQueue(s.passengerType, s.queueType), s.paxCount / 100 * fws.pcpPaxEstimate.pax.getOrElse(0))
           }
         }
       }

--- a/client/src/main/scala/drt/client/components/FlightComponents.scala
+++ b/client/src/main/scala/drt/client/components/FlightComponents.scala
@@ -9,18 +9,17 @@ import japgolly.scalajs.react.vdom.{TagOf, VdomArray}
 import org.scalajs.dom.html.{Div, Span}
 import uk.gov.homeoffice.drt.arrivals.{ApiFlightWithSplits, Arrival, TotalPaxSource}
 import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources
-import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.{ApiSplitsWithHistoricalEGateAndFTPercentages, Historical}
 import uk.gov.homeoffice.drt.ports._
 
 
 object FlightComponents {
-  def paxFeedSourceClass(paxSource: TotalPaxSource): String = (paxSource.feedSource, paxSource.splitSource) match {
-    case (ApiFeedSource, Some(ApiSplitsWithHistoricalEGateAndFTPercentages)) => "pax-rag-green"
-    case (LiveFeedSource, _) => "pax-rag-green"
-    case (ApiFeedSource, Some(Historical)) => "pax-rag-amber"
-    case (ForecastFeedSource, _) => "pax-rag-amber"
-    case (ApiFeedSource, _) => "pax-rag-red"
-    case (AclFeedSource, _) => "pax-rag-red"
+  def paxFeedSourceClass(paxSource: TotalPaxSource): String = (paxSource.feedSource) match {
+    case (ApiFeedSource) => "pax-rag-green"
+    case (LiveFeedSource) => "pax-rag-green"
+    case (HistoricApiFeedSource) => "pax-rag-amber"
+    case (ForecastFeedSource) => "pax-rag-amber"
+    case (ApiFeedSource) => "pax-rag-red"
+    case (AclFeedSource) => "pax-rag-red"
     case _ => "pax-rag-red"
   }
 

--- a/client/src/main/scala/drt/client/components/FlightComponents.scala
+++ b/client/src/main/scala/drt/client/components/FlightComponents.scala
@@ -18,7 +18,6 @@ object FlightComponents {
     case (LiveFeedSource) => "pax-rag-green"
     case (HistoricApiFeedSource) => "pax-rag-amber"
     case (ForecastFeedSource) => "pax-rag-amber"
-    case (ApiFeedSource) => "pax-rag-red"
     case (AclFeedSource) => "pax-rag-red"
     case _ => "pax-rag-red"
   }
@@ -32,10 +31,11 @@ object FlightComponents {
       else if (directRedListFlight.outgoingDiversion) "arrivals__table__flight__pcp-pax__outgoing"
       else ""
 
+    val pcpPaxNumber = flightWithSplits.pcpPaxEstimate.pax.map(_.toString).getOrElse("n/a")
+
     <.div(
       ^.className := s"right arrivals__table__flight__pcp-pax $diversionClass $isNotApiData",
-
-      <.span(Tippy.describe(paxNumberSources(flightWithSplits), <.span(^.className := s"$noPcpPaxClass", flightWithSplits.pcpPaxEstimate.pax))),
+      <.span(Tippy.describe(paxNumberSources(flightWithSplits), <.span(^.className := s"$noPcpPaxClass", pcpPaxNumber))),
       if (directRedListFlight.paxDiversion) {
         val incomingTip =
           if (directRedListFlight.incomingDiversion) s"Passengers diverted from ${flightWithSplits.apiFlight.Terminal}"
@@ -61,8 +61,9 @@ object FlightComponents {
 
     val paxNos = List(
       <.p(s"Pax: $portDirectPax (${flight.apiFlight.ActPax.getOrElse(0)} - ${flight.apiFlight.TranPax.getOrElse(0)} transfer)"),
-      <.p(s"Max: $max")
-    ) :+ flight.totalPaxFromApiExcludingTransfer.map(p => <.span(s"API: ${p.pax}")).getOrElse(EmptyVdom)
+      <.p(s"Max: $max"),
+      flight.totalPaxFromApiExcludingTransfer.map(p => <.p(s"API: ${p.pax}")).getOrElse(EmptyVdom),
+    )
     <.span(paxNos.toVdomArray)
   }
 

--- a/client/src/main/scala/drt/client/components/FlightTableComponents.scala
+++ b/client/src/main/scala/drt/client/components/FlightTableComponents.scala
@@ -32,7 +32,7 @@ object FlightTableComponents {
   def pcpTimeRange(fws: ApiFlightWithSplits): TagOf[Div] =
     fws.apiFlight.PcpTime.map { pcpTime: MillisSinceEpoch =>
       val sdateFrom = SDate(MilliDate(pcpTime))
-      val sdateTo = SDate(MilliDate(pcpTime + millisToDisembark(fws.pcpPaxEstimate.pax)))
+      val sdateTo = SDate(MilliDate(pcpTime + millisToDisembark(fws.pcpPaxEstimate.pax.getOrElse(0))))
       <.div(^.display := "flex", ^.flexWrap := "nowrap",
         sdateLocalTimePopup(sdateFrom),
         " \u2192 ",

--- a/client/src/test/scala/drt/client/components/BigSummaryBoxTests.scala
+++ b/client/src/test/scala/drt/client/components/BigSummaryBoxTests.scala
@@ -164,13 +164,13 @@ object BigSummaryBoxTests extends TestSuite {
             "Then we can aggregate the splits by multiply the % against the bestPax so that we can show them in a graph" - {
               val flights = List(
                 ApiFlightWithSplits(apiFlight(schDt = "2017-05-01T12:05Z", terminal = terminal1, actPax = Option(100), pcpTime = Option(mkMillis("2017-05-01T12:05Z")),
-                  totalPax = Set(TotalPaxSource(100, LiveFeedSource, None))),
+                  totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource))),
                   Set(Splits(Set(
                     ApiPaxTypeAndQueueCount(PaxTypes.NonVisaNational, Queues.NonEeaDesk, 30, None, None),
                     ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, Queues.EeaDesk, 70, None, None)),
                     SplitSources.Historical, None, Percentage))),
                 ApiFlightWithSplits(apiFlight(schDt = "2017-05-01T13:05Z", terminal = terminal1, actPax = Option(100), pcpTime = Option(mkMillis("2017-05-01T13:15Z")),
-                  totalPax = Set(TotalPaxSource(100, LiveFeedSource, None))),
+                  totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource))),
                   Set(Splits(Set(
                     ApiPaxTypeAndQueueCount(PaxTypes.NonVisaNational, Queues.NonEeaDesk, 40, None, None),
                     ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, Queues.EeaDesk, 60, None, None)),

--- a/client/src/test/scala/drt/client/components/PaxSplitsDisplayTests.scala
+++ b/client/src/test/scala/drt/client/components/PaxSplitsDisplayTests.scala
@@ -216,7 +216,7 @@ object PaxSplitsDisplayTests extends TestSuite {
       }
 
       "Given a flight with percentage splits, when I ask for pax per queue I should see the total pax broken down per queue" - {
-        val flight = ArrivalGenerator.apiFlight(actPax = Option(152), totalPax = Set(TotalPaxSource(152, LiveFeedSource, None)))
+        val flight = ArrivalGenerator.apiFlight(actPax = Option(152), totalPax = Set(TotalPaxSource(Option(152), LiveFeedSource)))
         val splits = Splits(
           Set(
             ApiPaxTypeAndQueueCount(PaxTypes.NonVisaNational, Queues.NonEeaDesk, 11.399999999999999, None, None),
@@ -240,7 +240,7 @@ object PaxSplitsDisplayTests extends TestSuite {
       }
 
       "Given a flight with PaxNumbers splits when I ask for pax per queue I should see the total broken down per queue" - {
-        val flight = ArrivalGenerator.apiFlight(actPax = Option(100), totalPax = Set(TotalPaxSource(100, LiveFeedSource, None)))
+        val flight = ArrivalGenerator.apiFlight(actPax = Option(100), totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource)))
         val splits = Splits(Set(
           ApiPaxTypeAndQueueCount(PaxTypes.NonVisaNational, Queues.NonEeaDesk, 15, None, None),
           ApiPaxTypeAndQueueCount(PaxTypes.NonVisaNational, Queues.FastTrack, 5, None, None)),

--- a/e2e/tests/integration/arrivals-page.ts
+++ b/e2e/tests/integration/arrivals-page.ts
@@ -152,7 +152,7 @@ describe('Arrivals page', () => {
       .asABorderForceOfficer()
       .waitForFlightToAppear("TS0123")
       .get(totalPaxSelector)
-      .contains("0")
+      .contains("n/a")
       .addManifest(manifest(
         [
           ukPassport,
@@ -192,7 +192,7 @@ describe('Arrivals page', () => {
       .asABorderForceOfficer()
       .waitForFlightToAppear("TS0123")
       .get(totalPaxSelector)
-      .contains("0")
+      .contains("n/a")
       .addManifest(manifest(
         [
           ukPassportWithIdentifier("id1"),
@@ -215,7 +215,7 @@ describe('Arrivals page', () => {
       .asABorderForceOfficer()
       .waitForFlightToAppear("TS0123")
       .get(totalPaxSelector)
-      .contains("0")
+      .contains("n/a")
       .addManifest(manifest(
         [
           ukPassport,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -70,7 +70,7 @@ object Settings {
     val openSaml = "2.6.1"
     val drtBirminghamSchema = "1.2.0"
     val drtCirium = "186"
-    val drtLib = "v220"
+    val drtLib = "v227"
     val playJson = "2.6.0"
     val playIteratees = "2.6.1"
     val uPickle = "1.2.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -70,7 +70,7 @@ object Settings {
     val openSaml = "2.6.1"
     val drtBirminghamSchema = "1.2.0"
     val drtCirium = "186"
-    val drtLib = "v227"
+    val drtLib = "v232"
     val playJson = "2.6.0"
     val playIteratees = "2.6.1"
     val uPickle = "1.2.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -70,7 +70,7 @@ object Settings {
     val openSaml = "2.6.1"
     val drtBirminghamSchema = "1.2.0"
     val drtCirium = "186"
-    val drtLib = "v232"
+    val drtLib = "v233"
     val playJson = "2.6.0"
     val playIteratees = "2.6.1"
     val uPickle = "1.2.0"

--- a/server/src/main/scala/actors/persistent/arrivals/AclForecastArrivalsActor.scala
+++ b/server/src/main/scala/actors/persistent/arrivals/AclForecastArrivalsActor.scala
@@ -33,7 +33,7 @@ class AclForecastArrivalsActor(initialSnapshotBytesThreshold: Int,
   override def handleFeedSuccess(incomingArrivals: Iterable[Arrival], createdAt: SDateLike): Unit = {
     log.info(s"Received arrivals (base)")
     val incomingArrivalsWithKeys = incomingArrivals.map(a => (a.unique,
-      a.copy(TotalPax = a.TotalPax ++ Set(TotalPaxSource(a.ActPax.getOrElse(0), AclFeedSource, None))))).toMap
+      a.copy(TotalPax = a.TotalPax ++ Set(TotalPaxSource(a.ActPax, AclFeedSource))))).toMap
     val (removals, updates) = Crunch.baseArrivalsRemovalsAndUpdates(incomingArrivalsWithKeys, state.arrivals)
     val newStatus = FeedStatusSuccess(createdAt.millisSinceEpoch, updates.size)
 

--- a/server/src/main/scala/actors/serializers/FlightMessageConversion.scala
+++ b/server/src/main/scala/actors/serializers/FlightMessageConversion.scala
@@ -152,11 +152,11 @@ object FlightMessageConversion {
     )
   }
 
-  def convertTotalPaxToMessage(totalPax: Set[TotalPaxSource]): Seq[FlightsMessage.TotalPaxSource] =
+  def convertTotalPaxToMessage(totalPax: Set[TotalPaxSource]): Seq[FlightsMessage.TotalPaxSourceMessage] =
     totalPax
       .map(tp =>
         uk.gov.homeoffice.drt.protobuf.messages.FlightsMessage
-          .TotalPaxSource(
+          .TotalPaxSourceMessage(
             pax = tp.pax,
             feedSource = Option(tp.feedSource.name))).toSeq
 

--- a/server/src/main/scala/actors/serializers/FlightMessageConversion.scala
+++ b/server/src/main/scala/actors/serializers/FlightMessageConversion.scala
@@ -157,9 +157,8 @@ object FlightMessageConversion {
       .map(tp =>
         uk.gov.homeoffice.drt.protobuf.messages.FlightsMessage
           .TotalPaxSource(
-            pax = Option(tp.pax),
-            feedSource = Option(tp.feedSource.name),
-            splitSource = tp.splitSource.map(_.toString))).toSeq
+            pax = tp.pax,
+            feedSource = Option(tp.feedSource.name))).toSeq
 
   def predictionToMessage(maybePred: Option[Prediction[Long]]): Option[PredictionLongMessage] =
     maybePred.map(pred => PredictionLongMessage(Option(pred.updatedAt), Option(pred.value)))
@@ -198,9 +197,8 @@ object FlightMessageConversion {
     ApiPax = flightMessage.apiPax,
     RedListPax = flightMessage.redListPax,
     ScheduledDeparture = flightMessage.scheduledDeparture,
-    TotalPax = Set(flightMessage.totalPax.map(a => uk.gov.homeoffice.drt.arrivals.TotalPaxSource(a.pax.getOrElse(0),
-      a.feedSource.flatMap(FeedSource.findByName).getOrElse(UnknownFeedSource),
-      a.splitSource.map(SplitSource(_)))): _*)
+    TotalPax = Set(flightMessage.totalPax.map(a => uk.gov.homeoffice.drt.arrivals.TotalPaxSource(a.pax,
+      a.feedSource.flatMap(FeedSource.findByName).getOrElse(UnknownFeedSource))): _*)
 
   )
 

--- a/server/src/main/scala/actors/serializers/FlightMessageConversion.scala
+++ b/server/src/main/scala/actors/serializers/FlightMessageConversion.scala
@@ -5,15 +5,14 @@ import actors.serializers.PortStateMessageConversion.splitMessageToApiSplits
 import drt.shared.FlightsApi.FlightsWithSplitsDiff
 import drt.shared._
 import org.slf4j.{Logger, LoggerFactory}
-import uk.gov.homeoffice.drt.protobuf.messages.CrunchState._
-import uk.gov.homeoffice.drt.protobuf.messages.FlightsMessage._
-import uk.gov.homeoffice.drt.protobuf.messages.Prediction.PredictionLongMessage
 import services.SDate
-import uk.gov.homeoffice.drt.arrivals.{TotalPaxSource, _}
-import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSource
+import uk.gov.homeoffice.drt.arrivals._
 import uk.gov.homeoffice.drt.ports.Terminals.Terminal
 import uk.gov.homeoffice.drt.ports.{ApiPaxTypeAndQueueCount, FeedSource, PortCode, UnknownFeedSource}
+import uk.gov.homeoffice.drt.protobuf.messages.CrunchState._
 import uk.gov.homeoffice.drt.protobuf.messages.FlightsMessage
+import uk.gov.homeoffice.drt.protobuf.messages.FlightsMessage._
+import uk.gov.homeoffice.drt.protobuf.messages.Prediction.PredictionLongMessage
 
 object FlightMessageConversion {
   val log: Logger = LoggerFactory.getLogger(getClass.toString)
@@ -152,13 +151,10 @@ object FlightMessageConversion {
     )
   }
 
-  def convertTotalPaxToMessage(totalPax: Set[TotalPaxSource]): Seq[FlightsMessage.TotalPaxSourceMessage] =
-    totalPax
-      .map(tp =>
-        uk.gov.homeoffice.drt.protobuf.messages.FlightsMessage
-          .TotalPaxSourceMessage(
-            pax = tp.pax,
-            feedSource = Option(tp.feedSource.name))).toSeq
+  def convertTotalPaxToMessage(totalPax: Set[TotalPaxSource]): Seq[TotalPaxSourceMessage] =
+    totalPax.map(tp =>
+      TotalPaxSourceMessage(pax = tp.pax, feedSource = Option(tp.feedSource.name))
+    ).toSeq
 
   def predictionToMessage(maybePred: Option[Prediction[Long]]): Option[PredictionLongMessage] =
     maybePred.map(pred => PredictionLongMessage(Option(pred.updatedAt), Option(pred.value)))
@@ -197,10 +193,13 @@ object FlightMessageConversion {
     ApiPax = flightMessage.apiPax,
     RedListPax = flightMessage.redListPax,
     ScheduledDeparture = flightMessage.scheduledDeparture,
-    TotalPax = Set(flightMessage.totalPax.map(a => uk.gov.homeoffice.drt.arrivals.TotalPaxSource(a.pax,
-      a.feedSource.flatMap(FeedSource.findByName).getOrElse(UnknownFeedSource))): _*)
-
+    TotalPax = flightMessage.totalPax.map(totalPaxSourceFromMessage).toSet
   )
+
+  def totalPaxSourceFromMessage(message: TotalPaxSourceMessage): TotalPaxSource = {
+    val feedSource = message.feedSource.flatMap(FeedSource.findByName).getOrElse(UnknownFeedSource)
+    TotalPaxSource(message.pax, feedSource)
+  }
 
   def flightsToMessage(flights: Iterable[ApiFlightWithSplits]): FlightsWithSplitsMessage =
     FlightsWithSplitsMessage(flights.map(FlightMessageConversion.flightWithSplitsToMessage).toSeq)

--- a/server/src/main/scala/drt/server/feeds/lgw/ResponseToArrivals.scala
+++ b/server/src/main/scala/drt/server/feeds/lgw/ResponseToArrivals.scala
@@ -61,7 +61,7 @@ case class ResponseToArrivals(data: String) {
       ApiPax = None,
       ScheduledDeparture = None,
       RedListPax = None,
-      TotalPax = Set(TotalPaxSource(actPax.getOrElse(0), LiveFeedSource, None)),
+      TotalPax = Set(TotalPaxSource(actPax, LiveFeedSource)),
     )
     log.debug(s"parsed arrival: $arrival")
     arrival

--- a/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeskRecs.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeskRecs.scala
@@ -20,10 +20,10 @@ import services.crunch.desklimits.TerminalDeskLimitsLike
 import services.crunch.deskrecs.RunnableOptimisation.CrunchRequest
 import services.graphstages.Crunch
 import uk.gov.homeoffice.drt.arrivals.{ApiFlightWithSplits, Arrival, TotalPaxSource}
-import uk.gov.homeoffice.drt.ports.{ApiFeedSource, HistoricApiFeedSource}
 import uk.gov.homeoffice.drt.ports.Queues.{Closed, Queue, QueueStatus}
-import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.{ApiSplitsWithHistoricalEGateAndFTPercentages, Historical}
+import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages
 import uk.gov.homeoffice.drt.ports.Terminals.Terminal
+import uk.gov.homeoffice.drt.ports.{ApiFeedSource, HistoricApiFeedSource}
 import uk.gov.homeoffice.drt.redlist.RedListUpdates
 
 import scala.collection.immutable.{Map, NumericRange}
@@ -100,10 +100,10 @@ object DynamicRunnableDeskRecs {
         case (crunchRequest, flights) =>
           val historicApiPax = flights
             .map { fws =>
-              val histApiPax = fws.apiFlight.TotalPax.filter { tp => tp.feedSource == ApiFeedSource && tp.splitSource == Option(ApiSplitsWithHistoricalEGateAndFTPercentages) }
+              val histApiPax = fws.apiFlight.TotalPax.filter(_.feedSource == ApiFeedSource)
               (fws.unique, histApiPax)
             }
-            .collect { case (key, nonEmptyPax) if nonEmptyPax.nonEmpty => (key, nonEmptyPax)}
+            .collect { case (key, nonEmptyPax) if nonEmptyPax.nonEmpty => (key, nonEmptyPax) }
             .toMap
 
           splitsSink

--- a/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeskRecs.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeskRecs.scala
@@ -20,7 +20,7 @@ import services.crunch.desklimits.TerminalDeskLimitsLike
 import services.crunch.deskrecs.RunnableOptimisation.CrunchRequest
 import services.graphstages.Crunch
 import uk.gov.homeoffice.drt.arrivals.{ApiFlightWithSplits, Arrival, TotalPaxSource}
-import uk.gov.homeoffice.drt.ports.ApiFeedSource
+import uk.gov.homeoffice.drt.ports.{ApiFeedSource, HistoricApiFeedSource}
 import uk.gov.homeoffice.drt.ports.Queues.{Closed, Queue, QueueStatus}
 import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.{ApiSplitsWithHistoricalEGateAndFTPercentages, Historical}
 import uk.gov.homeoffice.drt.ports.Terminals.Terminal
@@ -193,7 +193,7 @@ object DynamicRunnableDeskRecs {
             if (!flight.apiFlight.FeedSources.contains(ApiFeedSource)) {
               historicManifestsPaxProvider(flight.apiFlight).map {
                 case Some(manifestPaxLike: ManifestPaxCount) =>
-                  val totalPax: Set[TotalPaxSource] = flight.apiFlight.TotalPax ++ Set(TotalPaxSource(manifestPaxLike.pax.getOrElse(0), ApiFeedSource, Option(Historical)))
+                  val totalPax: Set[TotalPaxSource] = flight.apiFlight.TotalPax ++ Set(TotalPaxSource(manifestPaxLike.pax, HistoricApiFeedSource))
                   val updatedArrival = flight.apiFlight.copy(TotalPax = totalPax)
                   flight.copy(apiFlight = updatedArrival)
                 case None => flight
@@ -305,7 +305,7 @@ object DynamicRunnableDeskRecs {
             val arrival = flight.apiFlight.copy(
               ApiPax = Option(apiPax),
               FeedSources = flight.apiFlight.FeedSources + ApiFeedSource,
-              TotalPax = flight.apiFlight.TotalPax ++ Set(TotalPaxSource(apiPax, ApiFeedSource, Option(ApiSplitsWithHistoricalEGateAndFTPercentages)))
+              TotalPax = flight.apiFlight.TotalPax ++ Set(TotalPaxSource(Option(apiPax), ApiFeedSource))
             )
 
             flight.copy(apiFlight = arrival)

--- a/server/src/main/scala/services/exports/flights/templates/CedatFlightsExport.scala
+++ b/server/src/main/scala/services/exports/flights/templates/CedatFlightsExport.scala
@@ -68,7 +68,7 @@ case class CedatFlightsExport(start: SDateLike, end: SDateLike, terminal: Termin
       fws.apiFlight,
       millisToDateStringFn,
       millisToTimeStringFn
-    ) ++ List(fws.apiFlight.bestPcpPaxEstimate.pax.getOrElse("").toString) ++ splitsForSources
+    ) ++ List(fws.apiFlight.bestPcpPaxEstimate.pax.map(_.toString).getOrElse("")) ++ splitsForSources
   }
 
   override def rowValues(fws: ApiFlightWithSplits, maybeManifest: Option[VoyageManifest]): Seq[String] = (flightWithSplitsToCsvRow(fws) :::

--- a/server/src/main/scala/services/exports/flights/templates/CedatFlightsExport.scala
+++ b/server/src/main/scala/services/exports/flights/templates/CedatFlightsExport.scala
@@ -68,7 +68,7 @@ case class CedatFlightsExport(start: SDateLike, end: SDateLike, terminal: Termin
       fws.apiFlight,
       millisToDateStringFn,
       millisToTimeStringFn
-    ) ++ List(fws.apiFlight.bestPcpPaxEstimate.pax.toString) ++ splitsForSources
+    ) ++ List(fws.apiFlight.bestPcpPaxEstimate.pax.getOrElse("").toString) ++ splitsForSources
   }
 
   override def rowValues(fws: ApiFlightWithSplits, maybeManifest: Option[VoyageManifest]): Seq[String] = (flightWithSplitsToCsvRow(fws) :::

--- a/server/src/main/scala/services/exports/flights/templates/FlightsWithSplitsExport.scala
+++ b/server/src/main/scala/services/exports/flights/templates/FlightsWithSplitsExport.scala
@@ -53,14 +53,14 @@ trait FlightsWithSplitsExport extends FlightsExport {
       fws.apiFlight.ActualChox.map(millisToLocalDateTimeString(_)).getOrElse(""),
       fws.apiFlight.differenceFromScheduled.map(_.toMinutes.toString).getOrElse(""),
       fws.apiFlight.PcpTime.map(millisToLocalDateTimeString(_)).getOrElse(""),
-      fws.totalPax.map(_.pax.toString).getOrElse(""),
+      fws.totalPax.flatMap(_.pax).map(_.toString).getOrElse(""),
     )
   }
 
   protected def flightWithSplitsToCsvRow(fws: ApiFlightWithSplits): List[String] = {
     val apiIsInvalid = fws.hasApi && !fws.hasValidApi
     val splitsForSources = splitSources.flatMap((ss: SplitSource) => queueSplits(queueNames, fws, ss))
-    val pcpPax = if (fws.apiFlight.Origin.isDomesticOrCta) "-" else fws.pcpPaxEstimate.pax.toString
+    val pcpPax = if (fws.apiFlight.Origin.isDomesticOrCta) "-" else fws.pcpPaxEstimate.pax.map(_.toString).getOrElse("0")
     flightWithSplitsToCsvFields(fws, millisToDateStringFn, millisToLocalDateTimeStringFn) ++
       List(pcpPax, if (apiIsInvalid) "Y" else "") ++ splitsForSources
   }

--- a/server/src/main/scala/services/graphstages/ArrivalsGraphStage.scala
+++ b/server/src/main/scala/services/graphstages/ArrivalsGraphStage.scala
@@ -290,7 +290,7 @@ class ArrivalsGraphStage(name: String = "",
 
     def updateFilteredIncomingWithTotalPaxSource(filteredIncoming: SortedMap[UniqueArrival, Arrival], feedSource: FeedSource): SortedMap[UniqueArrival, Arrival] =
       filteredIncoming.map { case (k, arrival) =>
-      (k -> arrival.copy(TotalPax = arrival.TotalPax ++ Set(TotalPaxSource(arrival.ActPax.getOrElse(0) - arrival.TranPax.getOrElse(0), feedSource, None))))
+      (k -> arrival.copy(TotalPax = arrival.TotalPax ++ Set(TotalPaxSource(arrival.ActPax, feedSource))))
     }
 
     def changedArrivals(existingArrivals: SortedMap[UniqueArrival, Arrival],

--- a/server/src/main/scala/test/controllers/TestController.scala
+++ b/server/src/main/scala/test/controllers/TestController.scala
@@ -20,7 +20,7 @@ import test.TestDrtSystem
 import test.feeds.test.CSVFixtures
 import test.roles.MockRoles
 import test.roles.MockRoles.MockRolesProtocol._
-import uk.gov.homeoffice.drt.arrivals.Arrival
+import uk.gov.homeoffice.drt.arrivals.{Arrival, TotalPaxSource}
 import uk.gov.homeoffice.drt.ports.Terminals.Terminal
 import uk.gov.homeoffice.drt.ports.{LiveFeedSource, PortCode}
 import uk.gov.homeoffice.drt.time.SDateLike
@@ -66,29 +66,30 @@ class TestController @Inject()(val config: Configuration) extends InjectedContro
         case Some(flight) =>
           val walkTimeMinutes = 4
           val pcpTime: Long = org.joda.time.DateTime.parse(flight.SchDT).plusMinutes(walkTimeMinutes).getMillis
-          val actPax = Some(flight.ActPax).filter(_ != 0)
+          val actPax = Option(flight.ActPax).filter(_ != 0)
           val arrival = Arrival(
             Operator = flight.Operator,
             Status = flight.Status,
-            Estimated = Some(SDate(flight.EstDT).millisSinceEpoch),
-            Actual = Some(SDate(flight.ActDT).millisSinceEpoch),
-            EstimatedChox = Some(SDate(flight.EstChoxDT).millisSinceEpoch),
+            Estimated = Option(SDate(flight.EstDT).millisSinceEpoch),
+            Actual = Option(SDate(flight.ActDT).millisSinceEpoch),
+            EstimatedChox = Option(SDate(flight.EstChoxDT).millisSinceEpoch),
             PredictedTouchdown = None,
-            ActualChox = Some(SDate(flight.ActChoxDT).millisSinceEpoch),
-            Gate = Some(flight.Gate),
-            Stand = Some(flight.Stand),
-            MaxPax = Some(flight.MaxPax).filter(_ != 0),
+            ActualChox = Option(SDate(flight.ActChoxDT).millisSinceEpoch),
+            Gate = Option(flight.Gate),
+            Stand = Option(flight.Stand),
+            MaxPax = Option(flight.MaxPax).filter(_ != 0),
             ActPax = actPax,
-            TranPax = if (actPax.isEmpty) None else Some(flight.TranPax),
-            RunwayID = Some(flight.RunwayID),
-            BaggageReclaimId = Some(flight.BaggageReclaimId),
+            TranPax = if (actPax.isEmpty) None else Option(flight.TranPax),
+            RunwayID = Option(flight.RunwayID),
+            BaggageReclaimId = Option(flight.BaggageReclaimId),
             AirportID = PortCode(flight.AirportID),
             Terminal = Terminal(flight.Terminal),
             rawICAO = flight.ICAO,
             rawIATA = flight.IATA,
             Origin = PortCode(flight.Origin),
-            PcpTime = Some(pcpTime),
+            PcpTime = Option(pcpTime),
             FeedSources = Set(LiveFeedSource),
+            TotalPax = Set(TotalPaxSource(actPax, LiveFeedSource)),
             Scheduled = SDate(flight.SchDT).millisSinceEpoch
           )
           saveArrival(arrival).map(_ => Created)

--- a/server/src/test/scala/actors/serializers/FlightMessageConversionSpec.scala
+++ b/server/src/test/scala/actors/serializers/FlightMessageConversionSpec.scala
@@ -41,7 +41,13 @@ class FlightMessageConversionSpec extends Specification {
     ApiPax = Option(96),
     ScheduledDeparture = Option(8L),
     RedListPax = Option(26),
-    TotalPax = Set.empty[TotalPaxSource]
+    TotalPax = Set(TotalPaxSource(Option(95), HistoricApiFeedSource),
+      TotalPaxSource(Option(0), ForecastFeedSource),
+      TotalPaxSource(Option(95), LiveFeedSource),
+      TotalPaxSource(Option(95), ApiFeedSource),
+      TotalPaxSource(Option(95), AclFeedSource),
+      TotalPaxSource(Option(95), LiveBaseFeedSource),
+      TotalPaxSource(Option(95), ScenarioSimulationSource))
   )
 
   "Given an Arrival with no suffix" >> {

--- a/server/src/test/scala/drt/shared/PassengerNumberEstSpec.scala
+++ b/server/src/test/scala/drt/shared/PassengerNumberEstSpec.scala
@@ -14,7 +14,7 @@ class PassengerNumberEstSpec extends Specification {
 
         val flightWithSplits: ApiFlightWithSplits = flightWithPaxAndApiSplits(actPax = 100, sources = Set(LiveFeedSource))
 
-        val result = flightWithSplits.pcpPaxEstimate.pax
+        val result = flightWithSplits.pcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
 
         result === 100
       }
@@ -25,7 +25,7 @@ class PassengerNumberEstSpec extends Specification {
 
         val flightWithSplits: ApiFlightWithSplits = flightWithPaxAndApiSplits(actPax = 100, transferPax = 1, sources = Set(LiveFeedSource))
 
-        val result = flightWithSplits.pcpPaxEstimate.pax
+        val result = flightWithSplits.pcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
 
         result === 99
       }
@@ -36,7 +36,7 @@ class PassengerNumberEstSpec extends Specification {
 
         val flightWithSplits: ApiFlightWithSplits = flightWithPaxAndApiSplits(actPax = 100, splits = liveApiSplits(directPax = 96), sources = Set(LiveFeedSource))
 
-        val result = flightWithSplits.pcpPaxEstimate.pax
+        val result = flightWithSplits.pcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
 
         result === 96
       }
@@ -48,7 +48,7 @@ class PassengerNumberEstSpec extends Specification {
         val splits = liveApiSplits(directPax = 95, transferPax = 0)
         val flightWithSplits: ApiFlightWithSplits = flightWithPaxAndApiSplits(actPax = 100, transferPax = 1, splits = splits, sources = Set(LiveFeedSource))
 
-        val result = flightWithSplits.pcpPaxEstimate.pax
+        val result = flightWithSplits.pcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
 
         result === 95
       }
@@ -62,7 +62,7 @@ class PassengerNumberEstSpec extends Specification {
         val sources: Set[FeedSource] = Set(LiveFeedSource)
         val flightWithSplits: ApiFlightWithSplits = flightWithPaxAndApiSplits(actPax = 100, transferPax = 1, splits = splits, sources = sources)
 
-        val result = flightWithSplits.pcpPaxEstimate.pax
+        val result = flightWithSplits.pcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
 
         result === 99
       }
@@ -76,7 +76,7 @@ class PassengerNumberEstSpec extends Specification {
         val sources: Set[FeedSource] = Set(AclFeedSource)
         val flightWithSplits: ApiFlightWithSplits = flightWithPaxAndApiSplits(actPax = 100, transferPax = 1, splits = splits, sources = sources)
 
-        val result = flightWithSplits.pcpPaxEstimate.pax
+        val result = flightWithSplits.pcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
 
         result === 50
       }
@@ -90,7 +90,7 @@ class PassengerNumberEstSpec extends Specification {
 
         val flightWithSplits: ApiFlightWithSplits = flightWithPaxAndApiSplits(actPax = 100, sources = Set())
 
-        val result = flightWithSplits.totalPax.map(_.pax).getOrElse(0)
+        val result = flightWithSplits.totalPax.flatMap(_.pax.map(_.toInt)).getOrElse(0)
 
         result === 0
       }
@@ -101,7 +101,7 @@ class PassengerNumberEstSpec extends Specification {
 
         val flightWithSplits: ApiFlightWithSplits = flightWithPaxAndApiSplits(actPax = 100, sources = Set(AclFeedSource))
 
-        val result = flightWithSplits.totalPax.map(_.pax).getOrElse(0)
+        val result = flightWithSplits.totalPax.flatMap(_.pax.map(_.toInt)).getOrElse(0)
 
         result === 100
       }
@@ -112,7 +112,7 @@ class PassengerNumberEstSpec extends Specification {
 
         val flightWithSplits: ApiFlightWithSplits = flightWithPaxAndApiSplits(actPax = 100, transferPax = 1, Set(), Set(LiveFeedSource))
 
-        val result = flightWithSplits.totalPax.map(_.pax).getOrElse(0)
+        val result = flightWithSplits.totalPax.flatMap(_.pax.map(_.toInt)).getOrElse(0)
 
         result === 100
       }
@@ -123,7 +123,7 @@ class PassengerNumberEstSpec extends Specification {
 
         val flightWithSplits: ApiFlightWithSplits = flightWithPaxAndApiSplits(actPax = 100, splits = liveApiSplits(directPax = 96), sources = Set(LiveFeedSource))
 
-        val result = flightWithSplits.totalPax.map(_.pax).getOrElse(0)
+        val result = flightWithSplits.totalPax.flatMap(_.pax.map(_.toInt)).getOrElse(0)
 
         result === 96
       }
@@ -135,7 +135,7 @@ class PassengerNumberEstSpec extends Specification {
         val splits = liveApiSplits(directPax = 95, transferPax = 1)
         val flightWithSplits: ApiFlightWithSplits = flightWithPaxAndApiSplits(actPax = 100, transferPax = 1, splits = splits, sources = Set(LiveFeedSource))
 
-        val result = flightWithSplits.totalPax.map(_.pax).getOrElse(0)
+        val result = flightWithSplits.totalPax.flatMap(_.pax.map(_.toInt)).getOrElse(0)
 
         result === 96
       }
@@ -149,7 +149,7 @@ class PassengerNumberEstSpec extends Specification {
         val sources: Set[FeedSource] = Set(LiveFeedSource)
         val flightWithSplits: ApiFlightWithSplits = flightWithPaxAndApiSplits(actPax = 100, transferPax = 1, splits = splits, sources = sources)
 
-        val result = flightWithSplits.totalPax.map(_.pax).getOrElse(0)
+        val result = flightWithSplits.totalPax.flatMap(_.pax.map(_.toInt)).getOrElse(0)
 
         result === 100
       }
@@ -163,7 +163,7 @@ class PassengerNumberEstSpec extends Specification {
         val sources: Set[FeedSource] = Set()
         val flightWithSplits: ApiFlightWithSplits = flightWithPaxAndApiSplits(actPax = 100, transferPax = 1, splits = splits, sources = sources)
 
-        val result = flightWithSplits.totalPax.map(_.pax).getOrElse(0)
+        val result = flightWithSplits.totalPax.flatMap(_.pax.map(_.toInt)).getOrElse(0)
 
         result === 51
       }
@@ -179,7 +179,7 @@ class PassengerNumberEstSpec extends Specification {
       actPax = Option(actPax),
       tranPax = Option(transferPax),
       feedSources = sources,
-      totalPax = Set(sources.map(TotalPaxSource(actPax - transferPax, _, None)).toList: _*)
+      totalPax = Set(sources.map(TotalPaxSource(Option(actPax), _)).toList: _*)
     )
 
     ApiFlightWithSplits(flight, splits)

--- a/server/src/test/scala/drt/shared/PaxForArrivalsTest.scala
+++ b/server/src/test/scala/drt/shared/PaxForArrivalsTest.scala
@@ -1,0 +1,36 @@
+package drt.shared
+
+import drt.shared.FlightsApi.PaxForArrivals
+import org.specs2.mutable.Specification
+import uk.gov.homeoffice.drt.arrivals.TotalPaxSource
+import uk.gov.homeoffice.drt.ports.{ApiFeedSource, HistoricApiFeedSource, PortCode}
+import uk.gov.homeoffice.drt.ports.Terminals.T1
+
+class PaxForArrivalsTest extends Specification {
+  "When I ask to extract the historic api nos" >> {
+    "Given an arrival with no passenger totals" >> {
+      val arrival = ArrivalGenerator.arrival(iata = "BA0001", sch = 0L, terminal = T1, origin = PortCode("ABC"), totalPax = Set())
+      "I should get an empty PaxForArrivals" >> {
+        PaxForArrivals.from(Seq(arrival), HistoricApiFeedSource) === PaxForArrivals.empty
+      }
+    }
+
+    "Given an arrival with live api passenger totals" >> {
+      val arrival = ArrivalGenerator.arrival(iata = "BA0001", sch = 0L, terminal = T1, origin = PortCode("ABC"),
+        totalPax = Set(TotalPaxSource(Option(100), ApiFeedSource)))
+      "I should get an empty PaxForArrivals" >> {
+        PaxForArrivals.from(Seq(arrival), HistoricApiFeedSource) === PaxForArrivals.empty
+      }
+    }
+
+    "Given an arrival with live & historic api passenger totals" >> {
+      val arrival = ArrivalGenerator.arrival(iata = "BA0001", sch = 0L, terminal = T1, origin = PortCode("ABC"),
+        totalPax = Set(TotalPaxSource(Option(100), ApiFeedSource), TotalPaxSource(Option(100), HistoricApiFeedSource)))
+      "I should get a PaxForArrivals with HistoricApiFeedSource with 100 passengers" >> {
+        PaxForArrivals.from(Seq(arrival), HistoricApiFeedSource) === PaxForArrivals(Map(
+          arrival.unique -> Set(TotalPaxSource(Option(100), HistoricApiFeedSource))
+        ))
+      }
+    }
+  }
+}

--- a/server/src/test/scala/drt/shared/SplitsForArrivalsSpec.scala
+++ b/server/src/test/scala/drt/shared/SplitsForArrivalsSpec.scala
@@ -78,8 +78,8 @@ class SplitsForArrivalsSpec extends Specification {
 
         val updated = splitsForArrivals.diff(flights, now)
 
-        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival.copy(FeedSources = Set(ApiFeedSource), ApiPax = Option(1) ,
-          TotalPax = Set(TotalPaxSource(1,ApiFeedSource,Some(ApiSplitsWithHistoricalEGateAndFTPercentages)))
+        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival.copy(FeedSources = Set(ApiFeedSource), ApiPax = Option(1),
+          TotalPax = Set(TotalPaxSource(Option(1), ApiFeedSource))
         ), Set(newSplits, existingSplits), Option(now))), Seq())
       }
     }
@@ -95,8 +95,8 @@ class SplitsForArrivalsSpec extends Specification {
 
         val updated = splitsForArrivals.diff(flights, now)
 
-        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival.copy(FeedSources = Set(ApiFeedSource), ApiPax = Option(1) ,
-          TotalPax = Set(TotalPaxSource(1,ApiFeedSource,Some(ApiSplitsWithHistoricalEGateAndFTPercentages)))), Set(newSplits, existingSplits1), Option(now))), Seq())
+        updated === FlightsWithSplitsDiff(Seq(ApiFlightWithSplits(arrival.copy(FeedSources = Set(ApiFeedSource), ApiPax = Option(1),
+          TotalPax = Set(TotalPaxSource(Option(1), ApiFeedSource))), Set(newSplits, existingSplits1), Option(now))), Seq())
       }
     }
 

--- a/server/src/test/scala/feeds/acl/AclFeedSpec.scala
+++ b/server/src/test/scala/feeds/acl/AclFeedSpec.scala
@@ -258,7 +258,7 @@ class AclFeedSpec extends CrunchTestLike {
 
         offerAndWait(crunch.aclArrivalsInput, ArrivalsFeedSuccess(aclFlight))
 
-        val expected = Set(arrival.copy(FeedSources = Set(AclFeedSource), TotalPax = Set(TotalPaxSource(10, AclFeedSource, None))))
+        val expected = Set(arrival.copy(FeedSources = Set(AclFeedSource), TotalPax = Set(TotalPaxSource(Option(10), AclFeedSource))))
 
         crunch.portStateTestProbe.fishForMessage(3.seconds) {
           case ps: PortState =>
@@ -289,8 +289,8 @@ class AclFeedSpec extends CrunchTestLike {
 
         val expected = Set(liveFlight.copy(CarrierCode = aclFlight.CarrierCode,
           VoyageNumber = aclFlight.VoyageNumber, FeedSources = Set(AclFeedSource, LiveFeedSource),
-          TotalPax = liveFlight.TotalPax ++ Set(TotalPaxSource(aclFlight.ActPax.getOrElse(0), AclFeedSource, None),
-            TotalPaxSource(liveFlight.ActPax.getOrElse(0), LiveFeedSource, None))))
+          TotalPax = liveFlight.TotalPax ++ Set(TotalPaxSource(aclFlight.ActPax, AclFeedSource),
+            TotalPaxSource(liveFlight.ActPax, LiveFeedSource))))
 
         crunch.portStateTestProbe.fishForMessage(3.seconds) {
           case ps: PortState =>
@@ -332,7 +332,7 @@ class AclFeedSpec extends CrunchTestLike {
           .map(il => il.copy(FeedSources = Set(LiveFeedSource),
           )) ++
           newAcl.map(na => na.copy(FeedSources = Set(AclFeedSource),
-            TotalPax = na.TotalPax ++ Set(TotalPaxSource(na.ActPax.getOrElse(0), AclFeedSource, None))))
+            TotalPax = na.TotalPax ++ Set(TotalPaxSource(na.ActPax, AclFeedSource))))
 
         crunch.portStateTestProbe.fishForMessage(3.seconds) {
           case ps: PortState =>
@@ -370,8 +370,8 @@ class AclFeedSpec extends CrunchTestLike {
         val expected = newLive.map(_.copy(CarrierCode = CarrierCode("BA"),
           VoyageNumber = VoyageNumber(1),
           FeedSources = Set(LiveFeedSource, AclFeedSource),
-          TotalPax = Set(TotalPaxSource(liveArrival.ActPax.getOrElse(0), LiveFeedSource, None),
-            TotalPaxSource(initialAcl1.ActPax.getOrElse(0), AclFeedSource, None))))
+          TotalPax = Set(TotalPaxSource(liveArrival.ActPax, LiveFeedSource),
+            TotalPaxSource(initialAcl1.ActPax, AclFeedSource))))
 
         crunch.portStateTestProbe.fishForMessage(3.seconds) {
           case ps: PortState =>
@@ -436,7 +436,7 @@ class AclFeedSpec extends CrunchTestLike {
           case PortState(f, _, _) => f.values.map(_.apiFlight)
         }
 
-        val nonEmptyFlightsList = List(aclArrival.copy(FeedSources = Set(AclFeedSource), TotalPax = Set(TotalPaxSource(aclArrival.ActPax.getOrElse(0), AclFeedSource, None))))
+        val nonEmptyFlightsList = List(aclArrival.copy(FeedSources = Set(AclFeedSource), TotalPax = Set(TotalPaxSource(aclArrival.ActPax, AclFeedSource))))
         val expected = List(nonEmptyFlightsList)
 
         portStateFlightLists.distinct === expected

--- a/server/src/test/scala/feeds/lgw/LGWFeedSpec.scala
+++ b/server/src/test/scala/feeds/lgw/LGWFeedSpec.scala
@@ -52,7 +52,7 @@ class LGWFeedSpec extends CrunchTestLike with Mockito {
       Origin = PortCode("LHR"),
       FeedSources = Set(LiveFeedSource),
       Scheduled = SDate("2018-06-03T19:50:00Z").millisSinceEpoch, PcpTime = None,
-      TotalPax = Set(TotalPaxSource(120, LiveFeedSource, None)))
+      TotalPax = Set(TotalPaxSource(Option(120), LiveFeedSource)))
 
   }
 
@@ -86,7 +86,7 @@ class LGWFeedSpec extends CrunchTestLike with Mockito {
       FeedSources = Set(LiveFeedSource),
       Scheduled = SDate("2018-06-03T19:50:00Z").millisSinceEpoch,
       PcpTime = None,
-      TotalPax = Set(TotalPaxSource(0, LiveFeedSource, None)))
+      TotalPax = Set(TotalPaxSource(Option(0), LiveFeedSource)))
 
   }
 

--- a/server/src/test/scala/scenarios/ArrivalsScenarioSpec.scala
+++ b/server/src/test/scala/scenarios/ArrivalsScenarioSpec.scala
@@ -45,7 +45,7 @@ class ArrivalsScenarioSpec extends CrunchTestLike {
     TerminalQueueAllocatorWithFastTrack(terminalQueueAllocationMap))
 
   val splitsCalculator: SplitsCalculator = SplitsCalculator(testPaxTypeAllocator, defaultAirportConfig.terminalPaxSplits, ChildEGateAdjustments(1.0))
-  private val arrival: Arrival = ArrivalGenerator.arrival(actPax = Option(100), schDt = "2021-03-08T00:00",totalPax = Set(TotalPaxSource(100,LiveFeedSource,None)))
+  private val arrival: Arrival = ArrivalGenerator.arrival(actPax = Option(100), schDt = "2021-03-08T00:00",totalPax = Set(TotalPaxSource(Option(100),LiveFeedSource)))
   val arrivals = List(
     arrival
   )

--- a/server/src/test/scala/services/ArrivalSpec.scala
+++ b/server/src/test/scala/services/ArrivalSpec.scala
@@ -40,7 +40,7 @@ class ArrivalSpec extends Specification {
 
   "Given an arrival arriving at pcp at noon 2019-01-01 with 100 pax " >> {
     val pcpTime = "2019-01-01T12:00"
-    val arrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = "2019-01-01T12:00", actPax = Option(100), pcpDt = "2019-01-01T12:00",totalPax = Set(TotalPaxSource(100,LiveFeedSource,None)))
+    val arrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = "2019-01-01T12:00", actPax = Option(100), pcpDt = "2019-01-01T12:00", totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource)))
 
     val pcpRange = arrival.pcpRange
 
@@ -65,7 +65,7 @@ class ArrivalSpec extends Specification {
 
   "Given an arrival arriving at pcp at noon 2019-01-01 with 99 pax " >> {
     val pcpTime = "2019-01-01T12:00"
-    val arrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = "2019-01-01T12:00", actPax = Option(99), pcpDt = "2019-01-01T12:00", totalPax = Set(TotalPaxSource(99,LiveFeedSource,None)))
+    val arrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = "2019-01-01T12:00", actPax = Option(99), pcpDt = "2019-01-01T12:00", totalPax = Set(TotalPaxSource(Option(99), LiveFeedSource)))
 
     val pcpRange = arrival.pcpRange
     "When I ask how many minutes I should see 5" >> {
@@ -89,7 +89,7 @@ class ArrivalSpec extends Specification {
 
   "Given an arrival arriving at pcp at noon 2019-01-01 with 101 pax " >> {
     val pcpTime = "2019-01-01T12:00"
-    val arrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = "2019-01-01T12:00", actPax = Option(101), pcpDt = "2019-01-01T12:00", totalPax = Set(TotalPaxSource(101,LiveFeedSource,None)) )
+    val arrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = "2019-01-01T12:00", actPax = Option(101), pcpDt = "2019-01-01T12:00", totalPax = Set(TotalPaxSource(Option(101), LiveFeedSource)))
 
     val pcpRange = arrival.pcpRange
 

--- a/server/src/test/scala/services/PortStateSpec.scala
+++ b/server/src/test/scala/services/PortStateSpec.scala
@@ -131,7 +131,7 @@ class PortStateSpec extends CrunchTestLike {
 
         offerAndWait(crunch.aclArrivalsInput, ArrivalsFeedSuccess(Flights(Seq(newArrival))))
 
-        val expected = newArrival.copy(FeedSources = Set(AclFeedSource),TotalPax = Set(TotalPaxSource(newArrival.ActPax.getOrElse(0),AclFeedSource,None)))
+        val expected = newArrival.copy(FeedSources = Set(AclFeedSource),TotalPax = Set(TotalPaxSource(newArrival.ActPax,AclFeedSource)))
         crunch.portStateTestProbe.fishForMessage(1.seconds) {
           case PortState(flights, _, _) =>
             flights.size == 1 && flights.values.head.apiFlight == expected

--- a/server/src/test/scala/services/arrivals/PcpUtilsSpec.scala
+++ b/server/src/test/scala/services/arrivals/PcpUtilsSpec.scala
@@ -11,9 +11,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with 100 pax from API and 50 from Act Pax " +
       "Then I should expect 50 PCP pax" >> {
       val a = arrival(actPax = Option(50), apiPax = Option(100), feedSources = Set(LiveFeedSource),
-        totalPax = Set(TotalPaxSource(50, LiveFeedSource, None), TotalPaxSource(100, ApiFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(50), LiveFeedSource), TotalPaxSource(Option(100), ApiFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 50
 
       result === expected
@@ -22,9 +22,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with None from API and 50 from Act Pax " +
       "Then I should expect 50 PCP pax" >> {
       val a = arrival(actPax = Option(50), apiPax = None, feedSources = Set(LiveFeedSource),
-        totalPax = Set(TotalPaxSource(50, LiveFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(50), LiveFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 50
 
       result === expected
@@ -33,9 +33,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with 100 pax from API and None from Act Pax " +
       "Then I should expect 100 PCP pax" >> {
       val a = arrival(actPax = None, apiPax = Option(100), feedSources = Set(LiveFeedSource),
-        totalPax = Set(TotalPaxSource(100, ApiFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(100), ApiFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 100
 
       result === expected
@@ -44,9 +44,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with 100 pax and None for Transfer " +
       "Then I should expect 100 PCP pax" >> {
       val a = arrival(actPax = Option(100), tranPax = None, feedSources = Set(LiveFeedSource),
-        totalPax = Set(TotalPaxSource(100, LiveFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 100
 
       result === expected
@@ -55,9 +55,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with more Transfer Pax than Act Pax and a MaxPax of 150 " +
       "Then we should get 0 PCP Pax " >> {
       val a = arrival(actPax = Option(50), tranPax = Option(100), maxPax = Option(150), feedSources = Set(LiveFeedSource),
-        totalPax = Set(TotalPaxSource(50 - 100, LiveFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(50), LiveFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 0
 
       result === expected
@@ -66,9 +66,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with 100 pax and 0 Transfer " +
       "Then I should expect 100 PCP pax" >> {
       val a = arrival(actPax = Option(100), tranPax = Option(0), feedSources = Set(LiveFeedSource),
-        totalPax = Set(TotalPaxSource(100, LiveFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 100
 
       result === expected
@@ -77,9 +77,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with 0 act pax, 0 Transfer and 130 Max Pax" +
       "Then I should expect 0 PCP pax" >> {
       val a = arrival(actPax = Option(0), tranPax = Option(0), maxPax = Option(130), feedSources = Set(LiveFeedSource),
-        totalPax = Set(TotalPaxSource(0, LiveFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(0), LiveFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 0
 
       result === expected
@@ -88,9 +88,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with 100 act pax and 10 Transfer" +
       "Then I should expect 90 PCP pax" >> {
       val a = arrival(actPax = Option(100), tranPax = Option(10), feedSources = Set(LiveFeedSource),
-        totalPax = Set(TotalPaxSource(100 - 10, LiveFeedSource, None), TotalPaxSource(100, ApiFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource), TotalPaxSource(Option(100), ApiFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 90
 
       result === expected
@@ -100,7 +100,7 @@ class PcpUtilsSpec extends Specification {
       "Then I should expect 0 PCP pax" >> {
       val a = arrival(actPax = None, tranPax = None, maxPax = Option(130), feedSources = Set(LiveFeedSource))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 0
 
       result === expected
@@ -112,9 +112,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with 100 pax from API and 50 from Act Pax " +
       "Then I should expect 100 PCP pax - API trumps ACL numbers" >> {
       val a = arrival(actPax = Option(50), apiPax = Option(100), feedSources = Set(AclFeedSource),
-        totalPax = Set(TotalPaxSource(100, ApiFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(100), ApiFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 100
 
       result === expected
@@ -123,9 +123,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with None from API and 50 from Act Pax " +
       "Then I should expect 50 PCP pax" >> {
       val a = arrival(actPax = Option(50), apiPax = None, feedSources = Set(AclFeedSource),
-        totalPax = Set(TotalPaxSource(50, AclFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(50), AclFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 50
 
       result === expected
@@ -134,9 +134,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with 100 pax from API and None from Act Pax " +
       "Then I should expect 100 PCP pax" >> {
       val a = arrival(actPax = None, apiPax = Option(100), feedSources = Set(AclFeedSource),
-        totalPax = Set(TotalPaxSource(100, ApiFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(100), ApiFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 100
 
       result === expected
@@ -145,9 +145,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with 100 pax and None for Transfer " +
       "Then I should expect 100 PCP pax" >> {
       val a = arrival(actPax = Option(100), tranPax = None, feedSources = Set(AclFeedSource),
-        totalPax = Set(TotalPaxSource(100, AclFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(100), AclFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 100
 
       result === expected
@@ -157,7 +157,7 @@ class PcpUtilsSpec extends Specification {
       "Then we should get 0 PCP Pax " >> {
       val a = arrival(actPax = Option(50), tranPax = Option(100), maxPax = Option(150), feedSources = Set(AclFeedSource))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 0
 
       result === expected
@@ -166,9 +166,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with 100 pax and 0 Transfer " +
       "Then I should expect 100 PCP pax" >> {
       val a = arrival(actPax = Option(100), tranPax = Option(0), feedSources = Set(AclFeedSource),
-        totalPax = Set(TotalPaxSource(100, AclFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(100), AclFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 100
 
       result === expected
@@ -177,9 +177,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with 0 act pax, 0 Transfer and 130 Max Pax" +
       "Then I should expect 0 PCP pax" >> {
       val a = arrival(actPax = Option(0), tranPax = Option(0), maxPax = Option(130), feedSources = Set(AclFeedSource),
-        totalPax = Set(TotalPaxSource(0, AclFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(0), AclFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 0
 
       result === expected
@@ -188,9 +188,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with 100 act pax and 10 Transfer" +
       "Then I should expect 90 PCP pax" >> {
       val a = arrival(actPax = Option(100), tranPax = Option(10), feedSources = Set(AclFeedSource),
-        totalPax = Set(TotalPaxSource(100 - 10, AclFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(100), AclFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 90
 
       result === expected
@@ -199,9 +199,9 @@ class PcpUtilsSpec extends Specification {
     "Given an arrival with no values set for act pax and transfer and 130 for max pax" +
       "Then I should expect 0 PCP pax" >> {
       val a = arrival(actPax = None, tranPax = None, maxPax = Option(130), feedSources = Set(AclFeedSource),
-        totalPax = Set(TotalPaxSource(0, AclFeedSource, None)))
+        totalPax = Set(TotalPaxSource(Option(0), AclFeedSource)))
 
-      val result = a.bestPcpPaxEstimate.pax
+      val result = a.bestPcpPaxEstimate.pax.map(_.toInt).getOrElse(0)
       val expected = 0
 
       result === expected

--- a/server/src/test/scala/services/crunch/BlackJackFlowSpec.scala
+++ b/server/src/test/scala/services/crunch/BlackJackFlowSpec.scala
@@ -24,7 +24,7 @@ class BlackJackFlowSpec extends CrunchTestLike {
     "Then the updated blackjack numbers should appear in the PortState" >> {
     val scheduled = "2017-01-01T00:00Z"
 
-    val flight = ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(21), totalPax = Set(TotalPaxSource(21, AclFeedSource, None)))
+    val flight = ArrivalGenerator.arrival(schDt = scheduled, iata = "BA0001", terminal = T1, actPax = Option(21), totalPax = Set(TotalPaxSource(Option(21), AclFeedSource)))
     val initialBaseArrivals = Set(flight)
     val deskStats = ActualDeskStats(Map(
       T1 -> Map(

--- a/server/src/test/scala/services/crunch/FlightUpdatesTriggerNewPortStateSpec.scala
+++ b/server/src/test/scala/services/crunch/FlightUpdatesTriggerNewPortStateSpec.scala
@@ -48,8 +48,8 @@ class FlightUpdatesTriggerNewPortStateSpec extends CrunchTestLike {
         offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(inputFlightsAfter))
 
         val expectedFlights = Set(ApiFlightWithSplits(
-          updatedArrival.copy(FeedSources = Set(LiveFeedSource),TotalPax =
-            Set(TotalPaxSource(updatedArrival.ActPax.getOrElse(0),LiveFeedSource,None))
+          updatedArrival.copy(FeedSources = Set(LiveFeedSource), TotalPax =
+            Set(TotalPaxSource(updatedArrival.ActPax, LiveFeedSource))
           ),
           Set(Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, Queues.EeaDesk, 100.0, None, None)), TerminalAverage, None, Percentage))))
 
@@ -80,8 +80,8 @@ class FlightUpdatesTriggerNewPortStateSpec extends CrunchTestLike {
         offerAndWait(crunch.liveArrivalsInput, ArrivalsFeedSuccess(inputFlightsAfter))
 
         val expectedFlights = Set(ApiFlightWithSplits(
-          updatedArrival.copy(FeedSources = Set(LiveFeedSource),TotalPax =
-            Set(TotalPaxSource(updatedArrival.ActPax.getOrElse(0),LiveFeedSource,None))),
+          updatedArrival.copy(FeedSources = Set(LiveFeedSource), TotalPax =
+            Set(TotalPaxSource(updatedArrival.ActPax, LiveFeedSource))),
           Set(Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, Queues.EeaDesk, 100.0, None, None)), TerminalAverage, None, Percentage))))
 
         crunch.portStateTestProbe.fishForMessage(3.seconds) {

--- a/server/src/test/scala/services/crunch/ForecastCrunchSpec.scala
+++ b/server/src/test/scala/services/crunch/ForecastCrunchSpec.scala
@@ -181,7 +181,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
     offerAndWait(crunch.aclArrivalsInput, ArrivalsFeedSuccess(baseArrivals))
 
     val expectedForecastArrivals = Set(baseArrival.copy(FeedSources = Set(AclFeedSource),
-      TotalPax = Set(TotalPaxSource(baseArrival.ActPax.getOrElse(0),AclFeedSource,None))))
+      TotalPax = Set(TotalPaxSource(baseArrival.ActPax,AclFeedSource))))
 
     crunch.portStateTestProbe.fishForMessage(10.seconds) {
       case ps: PortState =>
@@ -210,7 +210,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
     offerAndWait(crunch.aclArrivalsInput, ArrivalsFeedSuccess(baseArrivals))
 
     val expectedForecastArrivals = Set(baseArrival.copy(ActPax = Some(50), TranPax = Some(25), FeedSources = Set(ForecastFeedSource, AclFeedSource),
-      TotalPax = Set(TotalPaxSource(baseArrival.ActPax.getOrElse(0),AclFeedSource,None))))
+      TotalPax = Set(TotalPaxSource(baseArrival.ActPax,AclFeedSource))))
 
     crunch.portStateTestProbe.fishForMessage(10.seconds) {
       case ps: PortState =>
@@ -245,7 +245,7 @@ class ForecastCrunchSpec extends CrunchTestLike {
     val expectedForecastArrivals = Set(baseArrival.copy(ActPax = forecastArrival.ActPax,
       TranPax = forecastArrival.TranPax, Estimated = Some(SDate(liveScheduled).millisSinceEpoch),
       FeedSources = Set(AclFeedSource, ForecastFeedSource, LiveFeedSource),
-      TotalPax = Set(TotalPaxSource(baseArrival.ActPax.getOrElse(0),AclFeedSource,None),TotalPaxSource(liveArrival.ActPax.getOrElse(0),LiveFeedSource,None))))
+      TotalPax = Set(TotalPaxSource(baseArrival.ActPax,AclFeedSource),TotalPaxSource(liveArrival.ActPax,LiveFeedSource))))
 
     crunch.portStateTestProbe.fishForMessage(10.seconds) {
       case ps: PortState =>
@@ -281,8 +281,8 @@ class ForecastCrunchSpec extends CrunchTestLike {
     offerAndWait(crunch.forecastArrivalsInput, ArrivalsFeedSuccess(forecastArrivals2nd))
 
     val expectedForecastArrivals = Set(
-      baseArrival1.copy(ActPax = Some(51), Status = ArrivalStatus("Port Forecast"), FeedSources = Set(ForecastFeedSource, AclFeedSource),TotalPax = Set(TotalPaxSource(baseArrival1.ActPax.getOrElse(0),AclFeedSource,None))),
-      baseArrival2.copy(ActPax = Some(52), Status = ArrivalStatus("Port Forecast"), FeedSources = Set(ForecastFeedSource, AclFeedSource),TotalPax = Set(TotalPaxSource(baseArrival2.ActPax.getOrElse(0),AclFeedSource,None))))
+      baseArrival1.copy(ActPax = Some(51), Status = ArrivalStatus("Port Forecast"), FeedSources = Set(ForecastFeedSource, AclFeedSource),TotalPax = Set(TotalPaxSource(baseArrival1.ActPax,AclFeedSource))),
+      baseArrival2.copy(ActPax = Some(52), Status = ArrivalStatus("Port Forecast"), FeedSources = Set(ForecastFeedSource, AclFeedSource),TotalPax = Set(TotalPaxSource(baseArrival2.ActPax,AclFeedSource))))
 
     crunch.portStateTestProbe.fishForMessage(10.seconds) {
       case ps: PortState =>

--- a/server/src/test/scala/services/crunch/VoyageManifestsSpec.scala
+++ b/server/src/test/scala/services/crunch/VoyageManifestsSpec.scala
@@ -359,7 +359,7 @@ class VoyageManifestsSpec extends CrunchTestLike {
     val portCode = PortCode("LHR")
 
     val flight = ArrivalGenerator.arrival(origin = PortCode("JFK"), schDt = scheduled, iata = "TST001", terminal = T1, actPax = None, tranPax = Option(6),
-      totalPax = Set(TotalPaxSource(0,AclFeedSource,None)))
+      totalPax = Set(TotalPaxSource(Option(0), AclFeedSource)))
     val inputManifests = ManifestsFeedSuccess(DqManifests(0, Set(
       VoyageManifest(EventTypes.CI, portCode, PortCode("JFK"), VoyageNumber(1), CarrierCode("TS"), ManifestDateOfArrival("2017-01-01"), ManifestTimeOfArrival("00:00"), List(
         euPassport,

--- a/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeskRecsSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeskRecsSpec.scala
@@ -187,7 +187,7 @@ class RunnableDynamicDeskRecsSpec extends CrunchTestLike {
   }
 
   "Given a flight and a mock splits calculator" >> {
-    val arrival = ArrivalGenerator.arrival(actPax = Option(100), origin = PortCode("JFK"), feedSources = Set(LiveFeedSource), totalPax = Set(TotalPaxSource(100, LiveFeedSource, None)))
+    val arrival = ArrivalGenerator.arrival(actPax = Option(100), origin = PortCode("JFK"), feedSources = Set(LiveFeedSource), totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource)))
     val flights = Seq(ApiFlightWithSplits(arrival, Set()))
     val splits = Splits(Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, EeaDesk, 1.0, None, None)), ApiSplitsWithHistoricalEGateAndFTPercentages, None, Percentage)
     val mockSplits: SplitsForArrival = (_, _) => splits
@@ -199,7 +199,7 @@ class RunnableDynamicDeskRecsSpec extends CrunchTestLike {
         val withLiveManifests = addManifests(flights, manifestsForArrival, mockSplits)
 
         withLiveManifests === Seq(ApiFlightWithSplits(arrival.copy(ApiPax = Option(1), FeedSources = arrival.FeedSources + ApiFeedSource,
-          TotalPax = arrival.TotalPax ++ Set(TotalPaxSource(1, ApiFeedSource, Option(ApiSplitsWithHistoricalEGateAndFTPercentages)))
+          TotalPax = arrival.TotalPax ++ Set(TotalPaxSource(Option(1), ApiFeedSource))
         ), Set(splits)))
       }
 
@@ -232,28 +232,28 @@ class RunnableDynamicDeskRecsSpec extends CrunchTestLike {
 
     "add historic API pax" >> {
       "When I have live manifests matching the arrival where the live manifest is within the trust threshold I should get some pax from historic API" >> {
-        checkPaxSource(arrival, Map(arrival -> Option(xOfPaxType(10, visa))), Set(TotalPaxSource(100, LiveFeedSource, None),
-          TotalPaxSource(10, ApiFeedSource, Option(Historical))))
+        checkPaxSource(arrival, Map(arrival -> Option(xOfPaxType(10, visa))), Set(TotalPaxSource(Option(100), LiveFeedSource),
+          TotalPaxSource(Option(10), HistoricApiFeedSource)))
       }
 
       "When I have ACL pax number I should get some pax from historic API" >> {
         val arrival = ArrivalGenerator.arrival(actPax = Option(100), origin = PortCode("JFK"), feedSources = Set(AclFeedSource),
-          totalPax = Set(TotalPaxSource(100, AclFeedSource, None)))
-        checkPaxSource(arrival, Map(arrival -> Option(xOfPaxType(10, visa))), Set(TotalPaxSource(100, AclFeedSource, None),
-          TotalPaxSource(10, ApiFeedSource, Option(Historical))))
+          totalPax = Set(TotalPaxSource(Option(100), AclFeedSource)))
+        checkPaxSource(arrival, Map(arrival -> Option(xOfPaxType(10, visa))), Set(TotalPaxSource(Option(100), AclFeedSource),
+          TotalPaxSource(Option(10), HistoricApiFeedSource)))
       }
 
       "When I have ForecastPortFeed pax number I should get some pax from historic API" >> {
         val arrival = ArrivalGenerator.arrival(actPax = Option(100), origin = PortCode("JFK"), feedSources = Set(ForecastFeedSource),
-          totalPax = Set(TotalPaxSource(100, ForecastFeedSource, None)))
-        checkPaxSource(arrival, Map(arrival -> Option(xOfPaxType(10, visa))), Set(TotalPaxSource(100, ForecastFeedSource, None),
-          TotalPaxSource(10, ApiFeedSource, Option(Historical))))
+          totalPax = Set(TotalPaxSource(Option(100), ForecastFeedSource)))
+        checkPaxSource(arrival, Map(arrival -> Option(xOfPaxType(10, visa))), Set(TotalPaxSource(Option(100), ForecastFeedSource),
+          TotalPaxSource(Option(10), HistoricApiFeedSource)))
       }
 
       "When I have no Feed I should get some pax from historic API" >> {
         val arrival = ArrivalGenerator.arrival(actPax = Option(100), origin = PortCode("JFK"), feedSources = Set(),
           totalPax = Set.empty)
-        checkPaxSource(arrival, Map(arrival -> Option(xOfPaxType(10, visa))), Set(TotalPaxSource(10, ApiFeedSource, Option(Historical))))
+        checkPaxSource(arrival, Map(arrival -> Option(xOfPaxType(10, visa))), Set(TotalPaxSource(Option(10), HistoricApiFeedSource)))
       }
     }
   }
@@ -292,7 +292,7 @@ class RunnableDynamicDeskRecsSpec extends CrunchTestLike {
   "Given an arrival with 100 pax " >> {
 
     val arrival = ArrivalGenerator.arrival("BA0001", actPax = Option(100), schDt = s"2021-06-01T12:00", origin = PortCode("JFK"), feedSources = Set(LiveFeedSource),
-      totalPax = Set(TotalPaxSource(100, LiveFeedSource, None)))
+      totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource)))
 
     "When I provide no live and no historic manifests, terminal splits should be applied (50% desk, 50% egates)" >> {
       val expected: Map[(Terminal, Queue), Int] = Map((T1, EGate) -> 50, (T1, EeaDesk) -> 50)

--- a/server/src/test/scala/services/crunch/deskrecs/RunnableDeskRecsSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/RunnableDeskRecsSpec.scala
@@ -173,7 +173,7 @@ class RunnableDeskRecsSpec extends CrunchTestLike {
     "Then I should see the workload associated with the best splits for that flight" >> {
     val scheduled = "2019-10-10T23:05:00Z"
     val arrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = scheduled, actPax = Option(25), feedSources = Set(LiveFeedSource),
-      totalPax = Set(TotalPaxSource(25, LiveFeedSource, None)))
+      totalPax = Set(TotalPaxSource(Option(25), LiveFeedSource)))
 
     val flight = List(ApiFlightWithSplits(arrival, Set(historicSplits), None))
 
@@ -208,7 +208,7 @@ class RunnableDeskRecsSpec extends CrunchTestLike {
     "Then I should see the workload associated with the best splits for that flight" >> {
     val scheduled = "2019-10-10T23:05:00Z"
     val arrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = scheduled, actPax = Option(75), tranPax = Option(50), feedSources = Set(LiveFeedSource),
-      totalPax = Set(TotalPaxSource(75 - 50, LiveFeedSource, None)))
+      totalPax = Set(TotalPaxSource(Option(75), LiveFeedSource)))
 
     val flight = List(ApiFlightWithSplits(arrival, Set(historicSplits), None))
 
@@ -245,9 +245,9 @@ class RunnableDeskRecsSpec extends CrunchTestLike {
     val scheduled = "2018-01-01T00:05"
     val scheduled2 = "2018-01-01T00:06"
     val arrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = scheduled, actPax = Option(25), feedSources = Set(LiveFeedSource),
-      totalPax = Set(TotalPaxSource(25, LiveFeedSource, None)))
+      totalPax = Set(TotalPaxSource(Option(25), LiveFeedSource)))
     val arrival2 = ArrivalGenerator.arrival(iata = "BA0002", schDt = scheduled2, actPax = Option(25), feedSources = Set(LiveFeedSource),
-      totalPax = Set(TotalPaxSource(25, LiveFeedSource, None)))
+      totalPax = Set(TotalPaxSource(Option(25), LiveFeedSource)))
 
     val flight = List(ApiFlightWithSplits(arrival, Set(historicSplits), None), ApiFlightWithSplits(arrival2, Set(historicSplits), None))
 
@@ -292,7 +292,7 @@ class RunnableDeskRecsSpec extends CrunchTestLike {
     val pcpOne = "2018-01-01T00:15"
     val pcpUpdated = "2018-01-01T00:05"
     val arrival = ArrivalGenerator.arrival(iata = "BA0001", schDt = pcpOne, actPax = Option(25), feedSources = Set(LiveFeedSource),
-      totalPax = Set(TotalPaxSource(25, LiveFeedSource, None)))
+      totalPax = Set(TotalPaxSource(Option(25), LiveFeedSource)))
 
     val historicSplits = Splits(
       Set(ApiPaxTypeAndQueueCount(EeaMachineReadable, Queues.EeaDesk, 100, None, None)),

--- a/server/src/test/scala/services/crunch/workload/WorkloadSpec.scala
+++ b/server/src/test/scala/services/crunch/workload/WorkloadSpec.scala
@@ -47,7 +47,7 @@ class WorkloadSpec extends CrunchTestLike {
     "When I ask for the workload for this arrival " +
     "Then I see the 1x the proc time provided" >> {
 
-    val arrival = ArrivalGenerator.arrival(actPax = Option(1), totalPax = Set(TotalPaxSource(1, AclFeedSource, None)))
+    val arrival = ArrivalGenerator.arrival(actPax = Option(1), totalPax = Set(TotalPaxSource(Option(1), AclFeedSource)))
     val splits = generateSplits(1, SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages, Option(EventTypes.DC))
 
     val workloads = workloadForFlight(arrival, splits, FlightFilter.regular(List(T1)))
@@ -56,7 +56,7 @@ class WorkloadSpec extends CrunchTestLike {
   }
 
   "Given an arrival with a PCP time that has seconds, then these seconds should be ignored for workload calcs" >> {
-    val arrival = ArrivalGenerator.arrival(actPax = Option(1),totalPax = Set(TotalPaxSource(1, AclFeedSource, None)))
+    val arrival = ArrivalGenerator.arrival(actPax = Option(1),totalPax = Set(TotalPaxSource(Option(1), AclFeedSource)))
       .copy(PcpTime = Some(SDate("2018-08-28T17:07:05").millisSinceEpoch))
 
     val splits = generateSplits(1, SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages, Option(EventTypes.DC))
@@ -74,7 +74,7 @@ class WorkloadSpec extends CrunchTestLike {
     "When I ask for the workload for this arrival " +
     "Then I see the 6x the proc time provided" >> {
 
-    val arrival = ArrivalGenerator.arrival(actPax = None, apiPax = Option(6),totalPax = Set(TotalPaxSource(6, ApiFeedSource, None)))
+    val arrival = ArrivalGenerator.arrival(actPax = None, apiPax = Option(6),totalPax = Set(TotalPaxSource(Option(6), ApiFeedSource)))
     val splits = generateSplits(6, SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages, Option(EventTypes.DC))
     val workloads = workloadForFlight(arrival, splits, FlightFilter.regular(List(T1)))
 
@@ -85,7 +85,7 @@ class WorkloadSpec extends CrunchTestLike {
     "When I ask for the workload for this arrival " +
     "Then I see the 1x the proc time provided" >> {
 
-    val arrival = ArrivalGenerator.arrival(actPax = Option(1), apiPax = Option(6), feedSources = Set(LiveFeedSource), totalPax = Set(TotalPaxSource(1, LiveFeedSource, None)))
+    val arrival = ArrivalGenerator.arrival(actPax = Option(1), apiPax = Option(6), feedSources = Set(LiveFeedSource), totalPax = Set(TotalPaxSource(Option(1), LiveFeedSource)))
     val splits = generateSplits(6, SplitSources.Historical, None)
     val workloads = workloadForFlight(arrival, splits, FlightFilter.regular(List(T1)))
 
@@ -121,7 +121,7 @@ class WorkloadSpec extends CrunchTestLike {
   }
 
   def workloadForFlightFromTo(origin: PortCode, config: AirportConfig, terminal: Terminal, paxCount: Int): Double = {
-    val arrival = ArrivalGenerator.arrival(schDt = "2021-06-01T12:00", actPax = Option(paxCount), terminal = terminal, origin = origin, totalPax = Set(TotalPaxSource(paxCount, AclFeedSource, None)))
+    val arrival = ArrivalGenerator.arrival(schDt = "2021-06-01T12:00", actPax = Option(paxCount), terminal = terminal, origin = origin, totalPax = Set(TotalPaxSource(Option(paxCount), AclFeedSource)))
     val splits = generateSplits(paxCount, SplitSources.Historical, None)
     workloadForFlight(arrival, splits, FlightFilter.forPortConfig(config))
   }

--- a/server/src/test/scala/services/export/StreamingFlightsExportSpec.scala
+++ b/server/src/test/scala/services/export/StreamingFlightsExportSpec.scala
@@ -34,7 +34,7 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
       status = ArrivalStatus("UNK"),
       estDt = "2017-01-01T20:00:00Z",
       feedSources = Set(LiveFeedSource),
-      totalPax = Set(TotalPaxSource(98, LiveFeedSource, None), TotalPaxSource(100, ApiFeedSource, None))
+      totalPax = Set(TotalPaxSource(Option(98), LiveFeedSource), TotalPaxSource(Option(100), ApiFeedSource))
     ),
     Set(Splits(
       Set(
@@ -72,7 +72,7 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
       status = ArrivalStatus("UNK"),
       estDt = "2017-01-01T20:00:00Z",
       feedSources = Set(LiveFeedSource),
-      totalPax = Set(TotalPaxSource(100, LiveFeedSource, None))
+      totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource))
     ),
     Set(Splits(
       Set(
@@ -109,7 +109,7 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
       status = ArrivalStatus("UNK"),
       estDt = "2017-01-01T20:00:00Z",
       feedSources = Set(LiveFeedSource),
-      totalPax = Set(TotalPaxSource(100, LiveFeedSource, None))
+      totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource))
     ),
     Set(Splits(
       Set(
@@ -135,7 +135,7 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
         operator = Option(Operator("SA")),
         status = ArrivalStatus("UNK"),
         estDt = "2017-01-01T20:00:00Z",
-        totalPax = Set(TotalPaxSource(100, AclFeedSource, None))
+        totalPax = Set(TotalPaxSource(Option(100), AclFeedSource))
       ),
 
       Set(Splits(
@@ -164,7 +164,7 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
         status = ArrivalStatus("UNK"),
         estDt = "2017-01-01T20:00:00Z",
         feedSources = Set(LiveFeedSource),
-        totalPax = Set(TotalPaxSource(100, LiveFeedSource, None))
+        totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource))
       ),
       Set(Splits(
         Set(
@@ -192,7 +192,7 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
         status = ArrivalStatus("UNK"),
         estDt = "2017-01-01T20:00:00Z",
         feedSources = Set(LiveFeedSource),
-        totalPax = Set(TotalPaxSource(105, LiveFeedSource, None))
+        totalPax = Set(TotalPaxSource(Option(105), LiveFeedSource))
       ),
       Set(Splits(
         Set(
@@ -407,26 +407,26 @@ class StreamingFlightsExportSpec extends CrunchTestLike {
   }
 
   "Given a flight with API pax count within the 5% threshold of the feed pax count, and no live feed, then the 'Invalid API' column should be blank" >> {
-    invalidApiFieldValue(actPax = 100, apiPax = 98, feedSources = Set(AclFeedSource),totalPax = Set(TotalPaxSource(100,AclFeedSource,None),
-      TotalPaxSource(98,ApiFeedSource,None))) === ""
+    invalidApiFieldValue(actPax = 100, apiPax = 98, feedSources = Set(AclFeedSource), totalPax = Set(TotalPaxSource(Option(100), AclFeedSource),
+      TotalPaxSource(Option(98), ApiFeedSource))) === ""
   }
 
   "Given a flight with API pax count within the 5% threshold of the feed pax count, with a live feed, then the 'Invalid API' column should be blank" >> {
-    invalidApiFieldValue(actPax = 100, apiPax = 98, feedSources = Set(LiveFeedSource, AclFeedSource),totalPax = Set(TotalPaxSource(100,LiveFeedSource,None),
-      TotalPaxSource(75,ApiFeedSource,None))) === ""
+    invalidApiFieldValue(actPax = 100, apiPax = 98, feedSources = Set(LiveFeedSource, AclFeedSource), totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource),
+      TotalPaxSource(Option(75), ApiFeedSource))) === ""
   }
 
   "Given a flight with API pax count outside the 5% threshold of the feed pax count, but with no live feed, then the 'Invalid API' column should be blank" >> {
-    invalidApiFieldValue(actPax = 100, apiPax = 75, feedSources = Set(AclFeedSource),totalPax = Set(TotalPaxSource(100,LiveFeedSource,None))) === ""
+    invalidApiFieldValue(actPax = 100, apiPax = 75, feedSources = Set(AclFeedSource), totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource))) === ""
   }
 
   "Given a flight with API pax count outside the 5% threshold of the feed pax count, with a live feed, then the 'Invalid API' column should be 'Y'" >> {
-    invalidApiFieldValue(actPax = 100, apiPax = 75, feedSources = Set(LiveFeedSource, AclFeedSource) ,totalPax = Set(TotalPaxSource(100,LiveFeedSource,None),
-      TotalPaxSource(75,ApiFeedSource,None))) === "Y"
+    invalidApiFieldValue(actPax = 100, apiPax = 75, feedSources = Set(LiveFeedSource, AclFeedSource), totalPax = Set(TotalPaxSource(Option(100), LiveFeedSource),
+      TotalPaxSource(Option(75), ApiFeedSource))) === "Y"
   }
 
-  private def invalidApiFieldValue(actPax: Int, apiPax: Int, feedSources: Set[FeedSource], totalPax :Set[TotalPaxSource]): String = {
-    val arrival = ArrivalGenerator.arrival(actPax = Option(actPax), feedSources = feedSources ,totalPax = totalPax)
+  private def invalidApiFieldValue(actPax: Int, apiPax: Int, feedSources: Set[FeedSource], totalPax: Set[TotalPaxSource]): String = {
+    val arrival = ArrivalGenerator.arrival(actPax = Option(actPax), feedSources = feedSources, totalPax = totalPax)
     val splits = Splits(Set(ApiPaxTypeAndQueueCount(PaxTypes.EeaMachineReadable, Queues.EGate, apiPax, None, None)),
       SplitRatiosNs.SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages, Option(EventTypes.DC))
     val fws = ApiFlightWithSplits(arrival, Set(splits))

--- a/server/src/test/scala/services/graphstages/ArrivalsGraphStagePaxNosSpec.scala
+++ b/server/src/test/scala/services/graphstages/ArrivalsGraphStagePaxNosSpec.scala
@@ -9,7 +9,7 @@ import org.specs2.execute.Success
 import server.feeds.{ArrivalsFeedResponse, ArrivalsFeedSuccess}
 import services.SDate
 import services.crunch.{CrunchTestLike, TestConfig}
-import uk.gov.homeoffice.drt.arrivals.ArrivalStatus
+import uk.gov.homeoffice.drt.arrivals.{ArrivalStatus, TotalPaxSource}
 import uk.gov.homeoffice.drt.ports.{AclFeedSource, FeedSource, LiveFeedSource}
 
 import scala.concurrent.duration._
@@ -142,11 +142,11 @@ class ArrivalsGraphStagePaxNosSpec extends CrunchTestLike {
     }
 
     "Given an arrival with a zero pax, undefined trans pax, and max pax of 100" >> {
-      val arrival = ArrivalGenerator.arrival(actPax = Option(0), tranPax = None, maxPax = Option(100))
+      val arrival = ArrivalGenerator.arrival(actPax = Option(0), tranPax = None, maxPax = Option(100), totalPax = Set(TotalPaxSource(Option(0), AclFeedSource)))
       "When I ask for the best pax" >> {
         val bestPax = arrival.bestPcpPaxEstimate.pax
         "I should see 0" >> {
-          bestPax === 0
+          bestPax === Some(0)
         }
       }
     }

--- a/server/src/test/scala/services/simulations/SimulationParamsSpec.scala
+++ b/server/src/test/scala/services/simulations/SimulationParamsSpec.scala
@@ -127,7 +127,7 @@ class SimulationParamsSpec extends Specification {
     val weightingOfOne = simulation.copy(passengerWeighting = 1.0)
 
     val flightWithSplits = ApiFlightWithSplits(ArrivalGenerator.arrival(actPax = Option(100), tranPax = Option(50),
-      totalPax = Set(TotalPaxSource(100,ScenarioSimulationSource,None))), Set())
+      totalPax = Set(TotalPaxSource(Option(100),ScenarioSimulationSource))), Set())
     val flights = FlightsWithSplits(List(
       flightWithSplits
     ).map(a => a.apiFlight.unique -> a).toMap)
@@ -156,7 +156,7 @@ class SimulationParamsSpec extends Specification {
     ).map(a => a.apiFlight.unique -> a).toMap)
 
     val flightWithSplits = ApiFlightWithSplits(ArrivalGenerator.arrival(actPax = Option(200), tranPax = Option(100),
-      totalPax = Set(TotalPaxSource(200,ScenarioSimulationSource,None))),Set())
+      totalPax = Set(TotalPaxSource(Option(200),ScenarioSimulationSource))),Set())
     val result = weightingOfTwo.applyPassengerWeighting(fws)
 
     result.flights.values.head.apiFlight.bestPcpPaxEstimate === flightWithSplits.apiFlight.bestPcpPaxEstimate

--- a/shared/src/main/scala/drt/shared/FlightApi.scala
+++ b/shared/src/main/scala/drt/shared/FlightApi.scala
@@ -112,7 +112,7 @@ object FlightsApi {
                         ApiPax = Option(totalPax),
                         FeedSources = fws.apiFlight.FeedSources + ApiFeedSource,
                         TotalPax = fws.apiFlight.TotalPax ++
-                          Set(TotalPaxSource(totalPax, ApiFeedSource, Option(ApiSplitsWithHistoricalEGateAndFTPercentages))))
+                          Set(TotalPaxSource(Some(totalPax), ApiFeedSource)))
                   }
 
                   fws.copy(apiFlight = updatedArrival, splits = mergedSplits, lastUpdated = Option(nowMillis))

--- a/shared/src/main/scala/drt/shared/SimulationParams.scala
+++ b/shared/src/main/scala/drt/shared/SimulationParams.scala
@@ -59,7 +59,7 @@ case class SimulationParams(
             ActPax = actualPax,
             TranPax = tranPax,
             FeedSources = fws.apiFlight.FeedSources + ScenarioSimulationSource,
-            TotalPax = Set(TotalPaxSource(actualPax.getOrElse(0), ScenarioSimulationSource, None))
+            TotalPax = Set(TotalPaxSource(actualPax, ScenarioSimulationSource))
           ))
     })
 }

--- a/shared/src/main/scala/drt/shared/splits/ApiSplitsToSplitRatio.scala
+++ b/shared/src/main/scala/drt/shared/splits/ApiSplitsToSplitRatio.scala
@@ -26,7 +26,7 @@ object ApiSplitsToSplitRatio {
 
   def flightPaxPerQueueUsingSplitsAsRatio(splits: Splits, fws: ApiFlightWithSplits): Map[Queue, Int] =
     queueTotals(
-      applyPaxSplitsToFlightPax(splits, fws.pcpPaxEstimate.pax)
+      applyPaxSplitsToFlightPax(splits, fws.pcpPaxEstimate.pax.getOrElse(0))
         .splits
         .map(ptqc => PaxTypeAndQueue(ptqc.passengerType, ptqc.queueType) -> ptqc.paxCount.toInt)
         .toMap


### PR DESCRIPTION
- Removing splitSource from TotalPaxSource and replacing with HistoricApiFeedSource
- making pax optional in TotalPaxSource so None is allowed to be display as `n/a` on arrivals 
