### PR TITLE
DRTII-1382 Fix shift update message for prod app. Move test endpoint …

### DIFF
--- a/e2e/cypress/e2e/api-role-access.cy.ts
+++ b/e2e/cypress/e2e/api-role-access.cy.ts
@@ -69,7 +69,7 @@ describe('API role access', () => {
     },
     {
       roles: ["test"],
-      endpoint: "/data/staff",
+      endpoint: "/test/replace-all-shifts",
       method: "POST",
       shouldBeGranted: false
     },

--- a/e2e/cypress/e2e/monthly-staffing.cy.ts
+++ b/e2e/cypress/e2e/monthly-staffing.cy.ts
@@ -41,7 +41,7 @@ describe('Monthly Staffing', () => {
     cy
       .request({
         method: "POST",
-        url: "/data/staff",
+        url: "/test/replace-all-shifts",
         body: {
           "shifts": [
             {
@@ -59,7 +59,7 @@ describe('Monthly Staffing', () => {
   Cypress.Commands.add('resetShifts', (csrfToken) => {
     cy.request({
       method: "POST",
-      url: "/data/staff",
+      url: "/test/replace-all-shifts",
       body: {
         "shifts": [
           {

--- a/e2e/cypress/support/commands.ts
+++ b/e2e/cypress/support/commands.ts
@@ -135,7 +135,7 @@ Cypress.Commands.add('deleteData', (csrfToken) => {
 Cypress.Commands.add('saveShifts', (shiftsJson, csrfToken) => {
   cy.request({
     method: "POST",
-    url: "/data/staff",
+    url: "/test/replace-all-shifts",
     body: shiftsJson,
     headers: {
       "Csrf-Token": csrfToken,

--- a/server/src/main/resources/routes
+++ b/server/src/main/resources/routes
@@ -123,7 +123,6 @@ POST          /email/feedback/:feedback                                         
 + nocsrf
 POST          /logging                                                                controllers.Application.logging
 
-POST          /data/staff                                                             controllers.application.StaffingController.saveStaff
 GET           /staff-movements/:date                                                  controllers.application.StaffingController.getStaffMovements(date: String)
 POST          /staff-movements                                                        controllers.application.StaffingController.addStaffMovements
 DELETE        /staff-movements/:uuid                                                  controllers.application.StaffingController.removeStaffMovements(uuid: String)

--- a/server/src/main/scala/actors/persistent/staffing/ShiftsActor.scala
+++ b/server/src/main/scala/actors/persistent/staffing/ShiftsActor.scala
@@ -31,7 +31,7 @@ case object GetFeedStatuses
 
 trait ShiftUpdate
 
-case class SetShifts(newShifts: Seq[StaffAssignmentLike]) extends ShiftUpdate
+case class ReplaceAllShifts(newShifts: Seq[StaffAssignmentLike]) extends ShiftUpdate
 
 case class UpdateShifts(shiftsToUpdate: Seq[StaffAssignmentLike]) extends ShiftUpdate
 
@@ -204,7 +204,7 @@ class ShiftsActor(val now: () => SDateLike,
         (sender(), StatusReply.Ack),
       ))
 
-    case SetShifts(newShiftAssignments) =>
+    case ReplaceAllShifts(newShiftAssignments) =>
       if (newShiftAssignments != state) {
         log.info(s"Replacing shifts state with ${newShiftAssignments.size} shifts")
         purgeExpiredAndUpdateState(ShiftAssignments(newShiftAssignments))

--- a/server/src/main/scala/controllers/TestRouter.scala
+++ b/server/src/main/scala/controllers/TestRouter.scala
@@ -24,6 +24,8 @@ class TestRouter @Inject()(cc: ControllerComponents, testController: TestControl
 
     case DELETE(p"/test/data") => testController.deleteAllData
 
+    case POST(p"/test/replace-all-shifts") => testController.replaceAllShifts
+
   }
 
 

--- a/server/src/main/scala/controllers/application/StaffingController.scala
+++ b/server/src/main/scala/controllers/application/StaffingController.scala
@@ -65,7 +65,7 @@ class StaffingController @Inject()(cc: ControllerComponents,
       request.body.asText match {
         case Some(text) =>
           val shifts = read[ShiftAssignments](text)
-          ctrl.shiftsSequentialWritesActor ! SetShifts(shifts.assignments)
+          ctrl.shiftsSequentialWritesActor ! UpdateShifts(shifts.assignments)
           Accepted
         case None =>
           BadRequest
@@ -132,22 +132,6 @@ class StaffingController @Inject()(cc: ControllerComponents,
         case None =>
           BadRequest
       }
-    }
-  }
-
-  def saveStaff: Action[AnyContent] = authByRole(StaffEdit) {
-    Action {
-      implicit request =>
-        val maybeShifts: Option[ShiftAssignments] = request.body.asJson.flatMap(ImportStaff.staffJsonToShifts)
-
-        maybeShifts match {
-          case Some(shifts) =>
-            log.info(s"Received ${shifts.assignments.length} shifts. Sending to actor")
-            ctrl.shiftsSequentialWritesActor ! SetShifts(shifts.assignments)
-            Created
-          case _ =>
-            BadRequest("{\"error\": \"Unable to parse data\"}")
-        }
     }
   }
 


### PR DESCRIPTION
Fix message type sent to actor for prod endpoint - update rather than replace
Rename replace message from `SetShifts` to `ReplaceAllShifts` for clarity
Move test endpoint for replacing shifts to test controller so it can't be called by the prod app