### PR TITLE
Drtii 1472 historic api not showing

### DIFF
--- a/server/src/main/scala/actors/PartitionedPortStateActor.scala
+++ b/server/src/main/scala/actors/PartitionedPortStateActor.scala
@@ -217,8 +217,7 @@ class PartitionedPortStateActor(flightsRouterActor: ActorRef,
     case StreamFailure(t) => log.error(s"Stream failed", t)
 
     case updates: FlightUpdates =>
-      val replyTo = sender()
-      askThenAck(flightsRouterActor, updates, replyTo)
+      askThenAck(flightsRouterActor, updates, sender())
 
     case noUpdates: PortStateMinutes[_, _] if noUpdates.isEmpty =>
       sender() ! StatusReply.Ack

--- a/server/src/main/scala/actors/daily/TerminalDayFlightActor.scala
+++ b/server/src/main/scala/actors/daily/TerminalDayFlightActor.scala
@@ -11,9 +11,9 @@ import scalapb.GeneratedMessage
 import uk.gov.homeoffice.drt.actor.RecoveryActorLike
 import uk.gov.homeoffice.drt.actor.commands.Commands.GetState
 import uk.gov.homeoffice.drt.arrivals._
-import uk.gov.homeoffice.drt.ports.{ApiFeedSource, FeedSource, ForecastFeedSource, HistoricApiFeedSource, MlFeedSource}
 import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.Historical
 import uk.gov.homeoffice.drt.ports.Terminals.Terminal
+import uk.gov.homeoffice.drt.ports.{FeedSource, ForecastFeedSource, HistoricApiFeedSource, MlFeedSource}
 import uk.gov.homeoffice.drt.protobuf.messages.CrunchState.{FlightsWithSplitsDiffMessage, FlightsWithSplitsMessage, SplitsForArrivalsMessage}
 import uk.gov.homeoffice.drt.protobuf.messages.FlightsMessage.FlightsDiffMessage
 import uk.gov.homeoffice.drt.protobuf.serialisation.FlightMessageConversion
@@ -188,8 +188,12 @@ class TerminalDayFlightActor(year: Int,
     }
   }
 
-  private def hasNoForecastPax(arrival: Arrival): Boolean =
-    arrival.PassengerSources.keySet.union(Set(HistoricApiFeedSource, MlFeedSource, ForecastFeedSource)).isEmpty
+  private def hasNoForecastPax(arrival: Arrival): Boolean = {
+    val existingSources: Set[FeedSource] = arrival.PassengerSources.keySet
+    val acceptableSources: Set[FeedSource] = Set(HistoricApiFeedSource, MlFeedSource, ForecastFeedSource)
+    val acceptableExistingSources = existingSources.intersect(acceptableSources)
+    acceptableExistingSources.isEmpty
+  }
 
   private def applyDiffAndPersist(applyDiff: (FlightsWithSplits, Long, List[FeedSource]) => (FlightsWithSplits, Set[Long])): Set[MillisSinceEpoch] = {
     val (updatedState, minutesToUpdate) = applyDiff(state, now().millisSinceEpoch, paxFeedSourceOrder)

--- a/server/src/main/scala/services/arrivals/RunnableHistoricManifestsLike.scala
+++ b/server/src/main/scala/services/arrivals/RunnableHistoricManifestsLike.scala
@@ -1,0 +1,26 @@
+package services.arrivals
+
+import akka.actor.ActorRef
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream._
+import akka.{Done, NotUsed}
+import uk.gov.homeoffice.drt.arrivals.UniqueArrival
+
+trait RunnableHistoricManifestsLike {
+  protected def constructAndRunGraph(flow: Flow[Iterable[UniqueArrival], Done, NotUsed])
+                                    (implicit mat: Materializer): (ActorRef, UniqueKillSwitch) = {
+    val completionMatcher: PartialFunction[Any, CompletionStrategy] = {
+      case Done => CompletionStrategy.immediately
+    }
+    Source.actorRef[Iterable[UniqueArrival]](
+        completionMatcher = completionMatcher,
+        failureMatcher = PartialFunction.empty,
+        bufferSize = 365,
+        overflowStrategy = OverflowStrategy.dropTail,
+      )
+      .via(flow)
+      .viaMat(KillSwitches.single)(Keep.both)
+      .to(Sink.ignore)
+      .run()
+  }
+}

--- a/server/src/main/scala/services/arrivals/RunnableHistoricSplits.scala
+++ b/server/src/main/scala/services/arrivals/RunnableHistoricSplits.scala
@@ -62,7 +62,7 @@ object RunnableHistoricSplits extends RunnableHistoricManifestsLike {
       maybeBestAvailableManifest(portCode, origin, voyageNumber, scheduled).map(_._2)
     }
     val maybeHistoricSplits = RunnableHistoricSplits.maybeHistoricSplits(getManifest, splitsFromManifest)
-    val persistSplits: SplitsForArrivals => Future[Done] = splits => flightsRouterActor.ask(splits.splits).map(_ => Done)
+    val persistSplits: SplitsForArrivals => Future[Done] = splits => flightsRouterActor.ask(splits).map(_ => Done)
     val flow = RunnableHistoricSplits.arrivalsToHistoricSplits(maybeHistoricSplits, persistSplits)
     constructAndRunGraph(flow)
   }

--- a/server/src/main/scala/services/arrivals/RunnableHistoricSplits.scala
+++ b/server/src/main/scala/services/arrivals/RunnableHistoricSplits.scala
@@ -2,12 +2,12 @@ package services.arrivals
 
 import akka.actor.ActorRef
 import akka.pattern.ask
-import akka.stream.{CompletionStrategy, Materializer, OverflowStrategy}
+import akka.stream._
 import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.util.Timeout
 import akka.{Done, NotUsed}
 import manifests.UniqueArrivalKey
-import manifests.passengers.{BestAvailableManifest, ManifestLike}
+import manifests.passengers.ManifestLike
 import org.slf4j.LoggerFactory
 import uk.gov.homeoffice.drt.arrivals.{Splits, SplitsForArrivals, UniqueArrival, VoyageNumber}
 import uk.gov.homeoffice.drt.ports.PortCode
@@ -17,13 +17,13 @@ import uk.gov.homeoffice.drt.time.{SDate, SDateLike}
 import scala.concurrent.{ExecutionContext, Future}
 
 
-object RunnableHistoricSplits {
+object RunnableHistoricSplits extends RunnableHistoricManifestsLike {
   private val log = LoggerFactory.getLogger(getClass)
 
-  def arrivalsToHistoricSplits(maybeHistoricSplits: UniqueArrival => Future[Option[Splits]],
-                               persistSplits: SplitsForArrivals => Future[Done],
-                              )
-                              (implicit ec: ExecutionContext, mat: Materializer): Flow[Iterable[UniqueArrival], Done, NotUsed] =
+  private def arrivalsToHistoricSplits(maybeHistoricSplits: UniqueArrival => Future[Option[Splits]],
+                                       persistSplits: SplitsForArrivals => Future[Done],
+                                      )
+                                      (implicit ec: ExecutionContext, mat: Materializer): Flow[Iterable[UniqueArrival], Done, NotUsed] =
     Flow[Iterable[UniqueArrival]]
       .mapAsync(1) { arrivalKeys =>
         log.info(s"Looking up historic splits for ${arrivalKeys.size} arrivals")
@@ -42,10 +42,9 @@ object RunnableHistoricSplits {
           }
       }
 
-  def maybeHistoricSplits(maybeManifest: UniqueArrival => Future[Option[ManifestLike]],
-                          splitsFromManifest: (ManifestLike, Terminal) => Splits,
-                         )
-                         (implicit ec: ExecutionContext): UniqueArrival => Future[Option[Splits]] =
+  private def maybeHistoricSplits(maybeManifest: UniqueArrival => Future[Option[ManifestLike]],
+                                  splitsFromManifest: (ManifestLike, Terminal) => Splits)
+                                 (implicit ec: ExecutionContext): UniqueArrival => Future[Option[Splits]] =
     uniqueArrival =>
       maybeManifest(uniqueArrival)
         .map(_.map(m => splitsFromManifest(m, uniqueArrival.terminal)))
@@ -53,9 +52,9 @@ object RunnableHistoricSplits {
   def apply(portCode: PortCode,
             flightsRouterActor: ActorRef,
             splitsFromManifest: (ManifestLike, Terminal) => Splits,
-            maybeBestAvailableManifest: (PortCode, PortCode, VoyageNumber, SDateLike) => Future[(UniqueArrivalKey, Option[BestAvailableManifest])],
+            maybeBestAvailableManifest: (PortCode, PortCode, VoyageNumber, SDateLike) => Future[(UniqueArrivalKey, Option[ManifestLike])],
            )
-           (implicit ec: ExecutionContext, timeout: Timeout, mat: Materializer): ActorRef = {
+           (implicit ec: ExecutionContext, timeout: Timeout, mat: Materializer): (ActorRef, UniqueKillSwitch) = {
     val getManifest: UniqueArrival => Future[Option[ManifestLike]] = uniqueArrival => {
       val origin: PortCode = uniqueArrival.origin
       val voyageNumber: VoyageNumber = VoyageNumber(uniqueArrival.number)
@@ -63,19 +62,8 @@ object RunnableHistoricSplits {
       maybeBestAvailableManifest(portCode, origin, voyageNumber, scheduled).map(_._2)
     }
     val maybeHistoricSplits = RunnableHistoricSplits.maybeHistoricSplits(getManifest, splitsFromManifest)
-    val persistSplits: SplitsForArrivals => Future[Done] = splits => flightsRouterActor.ask(SplitsForArrivals(splits.splits)).map(_ => Done)
+    val persistSplits: SplitsForArrivals => Future[Done] = splits => flightsRouterActor.ask(splits.splits).map(_ => Done)
     val flow = RunnableHistoricSplits.arrivalsToHistoricSplits(maybeHistoricSplits, persistSplits)
-    val (sourceActorRef, _) = flow
-      .runWith(
-        Source.actorRef(
-          completionMatcher = {
-            case Done => CompletionStrategy.immediately
-          },
-          failureMatcher = PartialFunction.empty,
-          bufferSize = 100,
-          overflowStrategy = OverflowStrategy.dropTail,
-        ),
-        Sink.ignore)
-    sourceActorRef
+    constructAndRunGraph(flow)
   }
 }

--- a/server/src/main/scala/slickdb/Tables.scala
+++ b/server/src/main/scala/slickdb/Tables.scala
@@ -120,7 +120,7 @@ trait Tables {
   }
 
   /** Table description of table arrival. Objects of this class serve as prototypes for rows in queries. */
-  class VoyageManifestPassengerInfo(_tableTag: Tag) extends profile.api.Table[VoyageManifestPassengerInfoRow](_tableTag, maybeSchema, "voyage_manifest_passenger_info") {
+  class VoyageManifestPassengerInfoTable(_tableTag: Tag) extends profile.api.Table[VoyageManifestPassengerInfoRow](_tableTag, maybeSchema, "voyage_manifest_passenger_info") {
     def * = (event_code, arrival_port_code, departure_port_code, voyage_number, carrier_code, scheduled_date, day_of_week, week_of_year, document_type, document_issuing_country_code, eea_flag, age, disembarkation_port_code, in_transit_flag, disembarkation_port_country_code, nationality_country_code, passenger_identifier, in_transit, json_file) <> (VoyageManifestPassengerInfoRow.tupled, VoyageManifestPassengerInfoRow.unapply)
 
     val event_code: Rep[String] = column[String]("event_code")
@@ -202,7 +202,7 @@ trait Tables {
   }
 
   /** Collection-like TableQuery object for table VoyageManifestPassengerInfo */
-  lazy val VoyageManifestPassengerInfo = new TableQuery(tag => new VoyageManifestPassengerInfo(tag))
+  lazy val VoyageManifestPassengerInfo = new TableQuery(tag => new VoyageManifestPassengerInfoTable(tag))
   lazy val ProcessedJson = new TableQuery(tag => new ProcessedJsonTable(tag))
   lazy val ProcessedZip = new TableQuery(tag => new ProcessedZipTable(tag))
   lazy val Arrival = new TableQuery(tag => new Arrival(tag))

--- a/server/src/test/scala/actors/PartitionedPortStateTestActor.scala
+++ b/server/src/test/scala/actors/PartitionedPortStateTestActor.scala
@@ -84,6 +84,7 @@ class PartitionedPortStateTestActor(probe: ActorRef,
     actor.ask(message).foreach { _ =>
       message match {
         case splits: SplitsForArrivals if splits.splits.keys.nonEmpty =>
+          println(s"Received splits for ${splits.splits.keys.size} flights")
           val updatedMillis = splits.splits.keys.map(_.scheduled)
           updateFlights(actor, Seq(), updatedMillis.min, updatedMillis.max)
 

--- a/server/src/test/scala/actors/PartitionedPortStateTestActor.scala
+++ b/server/src/test/scala/actors/PartitionedPortStateTestActor.scala
@@ -84,7 +84,6 @@ class PartitionedPortStateTestActor(probe: ActorRef,
     actor.ask(message).foreach { _ =>
       message match {
         case splits: SplitsForArrivals if splits.splits.keys.nonEmpty =>
-          println(s"Received splits for ${splits.splits.keys.size} flights")
           val updatedMillis = splits.splits.keys.map(_.scheduled)
           updateFlights(actor, Seq(), updatedMillis.min, updatedMillis.max)
 

--- a/server/src/test/scala/drt/server/feeds/api/DbHelper.scala
+++ b/server/src/test/scala/drt/server/feeds/api/DbHelper.scala
@@ -46,7 +46,7 @@ object DbHelper {
       in_transit = false,
       json_file = jsonFileName)
 
-    Await.ready(tables.run(TableQuery[tables.VoyageManifestPassengerInfo] += row), 1.second)
+    Await.ready(tables.run(TableQuery[tables.VoyageManifestPassengerInfoTable] += row), 1.second)
   }
 
 }

--- a/server/src/test/scala/manifests/ManifestLookupSpec.scala
+++ b/server/src/test/scala/manifests/ManifestLookupSpec.scala
@@ -17,8 +17,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 
 class ManifestLookupSpec extends CrunchTestLike with Before {
-  skipped("Postgres queries incompatible with H2")
-
   override def before: Any = {
     H2Tables.dropAndCreateH2Tables()
     val scheduled = SDate("2024-05-15T12:00Z")
@@ -72,6 +70,8 @@ class ManifestLookupSpec extends CrunchTestLike with Before {
 
   "ManifestLookup" should {
     "lookup a manifest" in {
+      skipped("Postgres queries incompatible with H2")
+
       val manifestLookup = ManifestLookup(H2Tables)
       val manifest = manifestLookup.maybeBestAvailableManifest(PortCode("LHR"), PortCode("JFK"), VoyageNumber(1), SDate("2024-05-15T12:00Z"))
       val expectedKey = UniqueArrivalKey(PortCode("LHR"), PortCode("JFK"), VoyageNumber(1), SDate("2024-05-15T12:00Z"))

--- a/server/src/test/scala/manifests/ManifestLookupSpec.scala
+++ b/server/src/test/scala/manifests/ManifestLookupSpec.scala
@@ -1,0 +1,94 @@
+package manifests
+
+import manifests.passengers.{BestAvailableManifest, ManifestPassengerProfile}
+import org.specs2.specification.Before
+import passengersplits.core.PassengerTypeCalculatorValues.DocumentType.Passport
+import services.crunch.{CrunchTestLike, H2Tables}
+import slickdb.{ProcessedJsonRow, ProcessedZipRow, VoyageManifestPassengerInfoRow}
+import uk.gov.homeoffice.drt.Nationality
+import uk.gov.homeoffice.drt.arrivals.EventTypes.DC
+import uk.gov.homeoffice.drt.arrivals.{CarrierCode, VoyageNumber}
+import uk.gov.homeoffice.drt.ports.{PaxAge, PortCode}
+import uk.gov.homeoffice.drt.ports.SplitRatiosNs.SplitSources.Historical
+import uk.gov.homeoffice.drt.time.SDate
+
+import java.sql.Timestamp
+import scala.concurrent.Await
+import scala.concurrent.duration.DurationInt
+
+class ManifestLookupSpec extends CrunchTestLike with Before {
+  skipped("Postgres queries incompatible with H2")
+
+  override def before: Any = {
+    H2Tables.dropAndCreateH2Tables()
+    val scheduled = SDate("2024-05-15T12:00Z")
+    val processedZipRow = ProcessedZipRow("some-zip", true, new Timestamp(scheduled.millisSinceEpoch), Option("2024-05-15"))
+    val processedJsonRow = ProcessedJsonRow(
+      zip_file_name = "some-zip",
+      json_file_name = "some-json",
+      suspicious_date = false,
+      success = true,
+      processed_at = new Timestamp(scheduled.millisSinceEpoch),
+      arrival_port_code = Option("LHR"),
+      departure_port_code = Option("JFK"),
+      voyage_number = Option(1),
+      carrier_code = Option("BA"),
+      scheduled = Option(new Timestamp(scheduled.millisSinceEpoch)),
+      event_code = Option("DC"),
+      non_interactive_total_count = Option(0),
+      non_interactive_trans_count = Option(0),
+      interactive_total_count = Option(1),
+      interactive_trans_count = Option(0),
+    )
+    val passengerRow = VoyageManifestPassengerInfoRow(
+      event_code = "DC",
+      arrival_port_code = "LHR",
+      departure_port_code = "JFK",
+      voyage_number = 1,
+      carrier_code = "BA",
+      scheduled_date = new Timestamp(scheduled.millisSinceEpoch),
+      day_of_week = 3,
+      week_of_year = 20,
+      document_type = "P",
+      document_issuing_country_code = "GB",
+      eea_flag = "EEA",
+      age = 30,
+      disembarkation_port_code = "LHR",
+      in_transit_flag = "N",
+      disembarkation_port_country_code = "GBR",
+      nationality_country_code = "GBR",
+      passenger_identifier = "1",
+      in_transit = false,
+      json_file = "some-json",
+    )
+    import H2Tables.profile.api._
+    Await.ready(
+      H2Tables.run(DBIO.seq(
+        H2Tables.ProcessedZip += processedZipRow,
+        H2Tables.ProcessedJson += processedJsonRow,
+        H2Tables.VoyageManifestPassengerInfo += passengerRow,
+      )), 1.second)
+  }
+
+  "ManifestLookup" should {
+    "lookup a manifest" in {
+      val manifestLookup = ManifestLookup(H2Tables)
+      val manifest = manifestLookup.maybeBestAvailableManifest(PortCode("LHR"), PortCode("JFK"), VoyageNumber(1), SDate("2024-05-15T12:00Z"))
+      val expectedKey = UniqueArrivalKey(PortCode("LHR"), PortCode("JFK"), VoyageNumber(1), SDate("2024-05-15T12:00Z"))
+      val expectedManifest = BestAvailableManifest(
+        source = Historical,
+        arrivalPortCode = PortCode("LHR"),
+        departurePortCode = PortCode("JFK"),
+        voyageNumber = VoyageNumber(1),
+        carrierCode = CarrierCode("BA"),
+        scheduled = SDate("2024-05-15T12:00Z"),
+        nonUniquePassengers = Seq(
+          ManifestPassengerProfile(nationality = Nationality("GBR"), documentType = Option(Passport),
+            age = Option(PaxAge(30)), inTransit = false, passengerIdentifier = Option("1"))
+        ),
+        maybeEventType = Option(DC)
+      )
+      Await.result(manifest, 1.second) === (expectedKey, Option(expectedManifest))
+    }
+  }
+}

--- a/server/src/test/scala/services/crunch/TestDrtActor.scala
+++ b/server/src/test/scala/services/crunch/TestDrtActor.scala
@@ -214,7 +214,7 @@ class TestDrtActor extends Actor {
       val queueUpdates = system.actorOf(Props(new QueueUpdatesSupervisor(tc.now, tc.airportConfig.queuesByTerminal.keys.toList, queueUpdatesProps(tc.now, InMemoryStreamingJournal))), "updates-supervisor-queues")
       val staffUpdates = system.actorOf(Props(new StaffUpdatesSupervisor(tc.now, tc.airportConfig.queuesByTerminal.keys.toList, staffUpdatesProps(tc.now, InMemoryStreamingJournal))), "updates-supervisor-staff")
       val flightUpdates = system.actorOf(Props(new FlightUpdatesSupervisor(tc.now, tc.airportConfig.queuesByTerminal.keys.toList, flightUpdatesProps(tc.now, InMemoryStreamingJournal))), "updates-supervisor-flight")
-      val portStateActor = system.actorOf(Props(new PartitionedPortStateTestActor(portStateProbe.ref, flightsRouterActor, queuesActor, staffActor, queueUpdates, staffUpdates, flightUpdates, tc.now, tc.airportConfig.queuesByTerminal, paxFeedSourceOrder)))
+      val portStateActor = system.actorOf(Props(new PartitionedPortStateTestActor(portStateProbe.ref, flightsRouterActor, queuesActor, staffActor, queueUpdates, staffUpdates, flightUpdates, tc.now, tc.airportConfig.queuesByTerminal, paxFeedSourceOrder)), "partitioned-port-state-actor")
       tc.initialPortState match {
         case Some(ps) =>
           val withPcpTimes = ps.flights.view.mapValues {


### PR DESCRIPTION
Increase historic manifest & pax queue buffers to fit more than 6 months of requests
Refactor some common code
Increase breadth of same flight query to include up to 3 weeks ago so we're taking an average rather than looking at a single flight
