### PR TITLE
Drtii 1037 resolve single queue desk rec errors

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -70,7 +70,7 @@ object Settings {
     val openSaml = "2.6.1"
     val drtBirminghamSchema = "1.2.0"
     val drtCirium = "186"
-    val drtLib = "v256"
+    val drtLib = "v258"
     val playJson = "2.6.0"
     val playIteratees = "2.6.1"
     val uPickle = "2.0.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -70,7 +70,7 @@ object Settings {
     val openSaml = "2.6.1"
     val drtBirminghamSchema = "1.2.0"
     val drtCirium = "186"
-    val drtLib = "v252"
+    val drtLib = "v256"
     val playJson = "2.6.0"
     val playIteratees = "2.6.1"
     val uPickle = "2.0.0"

--- a/server/src/main/scala/queueus/DynamicQueueStatusProvider.scala
+++ b/server/src/main/scala/queueus/DynamicQueueStatusProvider.scala
@@ -16,10 +16,10 @@ case class DynamicQueueStatusProvider(airportConfig: AirportConfig, egatesProvid
   def allStatusesForPeriod: NumericRange[MillisSinceEpoch] => Future[Map[Terminal, Map[Queue, Map[MillisSinceEpoch, QueueStatus]]]] =
     period => {
       egatesProvider().map { egatePortUpdates =>
-        airportConfig.queuesByTerminal.map { case (terminal, queues) =>
+        airportConfig.queuesByTerminalWithDiversions.map { case (terminal, queues) =>
           val byQueue = queues.map {
-            case EGate => (EGate, egateStatuses(period, egatePortUpdates, terminal))
-            case queue => (queue, deskStatuses(airportConfig.maxDesksByTerminalAndQueue24Hrs, period, terminal, queue))
+            case (EGate, _) => (EGate, egateStatuses(period, egatePortUpdates, terminal))
+            case (from, to) => (from, deskStatuses(airportConfig.maxDesksByTerminalAndQueue24Hrs, period, terminal, to))
           }.toMap
           (terminal, byQueue)
         }


### PR DESCRIPTION
Use new `queuesByTerminalWithDiversions` function to get correct queue status for diverted queues