### PR TITLE
Drtii 1043 crunch queue gets stuck on current day

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -70,7 +70,7 @@ object Settings {
     val openSaml = "2.6.1"
     val drtBirminghamSchema = "1.2.0"
     val drtCirium = "186"
-    val drtLib = "v273"
+    val drtLib = "v275"
     val playJson = "2.6.0"
     val playIteratees = "2.6.1"
     val uPickle = "2.0.0"

--- a/server/src/main/resources/config/akka.conf
+++ b/server/src/main/resources/config/akka.conf
@@ -9,6 +9,10 @@ akka {
     client.parsing.illegal-header-warnings = off
     client.parsing.max-content-length = 32m
   }
+  stream.materializer {
+    initial-input-buffer-size = 1
+    max-input-buffer-size = 1
+  }
   actor {
     allow-java-serialization = off
     serializers {

--- a/server/src/main/scala/actors/persistent/SortedActorRefSource.scala
+++ b/server/src/main/scala/actors/persistent/SortedActorRefSource.scala
@@ -67,6 +67,7 @@ final class SortedActorRefSource(persistentActor: ActorRef, crunchOffsetMinutes:
 
       setHandler(out, new OutHandler {
         override def onPull(): Unit = {
+          log.info(s"SortedActorRefSource Pulled (with ${buffer.size} elements). isAvailable: ${isAvailable(out)}")
           tryPushElement()
         }
       })

--- a/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeskRecs.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeskRecs.scala
@@ -183,7 +183,7 @@ object DynamicRunnableDeskRecs {
       .mapAsync(1) { case (cr, flights) =>
         val startTime = SDate.now()
         Source(flights)
-          .mapAsync(10) { flight =>
+          .mapAsync(1) { flight =>
             if (!flight.apiFlight.FeedSources.contains(ApiFeedSource)) {
               historicManifestsPaxProvider(flight.apiFlight).map {
                 case Some(manifestPaxLike: ManifestPaxCount) =>

--- a/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeskRecs.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeskRecs.scala
@@ -23,7 +23,7 @@ import uk.gov.homeoffice.drt.arrivals.{ApiFlightWithSplits, Arrival, TotalPaxSou
 import uk.gov.homeoffice.drt.ports.Queues.{Closed, Queue, QueueStatus}
 import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.ApiSplitsWithHistoricalEGateAndFTPercentages
 import uk.gov.homeoffice.drt.ports.Terminals.Terminal
-import uk.gov.homeoffice.drt.ports.{ApiFeedSource, HistoricApiFeedSource, LiveFeedSource}
+import uk.gov.homeoffice.drt.ports.{AclFeedSource, ApiFeedSource, ForecastFeedSource, HistoricApiFeedSource, LiveFeedSource}
 import uk.gov.homeoffice.drt.redlist.RedListUpdates
 
 import scala.collection.immutable.{Map, NumericRange}
@@ -208,11 +208,7 @@ object DynamicRunnableDeskRecs {
           }
       }
 
-  private def noReliablePax(f: ApiFlightWithSplits): Boolean =
-    !f.apiFlight.TotalPax.exists(tp => {
-      val sources = List(ApiFeedSource, HistoricApiFeedSource, LiveFeedSource)
-      sources.contains(tp.feedSource)
-    })
+  private def noReliablePax(f: ApiFlightWithSplits): Boolean = f.apiFlight.TotalPax.isEmpty
 
   def addSplits(liveManifestsProvider: ProcessingRequest => Future[Source[VoyageManifests, NotUsed]],
                 historicManifestsProvider: Iterable[Arrival] => Source[ManifestLike, NotUsed],

--- a/server/src/main/scala/services/crunch/deskrecs/RunnableOptimisation.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/RunnableOptimisation.scala
@@ -6,7 +6,7 @@ import akka.NotUsed
 import akka.actor.{ActorRef, ActorSystem}
 import akka.stream.scaladsl.GraphDSL.Implicits.SourceShapeArrow
 import akka.stream.scaladsl.{Flow, GraphDSL, RunnableGraph, Sink}
-import akka.stream.{ClosedShape, KillSwitches, UniqueKillSwitch}
+import akka.stream.{Attributes, ClosedShape, KillSwitches, UniqueKillSwitch}
 import drt.shared.CrunchApi.MillisSinceEpoch
 import drt.shared.PortStateMinutes
 import org.slf4j.{Logger, LoggerFactory}
@@ -71,5 +71,6 @@ object RunnableOptimisation {
     RunnableGraph
       .fromGraph(graph)
       .withAttributes(StreamSupervision.resumeStrategyWithLog(getClass.getName))
+      .withAttributes(Attributes.inputBuffer(initial = 1, max = 1))
   }
 }

--- a/server/src/main/scala/services/crunch/deskrecs/RunnableOptimisation.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/RunnableOptimisation.scala
@@ -64,13 +64,12 @@ object RunnableOptimisation {
     val graph = GraphDSL.create(crunchRequestSource, ks)((_, _)) {
       implicit builder =>
         (crunchRequests, killSwitch) =>
-          crunchRequests ~> crunchRequestsToQueueMinutes.withAttributes(Attributes.inputBuffer(initial = 1, max = 1)) ~> killSwitch ~> deskRecsSink
+          crunchRequests ~> crunchRequestsToQueueMinutes ~> killSwitch ~> deskRecsSink
           ClosedShape
     }
 
     RunnableGraph
       .fromGraph(graph)
       .withAttributes(StreamSupervision.resumeStrategyWithLog(getClass.getName))
-      .withAttributes(Attributes.inputBuffer(initial = 1, max = 1))
   }
 }

--- a/server/src/main/scala/services/crunch/deskrecs/RunnableOptimisation.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/RunnableOptimisation.scala
@@ -64,7 +64,7 @@ object RunnableOptimisation {
     val graph = GraphDSL.create(crunchRequestSource, ks)((_, _)) {
       implicit builder =>
         (crunchRequests, killSwitch) =>
-          crunchRequests ~> crunchRequestsToQueueMinutes ~> killSwitch ~> deskRecsSink
+          crunchRequests ~> crunchRequestsToQueueMinutes.withAttributes(Attributes.inputBuffer(initial = 1, max = 1)) ~> killSwitch ~> deskRecsSink
           ClosedShape
     }
 

--- a/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeskRecsSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeskRecsSpec.scala
@@ -58,7 +58,8 @@ object OptimiserMocks {
     }
   }
 
-  def getMockManifestLookupService(arrivalsWithMaybePax: Map[Arrival, Option[List[PassengerInfoJson]]], portCode: PortCode)(implicit ec: ExecutionContext, mat: Materializer): MockManifestLookupService =
+  def getMockManifestLookupService(arrivalsWithMaybePax: Map[Arrival, Option[List[PassengerInfoJson]]], portCode: PortCode)
+                                  (implicit mat: Materializer): MockManifestLookupService =
     MockManifestLookupService(arrivalsWithMaybePax.map { case (arrival, maybePax) =>
       val key = UniqueArrivalKey(portCode, arrival.Origin, arrival.VoyageNumber, SDate(arrival.Scheduled))
       val maybeManifest = maybePax.map(pax => BestAvailableManifest.historic(VoyageManifestGenerator.manifestForArrival(arrival, pax)))
@@ -69,25 +70,23 @@ object OptimiserMocks {
       (key, maybeManifest)
     }, portCode)
 
-  def mockFlightsProvider(arrivals: List[Arrival])
-                         (implicit ec: ExecutionContext): ProcessingRequest => Future[Source[List[ApiFlightWithSplits], NotUsed]] =
+  def mockFlightsProvider(arrivals: List[Arrival]): ProcessingRequest => Future[Source[List[ApiFlightWithSplits], NotUsed]] =
     _ => Future.successful(Source(List(arrivals.map(a => ApiFlightWithSplits(a, Set())))))
 
 
-  def mockLiveManifestsProviderNoop(implicit ec: ExecutionContext): ProcessingRequest => Future[Source[VoyageManifests, NotUsed]] = {
+  def mockLiveManifestsProviderNoop: ProcessingRequest => Future[Source[VoyageManifests, NotUsed]] = {
     _ => Future.successful(Source(List()))
   }
 
-  def mockHistoricManifestsProviderNoop(implicit ec: ExecutionContext): HistoricManifestsProvider = {
+  def mockHistoricManifestsProviderNoop: HistoricManifestsProvider = {
     _: Iterable[Arrival] => Source(List())
   }
 
-  def mockHistoricManifestsPaxProviderNoop(implicit ec: ExecutionContext): HistoricManifestsPaxProvider = {
+  def mockHistoricManifestsPaxProviderNoop: HistoricManifestsPaxProvider = {
     _: Arrival => Future.successful(None)
   }
 
-  def mockLiveManifestsProvider(arrival: Arrival, maybePax: Option[List[PassengerInfoJson]])
-                               (implicit ec: ExecutionContext): ProcessingRequest => Future[Source[VoyageManifests, NotUsed]] = {
+  def mockLiveManifestsProvider(arrival: Arrival, maybePax: Option[List[PassengerInfoJson]]): ProcessingRequest => Future[Source[VoyageManifests, NotUsed]] = {
     val manifests = maybePax match {
       case Some(pax) => VoyageManifests(Set(manifestForArrival(arrival, pax)))
       case None => VoyageManifests(Set())
@@ -231,19 +230,12 @@ class RunnableDynamicDeskRecsSpec extends CrunchTestLike {
     }
 
     "add historic API pax" >> {
-      "When I have ACL pax number I should get some pax from historic API" >> {
-        val arrival = ArrivalGenerator.arrival(actPax = Option(100), origin = PortCode("JFK"), feedSources = Set(AclFeedSource),
-          totalPax = Set(TotalPaxSource(Option(100), AclFeedSource)))
-        checkPaxSource(arrival, Map(arrival -> Option(xOfPaxType(10, visa))), Set(TotalPaxSource(Option(100), AclFeedSource),
-          TotalPaxSource(Option(10), HistoricApiFeedSource)))
-      }
-
-      "When I have ForecastPortFeed pax number I should get some pax from historic API" >> {
-        val arrival = ArrivalGenerator.arrival(actPax = Option(100), origin = PortCode("JFK"), feedSources = Set(ForecastFeedSource),
-          totalPax = Set(TotalPaxSource(Option(100), ForecastFeedSource)))
-        checkPaxSource(arrival, Map(arrival -> Option(xOfPaxType(10, visa))), Set(TotalPaxSource(Option(100), ForecastFeedSource),
-          TotalPaxSource(Option(10), HistoricApiFeedSource)))
-      }
+//      "When I have ACL pax number I should get some pax from historic API" >> {
+//        val arrival = ArrivalGenerator.arrival(actPax = Option(100), origin = PortCode("JFK"), feedSources = Set(AclFeedSource),
+//          totalPax = Set(TotalPaxSource(Option(100), AclFeedSource)))
+//        checkPaxSource(arrival, Map(arrival -> Option(xOfPaxType(10, visa))), Set(TotalPaxSource(Option(100), AclFeedSource),
+//          TotalPaxSource(Option(10), HistoricApiFeedSource)))
+//      }
 
       "When I have no Feed I should get some pax from historic API" >> {
         val arrival = ArrivalGenerator.arrival(actPax = Option(100), origin = PortCode("JFK"), feedSources = Set(),

--- a/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeskRecsSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeskRecsSpec.scala
@@ -231,11 +231,6 @@ class RunnableDynamicDeskRecsSpec extends CrunchTestLike {
     }
 
     "add historic API pax" >> {
-      "When I have live manifests matching the arrival where the live manifest is within the trust threshold I should get some pax from historic API" >> {
-        checkPaxSource(arrival, Map(arrival -> Option(xOfPaxType(10, visa))), Set(TotalPaxSource(Option(100), LiveFeedSource),
-          TotalPaxSource(Option(10), HistoricApiFeedSource)))
-      }
-
       "When I have ACL pax number I should get some pax from historic API" >> {
         val arrival = ArrivalGenerator.arrival(actPax = Option(100), origin = PortCode("JFK"), feedSources = Set(AclFeedSource),
           totalPax = Set(TotalPaxSource(Option(100), AclFeedSource)))


### PR DESCRIPTION
Fix historic pax from API requests so they're only made when there are no other sources of passengers
Currently requests are made even when we have better sources of pax numbers
We may want to reintroduce them when we only have an ACL source, but for now the queries are too expensive and slow the crunch to a crawl - one day at LHR was taking around 20 minutes rather than a few seconds