### PR TITLE
Drtii 1160 missing misc staff in lhr recommendations

### DIFF
--- a/server/src/main/scala/actors/DrtSystemInterface.scala
+++ b/server/src/main/scala/actors/DrtSystemInterface.scala
@@ -315,7 +315,7 @@ trait DrtSystemInterface extends UserRoleProviderLike {
       val delayUntilTomorrow = (SDate.now().getLocalNextMidnight.millisSinceEpoch - SDate.now().millisSinceEpoch) + MilliTimes.oneHourMillis
       log.info(s"Scheduling next day staff calculations to begin at ${delayUntilTomorrow / 1000}s -> ${SDate.now().addMillis(delayUntilTomorrow).toISOString()}")
 
-      val staffChecker = StaffMinutesChecker(staffRouterActor, staffingUpdateRequestQueue, params.forecastMaxDays, airportConfig)
+      val staffChecker = StaffMinutesChecker(now, staffingUpdateRequestQueue, params.forecastMaxDays, airportConfig)
 
       staffChecker.calculateForecastStaffMinutes()
       system.scheduler.scheduleAtFixedRate(delayUntilTomorrow.millis, 1.day)(() => staffChecker.calculateForecastStaffMinutes())

--- a/server/src/main/scala/services/staffing/StaffMinutesChecker.scala
+++ b/server/src/main/scala/services/staffing/StaffMinutesChecker.scala
@@ -1,19 +1,16 @@
 package services.staffing
 
-import actors.PartitionedPortStateActor.GetMinutesForTerminalDateRange
 import akka.actor.ActorRef
-import akka.pattern.ask
 import akka.util.Timeout
-import drt.shared.CrunchApi.{MinutesContainer, StaffMinute}
-import drt.shared.TM
 import org.slf4j.LoggerFactory
 import services.crunch.deskrecs.RunnableOptimisation.TerminalUpdateRequest
 import uk.gov.homeoffice.drt.ports.AirportConfig
-import uk.gov.homeoffice.drt.time.SDate
+import uk.gov.homeoffice.drt.ports.Terminals.Terminal
+import uk.gov.homeoffice.drt.time.SDateLike
 
 import scala.concurrent.ExecutionContext
 
-case class StaffMinutesChecker(staffActor: ActorRef,
+case class StaffMinutesChecker(now: () => SDateLike,
                                staffingUpdateRequestQueue: ActorRef,
                                forecastMaxDays: Int,
                                airportConfig: AirportConfig)
@@ -21,20 +18,12 @@ case class StaffMinutesChecker(staffActor: ActorRef,
   private val log = LoggerFactory.getLogger(getClass)
 
   def calculateForecastStaffMinutes(): Unit = {
-    (1 to forecastMaxDays).foreach { daysInFuture =>
-      val date = SDate(SDate.now().addDays(daysInFuture).toUtcDate)
-      val end = date.addDays(1).addMinutes(-1)
-      airportConfig.terminals.foreach { terminal =>
-        staffActor
-          .ask(GetMinutesForTerminalDateRange(date.millisSinceEpoch, end.millisSinceEpoch, terminal))
-          .mapTo[MinutesContainer[StaffMinute, TM]]
-          .map { container =>
-            if (container.minutes.isEmpty) {
-              log.info(s"Requesting staff minutes calculation for ${date.toLocalDate}")
-              val request = TerminalUpdateRequest(terminal, date.toLocalDate, airportConfig.crunchOffsetMinutes, airportConfig.minutesToCrunch)
-              staffingUpdateRequestQueue ! request
-            }
-          }
+    (forecastMaxDays - 2 until forecastMaxDays).foreach { daysInFuture =>
+      val date = now().addDays(daysInFuture).toLocalDate
+      airportConfig.terminals.foreach { terminal: Terminal =>
+        log.info(s"Requesting staff minutes calculation for $terminal on $date")
+        val request = TerminalUpdateRequest(terminal, date, airportConfig.crunchOffsetMinutes, airportConfig.minutesToCrunch)
+        staffingUpdateRequestQueue ! request
       }
     }
   }

--- a/server/src/test/scala/services/crunch/CrunchGraphInputsAndProbes.scala
+++ b/server/src/test/scala/services/crunch/CrunchGraphInputsAndProbes.scala
@@ -20,7 +20,11 @@ case class CrunchGraphInputsAndProbes(aclArrivalsInput: SourceQueueWithComplete[
                                       forecastArrivalsTestProbe: TestProbe,
                                       liveArrivalsTestProbe: TestProbe,
                                       aggregatedArrivalsActor: ActorRef,
-                                      portStateActor: ActorRef) {
+                                      portStateActor: ActorRef,
+                                      staffActor: ActorRef,
+                                      shiftsActor: ActorRef,
+                                      fixedPointsActor: ActorRef,
+                                      staffMovementsActor: ActorRef) {
   def shutdown(): Unit = {
     aclArrivalsInput.complete()
     forecastArrivalsInput.complete()

--- a/server/src/test/scala/services/crunch/CrunchGraphInputsAndProbes.scala
+++ b/server/src/test/scala/services/crunch/CrunchGraphInputsAndProbes.scala
@@ -21,10 +21,7 @@ case class CrunchGraphInputsAndProbes(aclArrivalsInput: SourceQueueWithComplete[
                                       liveArrivalsTestProbe: TestProbe,
                                       aggregatedArrivalsActor: ActorRef,
                                       portStateActor: ActorRef,
-                                      staffActor: ActorRef,
-                                      shiftsActor: ActorRef,
-                                      fixedPointsActor: ActorRef,
-                                      staffMovementsActor: ActorRef) {
+                                     ) {
   def shutdown(): Unit = {
     aclArrivalsInput.complete()
     forecastArrivalsInput.complete()

--- a/server/src/test/scala/services/crunch/CrunchTestLike.scala
+++ b/server/src/test/scala/services/crunch/CrunchTestLike.scala
@@ -426,7 +426,6 @@ class CrunchTestLike
     source ! offering
   }
 
-  def offerAndWait[T](source: ActorRef, offering: T): Unit = {
-    source ! offering
-  }
+  def offerAndWait[T](source: ActorRef, offering: T): Unit =
+    Await.ready(source.ask(offering), 1.second)
 }

--- a/server/src/test/scala/services/crunch/TestDrtActor.scala
+++ b/server/src/test/scala/services/crunch/TestDrtActor.scala
@@ -313,7 +313,11 @@ class TestDrtActor extends Actor {
         forecastArrivalsTestProbe = forecastArrivalsProbe,
         liveArrivalsTestProbe = liveArrivalsProbe,
         aggregatedArrivalsActor = aggregatedArrivalsActor,
-        portStateActor = portStateActor
+        portStateActor = portStateActor,
+        staffActor = staffActor,
+        shiftsActor = shiftsActor,
+        fixedPointsActor = fixedPointsActor,
+        staffMovementsActor = staffMovementsActor
       )
   }
 }

--- a/server/src/test/scala/services/crunch/TestDrtActor.scala
+++ b/server/src/test/scala/services/crunch/TestDrtActor.scala
@@ -314,10 +314,6 @@ class TestDrtActor extends Actor {
         liveArrivalsTestProbe = liveArrivalsProbe,
         aggregatedArrivalsActor = aggregatedArrivalsActor,
         portStateActor = portStateActor,
-        staffActor = staffActor,
-        shiftsActor = shiftsActor,
-        fixedPointsActor = fixedPointsActor,
-        staffMovementsActor = staffMovementsActor
       )
   }
 }

--- a/server/src/test/scala/services/staffing/StaffMinutesCheckerSpec.scala
+++ b/server/src/test/scala/services/staffing/StaffMinutesCheckerSpec.scala
@@ -1,0 +1,39 @@
+package services.staffing
+
+import akka.actor.ActorSystem
+import akka.testkit.TestProbe
+import akka.util.Timeout
+import org.specs2.mutable.Specification
+import services.crunch.deskrecs.RunnableOptimisation.TerminalUpdateRequest
+import uk.gov.homeoffice.drt.ports.config.Lhr
+import uk.gov.homeoffice.drt.time.{LocalDate, SDate}
+
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
+import scala.concurrent.duration.DurationInt
+
+class StaffMinutesCheckerSpec extends Specification {
+  "Given a StaffMinutesChecker with LHR's config and max-forecast-days of 2" >> {
+    "I should see TerminalUpdateRequests for every terminal for the last 2 days of the max forecast period" >> {
+      implicit val system: ActorSystem = ActorSystem("test")
+      implicit val ec: ExecutionContextExecutor = ExecutionContext.global
+      implicit val timeout: Timeout = new Timeout(1.second)
+      val testProbe = TestProbe("staffing-update-requests-queue")
+
+      val today = SDate("2023-01-08T10:00")
+      val forecastMaxDays = 3
+      val checker = StaffMinutesChecker(() => today, testProbe.ref, forecastMaxDays, Lhr.config)
+      checker.calculateForecastStaffMinutes()
+
+      val expected = for {
+        day <- Seq(LocalDate(2023, 1, 9), LocalDate(2023, 1, 10))
+        terminal <- Lhr.config.terminals
+      } yield {
+        TerminalUpdateRequest(terminal, day, Lhr.config.crunchOffsetMinutes, Lhr.config.minutesToCrunch)
+      }
+
+      testProbe.receiveN(8).toSet === expected.toSet
+
+      success
+    }
+  }
+}


### PR DESCRIPTION
Simplify staff checker to only request the last 2 days of the forecast to be recalculated without checking if there are already existing minutes as a day can contain partial minutes from the day before resulting in the day being skipped - the cause of the bug