### PR TITLE
DRTII-1524 Add period-minutes query string option

### DIFF
--- a/server/src/main/scala/controllers/application/AuthController.scala
+++ b/server/src/main/scala/controllers/application/AuthController.scala
@@ -131,8 +131,7 @@ abstract class AuthController(cc: ControllerComponents, ctrl: DrtSystemInterface
     val allowAccess = loggedInUser.hasRole(allowedRole)
 
     if (allowAccess) {
-      val eventualResult: Future[Result] = auth(action)(request)
-      eventualResult
+      auth(action)(request)
     } else {
       log.warning("Unauthorized")
       Future(unauthorizedMessageJson(allowedRole))
@@ -142,7 +141,7 @@ abstract class AuthController(cc: ControllerComponents, ctrl: DrtSystemInterface
   def unauthorizedMessageJson(allowedRole: Role): Result =
     Forbidden(write(ErrorResponse(s"Permission denied, you need $allowedRole to access this resource")))
 
-  def auth[A](action: Action[A]): Action[A] = Action.async(action.parser) { request: Request[A] =>
+  def auth[A](action: Action[A]): Action[A] = Action.async(action.parser) { request =>
 
     val loggedInUser: LoggedInUser = ctrl.getLoggedInUser(config, request.headers, request.session)
     val portRole = airportConfig.role

--- a/server/src/main/scala/controllers/application/AuthController.scala
+++ b/server/src/main/scala/controllers/application/AuthController.scala
@@ -131,7 +131,8 @@ abstract class AuthController(cc: ControllerComponents, ctrl: DrtSystemInterface
     val allowAccess = loggedInUser.hasRole(allowedRole)
 
     if (allowAccess) {
-      auth(action)(request)
+      val eventualResult: Future[Result] = auth(action)(request)
+      eventualResult
     } else {
       log.warning("Unauthorized")
       Future(unauthorizedMessageJson(allowedRole))
@@ -141,7 +142,7 @@ abstract class AuthController(cc: ControllerComponents, ctrl: DrtSystemInterface
   def unauthorizedMessageJson(allowedRole: Role): Result =
     Forbidden(write(ErrorResponse(s"Permission denied, you need $allowedRole to access this resource")))
 
-  def auth[A](action: Action[A]): Action[A] = Action.async(action.parser) { request =>
+  def auth[A](action: Action[A]): Action[A] = Action.async(action.parser) { request: Request[A] =>
 
     val loggedInUser: LoggedInUser = ctrl.getLoggedInUser(config, request.headers, request.session)
     val portRole = airportConfig.role

--- a/server/src/main/scala/controllers/application/SimulationsController.scala
+++ b/server/src/main/scala/controllers/application/SimulationsController.scala
@@ -165,7 +165,8 @@ class SimulationsController @Inject()(cc: ControllerComponents, ctrl: DrtSystemI
         airportConfig.desksExportQueueOrder,
         (_, _) => Future.successful(Option(MinutesContainer(crunchMinutes.values.toSeq))),
         (_, _) => Future.successful(None),
-        None
+        None,
+        15,
       )
 
       val result: Result = Try(sourceToCsvResponse(stream, fileName)) match {

--- a/server/src/main/scala/controllers/application/exports/DesksExportController.scala
+++ b/server/src/main/scala/controllers/application/exports/DesksExportController.scala
@@ -7,7 +7,7 @@ import controllers.application.AuthController
 import controllers.application.exports.CsvFileStreaming.{makeFileName, sourceToCsvResponse}
 import drt.shared.CrunchApi.MillisSinceEpoch
 import drt.shared.ErrorResponse
-import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import play.api.mvc.{Action, AnyContent, ControllerComponents, Request}
 import services.exports.StreamingDesksExport
 import uk.gov.homeoffice.drt.time.SDate
 import uk.gov.homeoffice.drt.auth.Roles.DesksAndQueuesView
@@ -21,110 +21,96 @@ import scala.util.{Failure, Success, Try}
 
 class DesksExportController @Inject()(cc: ControllerComponents, ctrl: DrtSystemInterface) extends AuthController(cc, ctrl) {
 
-  def exportDesksAndQueuesRecsAtPointInTimeCSV(
-                                                localDate: String,
-                                                pointInTime: String,
-                                                terminalName: String): Action[AnyContent] =
-    authByRole(DesksAndQueuesView) {
+  def exportDesksAndQueuesRecsAtPointInTimeCSV(localDate: String,
+                                               pointInTime: String,
+                                               terminalName: String): Action[AnyContent] =
+    Action.async { request =>
+      authByRole(DesksAndQueuesView) {
+        (LocalDate.parse(localDate), Try(SDate(pointInTime.toLong))) match {
+          case (Some(ld), Success(pit)) =>
+            val viewDay = SDate(ld)
+            val start = viewDay
+            val end = viewDay.getLocalNextMidnight.addMinutes(-1)
 
-      (LocalDate.parse(localDate), Try(SDate(pointInTime.toLong))) match {
-        case (Some(ld), Success(pit)) =>
-
-          val viewDay = SDate(ld)
-          val start = viewDay
-          val end = viewDay.getLocalNextMidnight.addMinutes(-1)
-
-          exportStreamingDesksAndQueuesBetweenTimestampsCSV(
-            start,
-            end,
-            terminalName,
-            deskRecsExportStreamForTerminalDates(pointInTime = Option(pit.millisSinceEpoch)),
-            s"desks-and-queues-recs-at-${pit.toISOString}-for"
-          )
-        case _ =>
-          Action(BadRequest(write(ErrorResponse("Invalid date format"))))
-      }
+            exportBetweenTimestampsCSV(
+              deskRecsExportStreamForTerminalDates(pointInTime = Option(pit.millisSinceEpoch), start, end, Terminal(terminalName), periodMinutes(request)),
+              makeFileName(s"desks-and-queues-recs-at-${pit.toISOString}-for", Option(Terminal(terminalName)), start.toLocalDate, end.toLocalDate, airportConfig.portCode),
+            )
+          case _ =>
+            Action(BadRequest(write(ErrorResponse("Invalid date format"))))
+        }
+      }(request)
     }
+
+  private def periodMinutes(request: Request[AnyContent]) = {
+    request.getQueryString("period-minutes").map(_.toInt).getOrElse(15)
+  }
 
   def exportDesksAndQueuesRecsBetweenTimeStampsCSV(startLocalDate: String,
                                                    endLocalDate: String,
                                                    terminalName: String): Action[AnyContent] =
-    authByRole(DesksAndQueuesView) {
-      (LocalDate.parse(startLocalDate), LocalDate.parse(endLocalDate)) match {
-        case (Some(startLD), Some(endLD)) =>
+    Action.async { request =>
+      authByRole(DesksAndQueuesView) {
+        (LocalDate.parse(startLocalDate), LocalDate.parse(endLocalDate)) match {
+          case (Some(startLD), Some(endLD)) =>
+            val start = SDate(startLD)
+            val end = SDate(endLD).getLocalNextMidnight.addMinutes(-1)
 
-          val start = SDate(startLD)
-          val end = SDate(endLD).getLocalNextMidnight.addMinutes(-1)
-
-          exportStreamingDesksAndQueuesBetweenTimestampsCSV(
-            start,
-            end,
-            terminalName,
-            deskRecsExportStreamForTerminalDates(pointInTime = None),
-            "desks-and-queues-recs"
-          )
-        case _ =>
-          Action(BadRequest(write(ErrorResponse("Invalid date format"))))
-      }
+            exportBetweenTimestampsCSV(
+              deskRecsExportStreamForTerminalDates(pointInTime = None, start, end, Terminal(terminalName), periodMinutes(request)),
+              makeFileName("desks-and-queues-recs", Option(Terminal(terminalName)), start.toLocalDate, end.toLocalDate, airportConfig.portCode),
+            )
+          case _ =>
+            Action(BadRequest(write(ErrorResponse("Invalid date format"))))
+        }
+      }(request)
     }
 
-  def exportDesksAndQueuesDepsAtPointInTimeCSV(
-                                                localDate: String,
-                                                pointInTime: String,
-                                                terminalName: String
+  def exportDesksAndQueuesDepsAtPointInTimeCSV(localDate: String,
+                                               pointInTime: String,
+                                               terminalName: String
                                               ): Action[AnyContent] =
-    authByRole(DesksAndQueuesView) {
-      (LocalDate.parse(localDate), Try(SDate(pointInTime.toLong))) match {
-        case (Some(ld), Success(pit)) =>
+    Action.async { request =>
+      authByRole(DesksAndQueuesView) {
+        (LocalDate.parse(localDate), Try(SDate(pointInTime.toLong))) match {
+          case (Some(ld), Success(pit)) =>
+            val start = SDate(ld)
+            val end = start.getLocalNextMidnight.addMinutes(-1)
 
-          val start = SDate(ld)
-          val end = start.getLocalNextMidnight.addMinutes(-1)
-
-          exportStreamingDesksAndQueuesBetweenTimestampsCSV(
-            start,
-            end,
-            terminalName,
-            deploymentsExportStreamForTerminalDates(pointInTime = Option(pit.millisSinceEpoch)),
-            s"desks-and-queues-deps-at-${pit.toISOString}-for"
-          )
-        case _ =>
-          Action(BadRequest(write(ErrorResponse("Invalid date format"))))
-      }
+            exportBetweenTimestampsCSV(
+              deploymentsExportStreamForTerminalDates(pointInTime = Option(pit.millisSinceEpoch), start, end, Terminal(terminalName), periodMinutes(request)),
+              makeFileName(s"desks-and-queues-deps-at-${pit.toISOString}-for", Option(Terminal(terminalName)), start.toLocalDate, end.toLocalDate, airportConfig.portCode),
+            )
+          case _ =>
+            Action(BadRequest(write(ErrorResponse("Invalid date format"))))
+        }
+      }(request)
     }
 
   def exportDesksAndQueuesDepsBetweenTimeStampsCSV(startLocalDate: String,
                                                    endLocalDate: String,
                                                    terminalName: String): Action[AnyContent] =
-    authByRole(DesksAndQueuesView) {
-      (LocalDate.parse(startLocalDate), LocalDate.parse(endLocalDate)) match {
-        case (Some(startLD), Some(endLD)) =>
+    Action.async { request =>
+      authByRole(DesksAndQueuesView) {
+        (LocalDate.parse(startLocalDate), LocalDate.parse(endLocalDate)) match {
+          case (Some(startLD), Some(endLD)) =>
+            val start = SDate(startLD)
+            val end = SDate(endLD).getLocalNextMidnight.addMinutes(-1)
 
-          val start = SDate(startLD)
-          val end = SDate(endLD).getLocalNextMidnight.addMinutes(-1)
-          exportStreamingDesksAndQueuesBetweenTimestampsCSV(
-            start,
-            end,
-            terminalName,
-            deploymentsExportStreamForTerminalDates(pointInTime = None),
-            "desks-and-queues-deps"
-          )
-        case _ =>
-          Action(BadRequest(write(ErrorResponse("Invalid date format"))))
-      }
+            exportBetweenTimestampsCSV(
+              deploymentsExportStreamForTerminalDates(pointInTime = None, start, end, Terminal(terminalName), periodMinutes(request)),
+              makeFileName("desks-and-queues-deps", Option(Terminal(terminalName)), start.toLocalDate, end.toLocalDate, airportConfig.portCode),
+            )
+          case _ =>
+            Action(BadRequest(write(ErrorResponse("Invalid date format"))))
+        }
+      }(request)
     }
-
-  private def exportStreamingDesksAndQueuesBetweenTimestampsCSV(
-                                                                 start: SDateLike,
-                                                                 end: SDateLike,
-                                                                 terminalName: String,
-                                                                 exportSourceFn: (SDateLike, SDateLike, Terminal) =>
-                                                                   Source[String, NotUsed],
-                                                                 filePrefix: String
-                                                               ): Action[AnyContent] = Action.async {
-    val exportSource: Source[String, NotUsed] = exportSourceFn(start, end, Terminal(terminalName))
-    log.info(s"Exporting between $start and $end")
-
-    val fileName = makeFileName(filePrefix, Option(Terminal(terminalName)), start.toLocalDate, end.toLocalDate, airportConfig.portCode) + ".csv"
+  
+  private def exportBetweenTimestampsCSV(exportSourceFn: () => Source[String, NotUsed],
+                                         fileName: String,
+                                        ): Action[AnyContent] = Action.async {
+    val exportSource: Source[String, NotUsed] = exportSourceFn()
 
     Try(sourceToCsvResponse(exportSource, fileName)) match {
       case Success(value) => Future(value)
@@ -134,33 +120,54 @@ class DesksExportController @Inject()(cc: ControllerComponents, ctrl: DrtSystemI
     }
   }
 
-  private def deskRecsExportStreamForTerminalDates(pointInTime: Option[MillisSinceEpoch])(
-    start: SDateLike,
-    end: SDateLike,
-    terminal: Terminal
-  ): Source[String, NotUsed] =
-    StreamingDesksExport.deskRecsToCSVStreamWithHeaders(
+  private def deskRecsExportStreamForTerminalDates(pointInTime: Option[MillisSinceEpoch],
+                                                   start: SDateLike,
+                                                   end: SDateLike,
+                                                   terminal: Terminal,
+                                                   periodMinutes: Int,
+                                                  ): () => Source[String, NotUsed] =
+    () => StreamingDesksExport.deskRecsToCSVStreamWithHeaders(
       start,
       end,
       terminal,
       airportConfig.desksExportQueueOrder,
       ctrl.minuteLookups.queuesLookup,
       ctrl.minuteLookups.staffLookup,
-      pointInTime
+      pointInTime,
+      periodMinutes,
     )
 
-  private def deploymentsExportStreamForTerminalDates(pointInTime: Option[MillisSinceEpoch])(
-    start: SDateLike,
-    end: SDateLike,
-    terminal: Terminal
-  ): Source[String, NotUsed] =
-    StreamingDesksExport.deploymentsToCSVStreamWithHeaders(
+  private def deploymentsExportStreamForTerminalDates(pointInTime: Option[MillisSinceEpoch],
+                                                      start: SDateLike,
+                                                      end: SDateLike,
+                                                      terminal: Terminal,
+                                                      periodMinutes: Int,
+                                                     ): () => Source[String, NotUsed] =
+    () => StreamingDesksExport.deploymentsToCSVStreamWithHeaders(
       start,
       end,
       terminal,
       airportConfig.desksExportQueueOrder,
       ctrl.minuteLookups.queuesLookup,
       ctrl.minuteLookups.staffLookup,
-      pointInTime
+      pointInTime,
+      periodMinutes,
+    )
+
+  private def passengersExportStreamForTerminalDates(pointInTime: Option[MillisSinceEpoch],
+                                                     start: SDateLike,
+                                                     end: SDateLike,
+                                                     terminal: Terminal,
+                                                     periodMinutes: Int,
+                                                    ): () => Source[String, NotUsed] =
+    () => StreamingDesksExport.deploymentsToCSVStreamWithHeaders(
+      start,
+      end,
+      terminal,
+      airportConfig.desksExportQueueOrder,
+      ctrl.minuteLookups.queuesLookup,
+      ctrl.minuteLookups.staffLookup,
+      pointInTime,
+      periodMinutes,
     )
 }

--- a/server/src/main/scala/controllers/application/exports/DesksExportController.scala
+++ b/server/src/main/scala/controllers/application/exports/DesksExportController.scala
@@ -34,7 +34,7 @@ class DesksExportController @Inject()(cc: ControllerComponents, ctrl: DrtSystemI
 
             exportBetweenTimestampsCSV(
               deskRecsExportStreamForTerminalDates(pointInTime = Option(pit.millisSinceEpoch), start, end, Terminal(terminalName), periodMinutes(request)),
-              makeFileName(s"desks-and-queues-recs-at-${pit.toISOString}-for", Option(Terminal(terminalName)), start.toLocalDate, end.toLocalDate, airportConfig.portCode),
+              makeFileName(s"desks-and-queues-recs-at-${pit.toISOString}-for", Option(Terminal(terminalName)), start.toLocalDate, end.toLocalDate, airportConfig.portCode) + ".csv",
             )
           case _ =>
             Action(BadRequest(write(ErrorResponse("Invalid date format"))))
@@ -58,7 +58,7 @@ class DesksExportController @Inject()(cc: ControllerComponents, ctrl: DrtSystemI
 
             exportBetweenTimestampsCSV(
               deskRecsExportStreamForTerminalDates(pointInTime = None, start, end, Terminal(terminalName), periodMinutes(request)),
-              makeFileName("desks-and-queues-recs", Option(Terminal(terminalName)), start.toLocalDate, end.toLocalDate, airportConfig.portCode),
+              makeFileName("desks-and-queues-recs", Option(Terminal(terminalName)), start.toLocalDate, end.toLocalDate, airportConfig.portCode) + ".csv",
             )
           case _ =>
             Action(BadRequest(write(ErrorResponse("Invalid date format"))))
@@ -79,7 +79,7 @@ class DesksExportController @Inject()(cc: ControllerComponents, ctrl: DrtSystemI
 
             exportBetweenTimestampsCSV(
               deploymentsExportStreamForTerminalDates(pointInTime = Option(pit.millisSinceEpoch), start, end, Terminal(terminalName), periodMinutes(request)),
-              makeFileName(s"desks-and-queues-deps-at-${pit.toISOString}-for", Option(Terminal(terminalName)), start.toLocalDate, end.toLocalDate, airportConfig.portCode),
+              makeFileName(s"desks-and-queues-deps-at-${pit.toISOString}-for", Option(Terminal(terminalName)), start.toLocalDate, end.toLocalDate, airportConfig.portCode) + ".csv",
             )
           case _ =>
             Action(BadRequest(write(ErrorResponse("Invalid date format"))))
@@ -99,7 +99,7 @@ class DesksExportController @Inject()(cc: ControllerComponents, ctrl: DrtSystemI
 
             exportBetweenTimestampsCSV(
               deploymentsExportStreamForTerminalDates(pointInTime = None, start, end, Terminal(terminalName), periodMinutes(request)),
-              makeFileName("desks-and-queues-deps", Option(Terminal(terminalName)), start.toLocalDate, end.toLocalDate, airportConfig.portCode),
+              makeFileName("desks-and-queues-deps", Option(Terminal(terminalName)), start.toLocalDate, end.toLocalDate, airportConfig.portCode) + ".csv",
             )
           case _ =>
             Action(BadRequest(write(ErrorResponse("Invalid date format"))))
@@ -143,23 +143,6 @@ class DesksExportController @Inject()(cc: ControllerComponents, ctrl: DrtSystemI
                                                       terminal: Terminal,
                                                       periodMinutes: Int,
                                                      ): () => Source[String, NotUsed] =
-    () => StreamingDesksExport.deploymentsToCSVStreamWithHeaders(
-      start,
-      end,
-      terminal,
-      airportConfig.desksExportQueueOrder,
-      ctrl.minuteLookups.queuesLookup,
-      ctrl.minuteLookups.staffLookup,
-      pointInTime,
-      periodMinutes,
-    )
-
-  private def passengersExportStreamForTerminalDates(pointInTime: Option[MillisSinceEpoch],
-                                                     start: SDateLike,
-                                                     end: SDateLike,
-                                                     terminal: Terminal,
-                                                     periodMinutes: Int,
-                                                    ): () => Source[String, NotUsed] =
     () => StreamingDesksExport.deploymentsToCSVStreamWithHeaders(
       start,
       end,

--- a/server/src/main/scala/controllers/application/exports/DesksExportController.scala
+++ b/server/src/main/scala/controllers/application/exports/DesksExportController.scala
@@ -106,7 +106,7 @@ class DesksExportController @Inject()(cc: ControllerComponents, ctrl: DrtSystemI
         }
       }(request)
     }
-  
+
   private def exportBetweenTimestampsCSV(exportSourceFn: () => Source[String, NotUsed],
                                          fileName: String,
                                         ): Action[AnyContent] = Action.async {

--- a/server/src/main/scala/services/exports/StreamingDesksExport.scala
+++ b/server/src/main/scala/services/exports/StreamingDesksExport.scala
@@ -147,8 +147,8 @@ object StreamingDesksExport {
   }
 
   private def deskRecsCsv(cm: CrunchMinute): String =
-    s"${Math.round(cm.paxLoad)},${cm.waitTime},${cm.deskRec},${cm.actWait.getOrElse("")},${cm.actDesks.getOrElse("")}"
+    s"${cm.workLoad},${cm.waitTime},${cm.deskRec},${cm.actWait.getOrElse("")},${cm.actDesks.getOrElse("")}"
 
   private def deploymentsCsv(cm: CrunchMinute): String =
-    s"${Math.round(cm.paxLoad)},${cm.deployedWait.getOrElse("")},${cm.deployedDesks.getOrElse(0)},${cm.actWait.getOrElse("")},${cm.actDesks.getOrElse("")}"
+    s"${cm.workLoad},${cm.deployedWait.getOrElse("")},${cm.deployedDesks.getOrElse(0)},${cm.actWait.getOrElse("")},${cm.actDesks.getOrElse("")}"
 }

--- a/server/src/main/scala/services/exports/StreamingDesksExport.scala
+++ b/server/src/main/scala/services/exports/StreamingDesksExport.scala
@@ -14,7 +14,8 @@ import uk.gov.homeoffice.drt.time.{DateRange, SDate, SDateLike, UtcDate}
 
 import scala.collection.immutable
 import scala.collection.immutable.SortedMap
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration.DurationLong
 
 object StreamingDesksExport {
   val log: Logger = LoggerFactory.getLogger(getClass)
@@ -37,61 +38,51 @@ object StreamingDesksExport {
   def queueHeadings(queues: Seq[Queue]): String = queues.map(queue => Queues.displayName(queue))
     .flatMap(qn => List.fill(colHeadings().length)(Queues.exportQueueDisplayNames.getOrElse(Queue(qn), qn))).mkString(",")
 
-  def deskRecsToCSVStreamWithHeaders(
-                                      start: SDateLike,
-                                      end: SDateLike,
-                                      terminal: Terminal,
-                                      exportQueuesInOrder: List[Queue],
-                                      crunchMinuteLookup: MinutesLookup[CrunchMinute, TQM],
-                                      staffMinuteLookup: MinutesLookup[StaffMinute, TM],
-                                      maybePit: Option[MillisSinceEpoch] = None
+  def deskRecsToCSVStreamWithHeaders(start: SDateLike,
+                                     end: SDateLike,
+                                     terminal: Terminal,
+                                     exportQueuesInOrder: List[Queue],
+                                     crunchMinuteLookup: MinutesLookup[CrunchMinute, TQM],
+                                     staffMinuteLookup: MinutesLookup[StaffMinute, TM],
+                                     maybePit: Option[MillisSinceEpoch] = None,
+                                     periodMinutes: Int,
                                     )(implicit ec: ExecutionContext): Source[String, NotUsed] =
-    exportDesksToCSVStream(
-      start,
-      end,
-      terminal,
-      exportQueuesInOrder,
-      crunchMinuteLookup,
-      staffMinuteLookup,
-      deskRecsCsv,
-      maybePit)
-      .prepend(Source(List(csvHeader(exportQueuesInOrder, "req"))))
+    exportDesksToCSVStream(start, end, terminal, exportQueuesInOrder, crunchMinuteLookup, staffMinuteLookup,
+      deskRecsCsv, maybePit, periodMinutes
+    ).prepend(Source(List(csvHeader(exportQueuesInOrder, "req"))))
 
 
-  def deploymentsToCSVStreamWithHeaders(
-                                         start: SDateLike,
-                                         end: SDateLike,
-                                         terminal: Terminal,
-                                         exportQueuesInOrder: List[Queue],
-                                         crunchMinuteLookup: MinutesLookup[CrunchMinute, TQM],
-                                         staffMinuteLookup: MinutesLookup[StaffMinute, TM],
-                                         maybePit: Option[MillisSinceEpoch] = None
+  def deploymentsToCSVStreamWithHeaders(start: SDateLike,
+                                        end: SDateLike,
+                                        terminal: Terminal,
+                                        exportQueuesInOrder: List[Queue],
+                                        crunchMinuteLookup: MinutesLookup[CrunchMinute, TQM],
+                                        staffMinuteLookup: MinutesLookup[StaffMinute, TM],
+                                        maybePit: Option[MillisSinceEpoch] = None,
+                                        periodMinutes: Int,
                                        )(implicit ec: ExecutionContext): Source[String, NotUsed] =
-    exportDesksToCSVStream(start, end, terminal, exportQueuesInOrder, crunchMinuteLookup, staffMinuteLookup, deploymentsCsv, maybePit)
-      .prepend(Source(List(csvHeader(exportQueuesInOrder, "dep"))))
+    exportDesksToCSVStream(start, end, terminal, exportQueuesInOrder, crunchMinuteLookup, staffMinuteLookup,
+      deploymentsCsv, maybePit, periodMinutes
+    ).prepend(Source(List(csvHeader(exportQueuesInOrder, "dep"))))
 
 
-  def exportDesksToCSVStream(
-                              start: SDateLike,
-                              end: SDateLike,
-                              terminal: Terminal,
-                              exportQueuesInOrder: List[Queue],
-                              crunchMinuteLookup: MinutesLookup[CrunchMinute, TQM],
-                              staffMinuteLookup: MinutesLookup[StaffMinute, TM],
-                              deskExportFn: CrunchMinute => String,
-                              maybePit: Option[MillisSinceEpoch] = None
-                            )(implicit ec: ExecutionContext): Source[String, NotUsed] = {
-
+  def exportDesksToCSVStream(start: SDateLike,
+                             end: SDateLike,
+                             terminal: Terminal,
+                             exportQueuesInOrder: List[Queue],
+                             crunchMinuteLookup: MinutesLookup[CrunchMinute, TQM],
+                             staffMinuteLookup: MinutesLookup[StaffMinute, TM],
+                             deskExportFn: CrunchMinute => String,
+                             maybePit: Option[MillisSinceEpoch] = None,
+                             periodMinutes: Int,
+                            )(implicit ec: ExecutionContext): Source[String, NotUsed] =
     DateRange.utcDateRangeSource(start, end)
-      .mapAsync(1)(crunchUtcDate => {
-
-        val futureMaybeCM: Future[Option[CrunchApi.MinutesContainer[CrunchMinute, TQM]]] = crunchMinuteLookup((terminal, crunchUtcDate), maybePit)
-        val futureMaybeSM: Future[Option[CrunchApi.MinutesContainer[StaffMinute, TM]]] = staffMinuteLookup((terminal, crunchUtcDate), maybePit)
+      .mapAsync(1) { crunchUtcDate =>
         for {
-          maybeCMs <- futureMaybeCM
-          maybeSMs <- futureMaybeSM
+          maybeCMs <- crunchMinuteLookup((terminal, crunchUtcDate), maybePit)
+          maybeSMs <- staffMinuteLookup((terminal, crunchUtcDate), maybePit)
         } yield {
-          minutesToCsv(
+          minutesDesksAndQueuesToCsv(
             terminal,
             exportQueuesInOrder,
             crunchUtcDate,
@@ -99,39 +90,39 @@ object StreamingDesksExport {
             end,
             maybeCMs.map(_.minutes.map(_.toMinute)).getOrElse(List()),
             maybeSMs.map(_.minutes.map(_.toMinute)).getOrElse(List()),
-            deskExportFn
+            deskExportFn,
+            periodMinutes,
           )
         }
-      })
-  }
+      }
 
-  type MaybeCrunchMinutes = Option[CrunchApi.MinutesContainer[CrunchMinute, TQM]]
-  type MaybeStaffMinutes = Option[CrunchApi.MinutesContainer[StaffMinute, TM]]
-  type MinutesTuple = (MaybeCrunchMinutes, MaybeStaffMinutes)
-
-  def minutesToCsv(terminal: Terminal,
-                   exportQueuesInOrder: List[Queue],
-                   utcDate: UtcDate,
-                   start: SDateLike,
-                   end: SDateLike,
-                   crunchMinutes: Iterable[CrunchMinute],
-                   staffMinutes: Iterable[StaffMinute],
-                   deskExportFn: CrunchMinute => String,
-                  ): String = {
+  def minutesDesksAndQueuesToCsv(terminal: Terminal,
+                                 exportQueuesInOrder: List[Queue],
+                                 utcDate: UtcDate,
+                                 start: SDateLike,
+                                 end: SDateLike,
+                                 crunchMinutes: Iterable[CrunchMinute],
+                                 staffMinutes: Iterable[StaffMinute],
+                                 deskExportFn: CrunchMinute => String,
+                                 periodMinutes: Int,
+                                ): String = {
     val portState = PortState(
       List(),
       crunchMinutes,
       staffMinutes
     )
 
+    val minutesCount = (end.millisSinceEpoch - start.millisSinceEpoch).milliseconds.toMinutes.toInt
+    val numberOfPeriods = minutesCount / periodMinutes
+
     val terminalCrunchMinutes = portState
-      .crunchSummary(SDate(utcDate), 24 * 4, 15, terminal, exportQueuesInOrder)
+      .crunchSummary(SDate(utcDate), numberOfPeriods, periodMinutes, terminal, exportQueuesInOrder)
     val terminalCrunchMinutesWithinRange: SortedMap[MillisSinceEpoch, Map[Queue, CrunchMinute]] = terminalCrunchMinutes.filter {
       case (millis, _) => start.millisSinceEpoch <= millis && millis <= end.millisSinceEpoch
     }
 
     val terminalStaffMinutes = portState
-      .staffSummary(SDate(utcDate), 24 * 4, 15, terminal)
+      .staffSummary(SDate(utcDate), numberOfPeriods, periodMinutes, terminal)
     val terminalStaffMinutesWithinRange: Map[MillisSinceEpoch, StaffMinute] = terminalStaffMinutes.filter {
       case (millis, _) => start.millisSinceEpoch <= millis && millis <= end.millisSinceEpoch
     }

--- a/server/src/test/scala/services/OptimiserInputSpec.scala
+++ b/server/src/test/scala/services/OptimiserInputSpec.scala
@@ -1,0 +1,51 @@
+package services
+
+import org.specs2.mutable.Specification
+import uk.gov.homeoffice.drt.egates.Desk
+
+import scala.io.{BufferedSource, Source}
+
+
+class OptimiserInputSpec extends Specification {
+  val oneDesk: Seq[Int] = Seq.fill(30)(1)
+  val oneBank: Seq[Int] = Seq.fill(30)(1)
+
+  val filename = "some-desks-and-queues-file.csv"
+  val fileSource: BufferedSource = Source.fromFile(filename)
+  val workloadIndex = 12
+  val desksIndex = 14
+  val wlDesks: Iterator[(String, String)] = for (line <- fileSource.getLines) yield {
+    val cells = line.split(",").toIndexedSeq
+    val workload = cells(workloadIndex)
+    val desks = cells(desksIndex)
+    (workload, desks)
+  }
+  val wlDesksSeq = wlDesks.toSeq :+ ("0", "0")
+  val workloads = wlDesksSeq.drop(2).map(_._1.toDouble)
+  val deskCounts = wlDesksSeq.drop(2).map(_._2.toInt)
+
+  fileSource.close()
+
+  "Crunch with desk workload processors" >> {
+    skipped("exploratory test")
+    "Given 1 minutes incoming workload per minute, and desks fixed at 1 per minute" >> {
+      "I should see all the workload completed each minute, leaving zero wait times" >> {
+        val processors = WorkloadProcessorsProvider(deskCounts.map(d => Seq.fill(d)(Desk)))
+        val result: Seq[Int] = OptimiserWithFlexibleProcessors.runSimulationOfWork(
+          workloads = workloads,
+          desks = deskCounts,
+          config = OptimiserConfig(60, processors)).get
+
+        println(s"waits: ${
+          result.zipWithIndex.map { x =>
+            val hour = x._2 / 60
+            val minute = x._2 % 60
+            f"$hour%02d:$minute%02d => ${x._1}"
+          }.mkString("\n")
+        }")
+
+        success
+      }
+    }
+  }
+}

--- a/server/src/test/scala/services/exports/StreamingDesksBstExportSpec.scala
+++ b/server/src/test/scala/services/exports/StreamingDesksBstExportSpec.scala
@@ -87,12 +87,14 @@ class StreamingDesksBstExportSpec extends CrunchTestLike {
       val staffMinuteLookup = MockMinutesLookup.smLookup(staffMinutesContainer)
 
       val resultSource: Source[String, NotUsed] = StreamingDesksExport.deskRecsToCSVStreamWithHeaders(
-        exportStart,
-        exportEnd,
-        T1,
-        defaultAirportConfig.forecastExportQueueOrder,
-        crunchMinuteLookup,
-        staffMinuteLookup
+        start = exportStart,
+        end = exportEnd,
+        terminal = T1,
+        exportQueuesInOrder = defaultAirportConfig.forecastExportQueueOrder,
+        crunchMinuteLookup = crunchMinuteLookup,
+        staffMinuteLookup = staffMinuteLookup,
+        maybePit = None,
+        periodMinutes = 15
       )
 
       val result = takeCSVLines(dropHeadings(resultStreamToCSV(resultSource)), 8)

--- a/server/src/test/scala/services/exports/StreamingDesksExportSpec.scala
+++ b/server/src/test/scala/services/exports/StreamingDesksExportSpec.scala
@@ -70,12 +70,15 @@ class StreamingDesksExportSpec extends CrunchTestLike {
       val staffMinuteLookup = MockMinutesLookup.smLookup(staffMinutesContainer)
 
       val resultSource: Source[String, NotUsed] = StreamingDesksExport.deskRecsToCSVStreamWithHeaders(
-        minute1,
-        minute2,
-        T1,
-        defaultAirportConfig.forecastExportQueueOrder,
-        crunchMinuteLookup,
-        staffMinuteLookup)
+        start = minute1,
+        end = minute2,
+        terminal = T1,
+        exportQueuesInOrder = defaultAirportConfig.forecastExportQueueOrder,
+        crunchMinuteLookup = crunchMinuteLookup,
+        staffMinuteLookup = staffMinuteLookup,
+        maybePit = None,
+        periodMinutes = 15,
+      )
 
       val result = takeCSVLines(dropHeadings(resultStreamToCSV(resultSource)), 2)
 
@@ -93,12 +96,15 @@ class StreamingDesksExportSpec extends CrunchTestLike {
       val staffMinuteLookup = MockMinutesLookup.smLookup(staffMinutesContainer)
 
       val resultSource: Source[String, NotUsed] = StreamingDesksExport.deploymentsToCSVStreamWithHeaders(
-        minute1,
-        minute2,
-        T1,
-        defaultAirportConfig.forecastExportQueueOrder,
-        crunchMinuteLookup,
-        staffMinuteLookup)
+        start = minute1,
+        end = minute2,
+        terminal = T1,
+        exportQueuesInOrder = defaultAirportConfig.forecastExportQueueOrder,
+        crunchMinuteLookup = crunchMinuteLookup,
+        staffMinuteLookup = staffMinuteLookup,
+        maybePit = None,
+        periodMinutes = 15,
+      )
 
       val result = takeCSVLines(dropHeadings(resultStreamToCSV(resultSource)), 2)
 
@@ -121,7 +127,10 @@ class StreamingDesksExportSpec extends CrunchTestLike {
         T1,
         defaultAirportConfig.forecastExportQueueOrder,
         crunchMinuteLookup,
-        staffMinuteLookup)
+        staffMinuteLookup,
+        maybePit = None,
+        periodMinutes = 15,
+      )
 
       val result = takeCSVLines(resultStreamToCSV(resultSource), 4)
 
@@ -141,12 +150,15 @@ class StreamingDesksExportSpec extends CrunchTestLike {
       val staffMinuteLookup = MockMinutesLookup.smLookup(staffMinutesContainer)
 
       val resultSource: Source[String, NotUsed] = StreamingDesksExport.deploymentsToCSVStreamWithHeaders(
-        minute1,
-        minute2,
-        T1,
-        defaultAirportConfig.forecastExportQueueOrder,
-        crunchMinuteLookup,
-        staffMinuteLookup)
+        start = minute1,
+        end = minute2,
+        terminal = T1,
+        exportQueuesInOrder = defaultAirportConfig.forecastExportQueueOrder,
+        crunchMinuteLookup = crunchMinuteLookup,
+        staffMinuteLookup = staffMinuteLookup,
+        maybePit = None,
+        periodMinutes = 15,
+      )
 
       val result = takeCSVLines(resultStreamToCSV(resultSource), 4)
 
@@ -166,12 +178,15 @@ class StreamingDesksExportSpec extends CrunchTestLike {
       val staffMinuteLookup = MockMinutesLookup.smLookup(staffMinutesContainer)
 
       val resultSource: Source[String, NotUsed] = StreamingDesksExport.deskRecsToCSVStreamWithHeaders(
-        minute1,
-        minute2,
-        T1,
-        defaultAirportConfig.forecastExportQueueOrder,
-        crunchMinuteLookup,
-        staffMinuteLookup)
+        start = minute1,
+        end = minute2,
+        terminal = T1,
+        exportQueuesInOrder = defaultAirportConfig.forecastExportQueueOrder,
+        crunchMinuteLookup = crunchMinuteLookup,
+        staffMinuteLookup = staffMinuteLookup,
+        maybePit = None,
+        periodMinutes = 15,
+      )
 
       val result = takeCSVLines(dropHeadings(resultStreamToCSV(resultSource)), 2)
 
@@ -192,12 +207,15 @@ class StreamingDesksExportSpec extends CrunchTestLike {
       val end = SDate("2020-11-03").getLocalNextMidnight.addMinutes(-1)
 
       val resultSource: Source[String, NotUsed] = StreamingDesksExport.deskRecsToCSVStreamWithHeaders(
-        start,
-        end,
-        T1,
-        defaultAirportConfig.forecastExportQueueOrder,
-        crunchMinuteLookup,
-        staffMinuteLookup)
+        start = start,
+        end = end,
+        terminal = T1,
+        exportQueuesInOrder = defaultAirportConfig.forecastExportQueueOrder,
+        crunchMinuteLookup = crunchMinuteLookup,
+        staffMinuteLookup = staffMinuteLookup,
+        maybePit = None,
+        periodMinutes = 15,
+      )
 
       val result = resultStreamToCSV(resultSource).split("\n").length
 
@@ -219,12 +237,15 @@ class StreamingDesksExportSpec extends CrunchTestLike {
       val end = SDate("2020-11-02")
 
       val resultSource: Source[String, NotUsed] = StreamingDesksExport.deskRecsToCSVStreamWithHeaders(
-        start,
-        end,
-        T1,
-        defaultAirportConfig.forecastExportQueueOrder,
-        crunchMinuteLookup,
-        staffMinuteLookup)
+        start = start,
+        end = end,
+        terminal = T1,
+        exportQueuesInOrder = defaultAirportConfig.forecastExportQueueOrder,
+        crunchMinuteLookup = crunchMinuteLookup,
+        staffMinuteLookup = staffMinuteLookup,
+        maybePit = None,
+        periodMinutes = 15,
+      )
 
       val headingLines = 2
 
@@ -251,12 +272,15 @@ class StreamingDesksExportSpec extends CrunchTestLike {
 
 
       val resultSource: Source[String, NotUsed] = StreamingDesksExport.deskRecsToCSVStreamWithHeaders(
-        minute1,
-        minute2,
-        T1,
-        defaultAirportConfig.forecastExportQueueOrder,
-        crunchMinuteLookup,
-        staffMinuteLookup)
+        start = minute1,
+        end = minute2,
+        terminal = T1,
+        exportQueuesInOrder = defaultAirportConfig.forecastExportQueueOrder,
+        crunchMinuteLookup = crunchMinuteLookup,
+        staffMinuteLookup = staffMinuteLookup,
+        maybePit = None,
+        periodMinutes = 15,
+      )
 
       val result = takeCSVLines(dropHeadings(resultStreamToCSV(resultSource)), 2)
 


### PR DESCRIPTION
Add optional query string parameter `period-minutes` to specify the granularity of the desks and queues exports