### PR TITLE
DRTII-1566 smaller change with less css

### DIFF
--- a/client/src/main/scala/drt/client/components/TerminalDesksAndQueues.scala
+++ b/client/src/main/scala/drt/client/components/TerminalDesksAndQueues.scala
@@ -195,7 +195,7 @@ object TerminalDesksAndQueues {
 
         <.div(^.className := "view-controls",
           <.div(^.className := "view-controls-selector", deskTypeControls.toTagMod),
-          <.div(^.className := "display-view-controls-selector", displayTypeControls.toTagMod),
+          <.div(^.className := "view-controls-selector", displayTypeControls.toTagMod),
         )
       }
 

--- a/server/src/main/assets/stylesheets/main.less
+++ b/server/src/main/assets/stylesheets/main.less
@@ -962,16 +962,6 @@ rect.bordered {
 .view-controls-selector {
   display: flex;
   justify-content: space-between;
-  gap: 20px;
-  background-color: #eee;
-  border-radius: 5px;
-  margin: 2px 0px;
-  padding: 5px 10px;
-}
-
-.display-view-controls-selector {
-  display: flex;
-  gap: 45px;
   background-color: #eee;
   border-radius: 5px;
   margin: 2px 0px;
@@ -980,7 +970,8 @@ rect.bordered {
 
 .controls-radio-wrapper {
   display: flex;
-  justify-content: space-between;
+  justify-content: left;
+  width: 150px;
   align-items: center;
   gap: 5px;
 }


### PR DESCRIPTION
Set the `controls-radio-wrapper` width:
 - Simplifies css
 - Makes css more robust for future content changes