### PR TITLE
DRTII-1230 Disable CSRF for forecast upload end point

### DIFF
--- a/server/src/main/resources/routes
+++ b/server/src/main/resources/routes
@@ -106,6 +106,7 @@ DELETE        /staff-movements/:uuid                                            
 
 # Feed import
 POST          /data/feed/red-list-counts                                              controllers.Application.feedImportRedListCounts()
++ nocsrf
 POST          /data/feed/:feedType/:portCode                                          controllers.Application.feedImport(feedType: String, portCode: String)
 # Training
 GET           /feature-guide-video/:filename                                          controllers.S3FileController.getFile(filename:String)


### PR DESCRIPTION
Remove csrf check for upload endpoint to enable programmatic feed uploads