### PR TITLE
DRTII-1454 Move throttle to after manifests have been filtered

### DIFF
--- a/server/src/main/scala/drt/server/feeds/api/ApiFeed.scala
+++ b/server/src/main/scala/drt/server/feeds/api/ApiFeed.scala
@@ -30,12 +30,12 @@ case class ApiFeedImpl(arrivalKeyProvider: ManifestArrivalKeys,
             Option((nextMarker, newKeys), (lastProcessedAt, lastKeys))
         }
       }
-      .throttle(1, throttle)
       .map { case (marker, keys) =>
         if (keys.isEmpty) manifestProcessor.reportNoNewData(marker)
         keys
       }
       .mapConcat(identity)
+      .throttle(1, throttle)
       .mapAsync(1) {
         case (uniqueArrivalKey, processedAt) =>
           manifestProcessor

--- a/server/src/main/scala/drt/server/feeds/api/ManifestArrivalKeys.scala
+++ b/server/src/main/scala/drt/server/feeds/api/ManifestArrivalKeys.scala
@@ -50,11 +50,6 @@ case class DbManifestArrivalKeys(tables: Tables, destinationPortCode: PortCode)
       .as[(String, Long)]
       .map(_.headOption)
 
-  def zipsQuery(ts: String): SqlStreamingAction[Vector[(String, MillisSinceEpoch)], (String, MillisSinceEpoch), Effect] =
-    sql"""SELECT pz.zip_file_name, EXTRACT(EPOCH FROM pz.processed_at) * 1000 FROM processed_zip pz WHERE pz.processed_at > TIMESTAMP '#$ts' ORDER BY pz.processed_at
-         |""".stripMargin
-      .as[(String, Long)]
-
   def jsonQuery(zipFileName: String): DBIOAction[Vector[String], NoStream, Effect] =
     sql"""SELECT pj.json_file_name FROM processed_json pj WHERE pj.zip_file_name=$zipFileName
          |""".stripMargin


### PR DESCRIPTION
Move throttle so that it takes effect after we've filtered out zip files that didn't contain manifests for the running port