### PR TITLE
Drtii 1301 api data not matched at gla for ek0027 qf8027

### DIFF
--- a/client/src/main/scala/drt/client/components/FlightTableComponents.scala
+++ b/client/src/main/scala/drt/client/components/FlightTableComponents.scala
@@ -69,7 +69,4 @@ object FlightTableComponents {
     } getOrElse {
       <.div()
     }
-
-  def uniqueArrivalsWithCodeShares(paxFeedSourceOrder: List[FeedSource]): Seq[ApiFlightWithSplits] => Seq[(ApiFlightWithSplits, Seq[String])] =
-    CodeShares.uniqueArrivalsWithCodeShares((f: ApiFlightWithSplits) => identity(f.apiFlight), paxFeedSourceOrder)
 }

--- a/client/src/main/scala/drt/client/components/FlightTableContent.scala
+++ b/client/src/main/scala/drt/client/components/FlightTableContent.scala
@@ -89,8 +89,7 @@ object FlightTableContent {
         }
       val flightsForTerminal =
         flightDisplayFilter.forTerminalIncludingIncomingDiversions(flights, props.terminal)
-      val flightsWithCodeShares = FlightTableComponents
-        .uniqueArrivalsWithCodeShares(props.paxFeedSourceOrder)(flightsForTerminal.toSeq)
+      val flightsWithCodeShares = CodeShares.uniqueArrivalsWithCodeShares(props.paxFeedSourceOrder)(flightsForTerminal.toSeq)
       val sortedFlights = flightsWithCodeShares.sortBy(_._1.apiFlight.PcpTime.getOrElse(0L))
 
       if (sortedFlights.nonEmpty) {

--- a/server/src/main/scala/services/exports/PassengerExports.scala
+++ b/server/src/main/scala/services/exports/PassengerExports.scala
@@ -67,13 +67,13 @@ object PassengerExports {
       val windowStart = SDate(current)
       val windowEnd = SDate(current).addDays(1).addMinutes(-1)
       val arrivals = flights.collect {
-        case fws if fws.apiFlight.hasPcpDuring(windowStart, windowEnd, paxFeedSourceOrder) => fws.apiFlight
+        case fws if fws.apiFlight.hasPcpDuring(windowStart, windowEnd, paxFeedSourceOrder) => fws
       }
-      val uniqueArrivals = CodeShares.uniqueArrivals[Arrival](identity, paxFeedSourceOrder)(arrivals).toSeq
+      val uniqueArrivals = CodeShares.uniqueArrivals(paxFeedSourceOrder)(arrivals).toSeq
 
       uniqueArrivals
-        .sortBy(_.PcpTime.getOrElse(0L))
-        .map(arrival => totalPaxForArrivalInWindow(arrival, paxFeedSourceOrder, windowStart.millisSinceEpoch, windowEnd.millisSinceEpoch))
+        .sortBy(_.apiFlight.PcpTime.getOrElse(0L))
+        .map(arrival => totalPaxForArrivalInWindow(arrival.apiFlight, paxFeedSourceOrder, windowStart.millisSinceEpoch, windowEnd.millisSinceEpoch))
         .sum
     }
 

--- a/server/src/main/scala/services/exports/flights/templates/FlightsExport.scala
+++ b/server/src/main/scala/services/exports/flights/templates/FlightsExport.scala
@@ -34,6 +34,9 @@ trait FlightsExport {
 
   val paxFeedSourceOrder: List[FeedSource]
 
+  lazy val uniqueArrivalsWithCodeShares: Seq[ApiFlightWithSplits] => Iterable[ApiFlightWithSplits] =
+    CodeShares.uniqueArrivals(paxFeedSourceOrder)
+
   private def flightToCsvRow(fws: ApiFlightWithSplits, maybeManifest: Option[VoyageManifest]): String = rowValues(fws, maybeManifest).mkString(",")
 
   def csvStream(flightsStream: Source[(FlightsWithSplits, VoyageManifests), NotUsed]): Source[String, NotUsed] =
@@ -55,8 +58,5 @@ trait FlightsExport {
           (fws, maybeManifest)
         }
     }
-
-  val uniqueArrivalsWithCodeShares: Seq[ApiFlightWithSplits] => Iterable[ApiFlightWithSplits] = CodeShares
-    .uniqueArrivals((f: ApiFlightWithSplits) => identity(f.apiFlight), paxFeedSourceOrder)
 
 }

--- a/server/src/main/scala/services/graphstages/DynamicWorkloadCalculator.scala
+++ b/server/src/main/scala/services/graphstages/DynamicWorkloadCalculator.scala
@@ -51,7 +51,7 @@ case class DynamicWorkloadCalculator(terminalProcTimes: Map[Terminal, Map[PaxTyp
                                  paxFeedSourceOrder: List[FeedSource],
                                 )
                                 (implicit ex: ExecutionContext, mat: Materializer): SplitMinutes = {
-    val uniqueWithCodeShares = CodeShares.uniqueArrivals[ApiFlightWithSplits](f => f.apiFlight, paxFeedSourceOrder)(flights.flights.values.toSeq)
+    val uniqueWithCodeShares = CodeShares.uniqueArrivals(paxFeedSourceOrder)(flights.flights.values.toSeq)
     val relevantFlights = flightsWithPcpWorkload(uniqueWithCodeShares, redListUpdates)
     val procTimes = (terminal: Terminal) => (paxType: PaxType, queue: Queue) =>
       terminalProcTimes


### PR DESCRIPTION
Code share detection now uses the presence of live API splits as detector of main flight, followed by highest pax nos 