### PR TITLE
Drtii 1928 false wait times

### DIFF
--- a/client/src/main/scala/drt/client/components/QueueChartComponent.scala
+++ b/client/src/main/scala/drt/client/components/QueueChartComponent.scala
@@ -15,7 +15,8 @@ object QueueChartComponent {
                    queueSummaries: List[(Long, Map[Queue, CrunchMinute])],
                    sla: Int,
                    interval: Int,
-                   deskType: DeskType)
+                   deskType: DeskType,
+                  )
 
   val component: Component[Props, Unit, Unit, CtorType.Props] = ScalaComponent.builder[Props]("QueueChart")
     .render_P { props =>
@@ -25,7 +26,11 @@ object QueueChartComponent {
       val paxInQueueSet: ChartJsDataSet = ChartJsDataSet.line(
         label = "Pax in queue",
         data = props.queueSummaries.map {
-          case (_, queuesAndMinutes) => queuesAndMinutes(props.queue).maybePaxInQueue.getOrElse(0).toDouble
+          case (_, queuesAndMinutes) =>
+            if (props.deskType == Ideal)
+              queuesAndMinutes(props.queue).maybePaxInQueue.getOrElse(0).toDouble
+            else
+              queuesAndMinutes(props.queue).maybeDeployedPaxInQueue.getOrElse(0).toDouble
         },
         colour = RGBA.blue1,
         backgroundColour = Option(RGBA.blue1.copy(alpha = 0.2)),

--- a/server/src/main/scala/services/crunch/desklimits/fixed/FixedTerminalDeskLimits.scala
+++ b/server/src/main/scala/services/crunch/desklimits/fixed/FixedTerminalDeskLimits.scala
@@ -3,11 +3,12 @@ package services.crunch.desklimits.fixed
 import services.WorkloadProcessorsProvider
 import services.crunch.desklimits.{EmptyCapacityProvider, QueueCapacityProvider, TerminalDeskLimitsLike}
 import uk.gov.homeoffice.drt.ports.Queues.Queue
+import uk.gov.homeoffice.drt.time.LocalDate
 
 import scala.collection.immutable.{Map, NumericRange}
 import scala.concurrent.Future
 
-case class FixedTerminalDeskLimits(minDesksByQueue24Hrs: Map[Queue, IndexedSeq[Int]],
+case class FixedTerminalDeskLimits(minDesksByQueue24Hrs: LocalDate => Map[Queue, IndexedSeq[Int]],
                                    maxDesksByQueue24Hrs: Map[Queue, QueueCapacityProvider],
                                   ) extends TerminalDeskLimitsLike {
   override def maxDesksForMinutes(minuteMillis: NumericRange[Long],

--- a/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeployments.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeployments.scala
@@ -97,6 +97,13 @@ object DynamicRunnableDeployments extends DrtRunnableGraph {
           log.info(s"[deployments] Optimising ${request.terminal} ${request.date.toISOString}")
           loadsToQueueMinutes(request.minutesInMillis(ac.crunchOffsetMinutes), loads, deskLimitsByTerminal, "deployments", request.terminal)
             .map { minutes =>
+//              if (request.date == LocalDate(2025, 8, 5)) {
+//                println(s"[deployments] ${request.terminal} ${request.date.toISOString} - wait times:\n${minutes.asContainer.minutes.toSeq.sortBy(_.minute).map { x =>
+//                  val min: CrunchMinute = x.toMinute
+//                  s"${min.minute} -> ${min.deployedDesks} desks -> ${min.deployedWait} wait time"
+//                }.mkString("\n")
+//                }")
+//              }
               log.info(s"[deployments] Optimising complete. Took ${SDate.now().millisSinceEpoch - started}ms")
               setUpdatedAtForDay(request.terminal, request.date, SDate.now().millisSinceEpoch)
               Option(minutes)

--- a/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeployments.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/DynamicRunnableDeployments.scala
@@ -97,13 +97,6 @@ object DynamicRunnableDeployments extends DrtRunnableGraph {
           log.info(s"[deployments] Optimising ${request.terminal} ${request.date.toISOString}")
           loadsToQueueMinutes(request.minutesInMillis(ac.crunchOffsetMinutes), loads, deskLimitsByTerminal, "deployments", request.terminal)
             .map { minutes =>
-//              if (request.date == LocalDate(2025, 8, 5)) {
-//                println(s"[deployments] ${request.terminal} ${request.date.toISOString} - wait times:\n${minutes.asContainer.minutes.toSeq.sortBy(_.minute).map { x =>
-//                  val min: CrunchMinute = x.toMinute
-//                  s"${min.minute} -> ${min.deployedDesks} desks -> ${min.deployedWait} wait time"
-//                }.mkString("\n")
-//                }")
-//              }
               log.info(s"[deployments] Optimising complete. Took ${SDate.now().millisSinceEpoch - started}ms")
               setUpdatedAtForDay(request.terminal, request.date, SDate.now().millisSinceEpoch)
               Option(minutes)

--- a/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProvider.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProvider.scala
@@ -51,7 +51,7 @@ case class PortDesksAndWaitsProvider(queuesByTerminal: (LocalDate, LocalDate, Te
 
   private def deskRecsToSimulations(terminalQueueDeskRecs: Iterable[DeskRecMinute]): Map[TQM, SimulationMinute] = terminalQueueDeskRecs
     .map {
-      case DeskRecMinute(t, q, m, _, _, d, w, _) => (TQM(t, q, m), SimulationMinute(t, q, m, d, w))
+      case DeskRecMinute(t, q, m, _, _, d, w, piq) => (TQM(t, q, m), SimulationMinute(t, q, m, d, w, piq))
     }.toMap
 
   private def terminalDescRecs(terminal: Terminal, description: String): TerminalDesksAndWaitsProvider =

--- a/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProvider.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProvider.scala
@@ -43,6 +43,15 @@ case class PortDesksAndWaitsProvider(queuesByTerminal: (LocalDate, LocalDate, Te
                                  )
                                  (implicit ec: ExecutionContext, mat: Materializer): Future[SimulationMinutes] = {
     terminalLoadsToDesks(minuteMillis, passengersByQueue, deskLimitProviders, description, terminal).map { deskRecMinutes =>
+//      val date = SDate(minuteMillis.min).toLocalDate
+//      println(s"---- Loads to simulations for $date ${deskRecMinutes.minutes.size} minutes ----\n")
+//      if (date == LocalDate(2025, 8, 5)) {
+//        deskRecMinutes.minutes.toSeq.sortBy(_.minute).foreach { case DeskRecMinute(t, q, m, pl, wl, d, w, mp) =>
+//          val sDateLike = SDate(m)
+//          println(s"DeskRecMinute: $t, $q, ${sDateLike.toISOString}: $pl, $wl, $d, $w, $mp")
+//        }
+//      }
+
       val simMinutes = deskRecsToSimulations(deskRecMinutes.minutes).values.toSeq
       log.info(s"Deployments & waits calculated for ${SDate(minuteMillis.min).toISOString} to ${SDate(minuteMillis.max).toISOString}")
       SimulationMinutes(simMinutes)

--- a/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProvider.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/PortDesksAndWaitsProvider.scala
@@ -43,15 +43,6 @@ case class PortDesksAndWaitsProvider(queuesByTerminal: (LocalDate, LocalDate, Te
                                  )
                                  (implicit ec: ExecutionContext, mat: Materializer): Future[SimulationMinutes] = {
     terminalLoadsToDesks(minuteMillis, passengersByQueue, deskLimitProviders, description, terminal).map { deskRecMinutes =>
-//      val date = SDate(minuteMillis.min).toLocalDate
-//      println(s"---- Loads to simulations for $date ${deskRecMinutes.minutes.size} minutes ----\n")
-//      if (date == LocalDate(2025, 8, 5)) {
-//        deskRecMinutes.minutes.toSeq.sortBy(_.minute).foreach { case DeskRecMinute(t, q, m, pl, wl, d, w, mp) =>
-//          val sDateLike = SDate(m)
-//          println(s"DeskRecMinute: $t, $q, ${sDateLike.toISOString}: $pl, $wl, $d, $w, $mp")
-//        }
-//      }
-
       val simMinutes = deskRecsToSimulations(deskRecMinutes.minutes).values.toSeq
       log.info(s"Deployments & waits calculated for ${SDate(minuteMillis.min).toISOString} to ${SDate(minuteMillis.max).toISOString}")
       SimulationMinutes(simMinutes)

--- a/server/src/test/scala/drt/shared/SimulationMinuteSpec.scala
+++ b/server/src/test/scala/drt/shared/SimulationMinuteSpec.scala
@@ -30,6 +30,7 @@ class SimulationMinuteSpec extends Specification {
         minute = 0L,
         desks = 2,
         waitTime = 3,
+        maybePaxInQueue = Option(4),
       )
     }
     "When they have the same values `maybeUpdated` should return None" >> {

--- a/server/src/test/scala/services/crunch/desklimits/fixed/FixedTerminalDeskLimitsSpec.scala
+++ b/server/src/test/scala/services/crunch/desklimits/fixed/FixedTerminalDeskLimitsSpec.scala
@@ -31,7 +31,7 @@ class FixedTerminalDeskLimitsSpec extends CrunchTestLike {
     "When I ask for max desks at each hour from midnight to midnight outside BST " +
     "Then I should get 10 for every hour" >> {
     val maxDesks = IndexedSeq.fill(24)(10)
-    val limits = FixedTerminalDeskLimits(Map(EeaDesk -> minDesks), Map(EeaDesk -> DeskCapacityProvider(maxDesks)))
+    val limits = FixedTerminalDeskLimits(_ => Map(EeaDesk -> minDesks), Map(EeaDesk -> DeskCapacityProvider(maxDesks)))
     val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
     val expected = uniformDesksForHours(10, 24)
 
@@ -42,7 +42,7 @@ class FixedTerminalDeskLimitsSpec extends CrunchTestLike {
     "When I ask for max desks at each hour from midnight to midnight inside BST " +
     "Then I should get 0 through 23, ie not offset by an hour" >> {
     val maxDesks = 0 to 23
-    val limits = FixedTerminalDeskLimits(Map(EeaDesk -> minDesks), Map(EeaDesk -> DeskCapacityProvider(maxDesks)))
+    val limits = FixedTerminalDeskLimits(_ => Map(EeaDesk -> minDesks), Map(EeaDesk -> DeskCapacityProvider(maxDesks)))
     val result = limits.maxDesksForMinutes(nonBstMidnightToMidnightByHour, EeaDesk, Map())
     val expected = WorkloadProcessorsProvider((0 to 23).map(d => WorkloadProcessors(Seq.fill(d)(Desk))))
 

--- a/server/src/test/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimitsFromAvailableStaffSpec.scala
+++ b/server/src/test/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimitsFromAvailableStaffSpec.scala
@@ -44,7 +44,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
       "Then I should get 5 for every hour - the available staff" >> {
         val terminalDesks = 10
         val availableStaff = List.fill(24)(5)
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), Map(), Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), _ => Map(), Map())
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
         val expected = uniformDesksForHours(5, 24)
 
@@ -58,7 +58,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
       "Then I should get 10 for every hour - the terminal desks" >> {
         val terminalDesks = 10
         val availableStaff = List.fill(24)(20)
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), Map(), Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), _ => Map(), Map())
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
         val expected = uniformDesksForHours(10, 24)
 

--- a/server/src/test/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimitsFromAvailableStaffSpec.scala
+++ b/server/src/test/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimitsFromAvailableStaffSpec.scala
@@ -73,7 +73,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
         val terminalDesks = 10
         val availableStaff = List.fill(24)(5)
         val minDesksForEeaAndNonEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> minDesks)
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), minDesksForEeaAndNonEea, Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map())
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
         val expected = uniformDesksForHours(4, 24)
 
@@ -88,7 +88,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
         val terminalDesks = 10
         val availableStaff = List.fill(24)(15)
         val minDesksForEeaAndNonEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> minDesks)
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), minDesksForEeaAndNonEea, Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map())
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
         val expected = uniformDesksForHours(9, 24)
 
@@ -104,7 +104,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
         val availableStaff = List.fill(24)(15)
         val minDesksForEeaAndNonEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> minDesks)
         val existingNonEeaAllocation: Map[Queue, List[Int]] = Map(NonEeaDesk -> List.fill(24)(2))
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), minDesksForEeaAndNonEea, Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map())
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, existingNonEeaAllocation)
         val expected = uniformDesksForHours(8, 24)
 
@@ -120,7 +120,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
         val availableStaff = List.fill(24)(5)
         val minDesksForEeaAndNonEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> minDesks)
         val existingNonEeaAllocation: Map[Queue, List[Int]] = Map(NonEeaDesk -> List.fill(24)(2))
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), minDesksForEeaAndNonEea, Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map())
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, existingNonEeaAllocation)
         val expected = uniformDesksForHours(3, 24)
 
@@ -136,7 +136,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
         val availableStaff = List.fill(24)(5)
         val minDesksForEeaAndNonEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> minDesks, EGate -> minDesks)
         val existingNonEeaAllocation: Map[Queue, List[Int]] = Map(NonEeaDesk -> List.fill(24)(2))
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), minDesksForEeaAndNonEea, Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map())
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, existingNonEeaAllocation)
         val expected = uniformDesksForHours(2, 24)
 
@@ -152,7 +152,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
         val availableStaff = List.fill(24)(15)
         val minDesksForEeaAndNonEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> minDesks, EGate -> minDesks)
         val existingNonEeaAllocation: Map[Queue, List[Int]] = Map(NonEeaDesk -> List.fill(24)(2))
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), minDesksForEeaAndNonEea, Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map())
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, existingNonEeaAllocation)
         val expected = uniformDesksForHours(8, 24)
 
@@ -168,7 +168,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
           val terminalDesks = 10
           val availableStaff = List.fill(24)(0)
           val minDesksForEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks)
-          val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), minDesksForEea, Map())
+          val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), _ => minDesksForEea, Map())
           val result: Future[(Iterable[Int], WorkloadProcessorsProvider)] = limits.deskLimitsForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
           val expected = (List.fill(24)(0), uniformDesksForHours(0, 24))
 
@@ -183,7 +183,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
           val terminalDesks = 10
           val availableStaff = List.fill(24)(1)
           val minDesksForEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> IndexedSeq.fill(24)(4))
-          val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), minDesksForEea, Map())
+          val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), _ => minDesksForEea, Map())
           val result = limits.deskLimitsForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
           val expected = (List.fill(24)(0), uniformDesksForHours(0, 24))
 
@@ -199,7 +199,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
           val availableStaff = List.fill(24)(2)
           val minDesksForEea: Map[Queue, IndexedSeq[Int]] = Map(EGate -> minDesks)
           val egatesCapProvider = EgatesCapacityProvider(() => Future.successful(EgateBanksUpdates(List(EgateBanksUpdate(0L, IndexedSeq.fill(3)(EgateBank(IndexedSeq())))))))
-          val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(), minDesksForEea, Map(EGate -> egatesCapProvider))
+          val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(), _ => minDesksForEea, Map(EGate -> egatesCapProvider))
           val result = limits.deskLimitsForMinutes(bstMidnightToMidnightByHour, EGate, Map())
           val expected = (List.fill(24)(0), WorkloadProcessorsProvider(IndexedSeq.fill(24)(WorkloadProcessors(Seq.fill(2)(EgateBank(IndexedSeq()))))))
 

--- a/server/src/test/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimitsSpec.scala
+++ b/server/src/test/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimitsSpec.scala
@@ -36,7 +36,7 @@ class FlexedTerminalDeskLimitsSpec extends CrunchTestLike {
     "When I ask for max desks at each hour from midnight to midnight outside BST " >> {
       "Then I should get 10 for every hour" >> {
         val terminalDesks = 10
-        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk), minDesksByQueue, Map())
+        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk), _ => minDesksByQueue, Map())
         val result: Future[WorkloadProcessorsProvider] = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
         val expected = uniformDesksForHours(10, 24)
 
@@ -49,7 +49,7 @@ class FlexedTerminalDeskLimitsSpec extends CrunchTestLike {
     "When I ask for max desks for Eee for 24 hours, with no existing allocations for Non-EEA " >> {
       "Then I should get 9 for every hour (10 minus 1 minimum Non-EEA desk)" >> {
         val terminalDesks = 10
-        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk, NonEeaDesk), minDesksByQueue, Map())
+        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksByQueue, Map())
         val noExistingAllocations = Map[Queue, List[Int]]()
         val result = limits.maxDesksForMinutes(nonBstMidnightToMidnightByHour, EeaDesk, noExistingAllocations)
         val expected = uniformDesksForHours(9, 24)
@@ -63,7 +63,7 @@ class FlexedTerminalDeskLimitsSpec extends CrunchTestLike {
     "When I ask for max desks for Eee for 24 hours, with existing allocations for Non-EEA of 4 desks " >> {
       "Then I should get 6 for every hour (10 minus 4 allocated Non-EEA desks)" >> {
         val terminalDesks = 10
-        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk, NonEeaDesk), minDesksByQueue, Map())
+        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksByQueue, Map())
         val existingNonEeaAllocations = Map[Queue, List[Int]](NonEeaDesk -> List.fill(24)(4))
         val result = limits.maxDesksForMinutes(nonBstMidnightToMidnightByHour, EeaDesk, existingNonEeaAllocations)
         val expected = uniformDesksForHours(6, 24)
@@ -77,7 +77,7 @@ class FlexedTerminalDeskLimitsSpec extends CrunchTestLike {
     "When I ask for max desks for EGates for 24 hours, with existing allocations for the flexed desks " >> {
       "Then I should get 3 for every hour - the max for EGates regardless of the existing allocations" >> {
         val terminalDesks = 10
-        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk, NonEeaDesk), minDesksByQueue, Map(EGate -> DeskCapacityProvider(IndexedSeq.fill(24)(3))))
+        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksByQueue, Map(EGate -> DeskCapacityProvider(IndexedSeq.fill(24)(3))))
         val existingFlexedAllocations = Map[Queue, List[Int]](
           EeaDesk -> List.fill(24)(5),
           NonEeaDesk -> List.fill(24)(5)

--- a/server/src/test/scala/services/crunch/deskrecs/DeskFlexingSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/DeskFlexingSpec.scala
@@ -83,7 +83,7 @@ class DeskFlexingSpec extends CrunchTestLike {
 
         val queues = List(EeaDesk, NonEeaDesk)
 
-        val maxDeskProvider = FlexedTerminalDeskLimits(totalDesks, Set(EeaDesk, NonEeaDesk), minDesks, maxDesks.view.mapValues(d => DeskCapacityProvider(d)).toMap)
+        val maxDeskProvider = FlexedTerminalDeskLimits(totalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesks, maxDesks.view.mapValues(d => DeskCapacityProvider(d)).toMap)
 
         val eventualDesksAndWaits = services.crunch.deskrecs.TerminalDesksAndWaitsProvider(T1, (_: LocalDate, q: Queue) => Future.successful(ac.slaByQueue(q)), queuePriority, observer.mockDeskRecs, "test")
           .desksAndWaits(minuteMillis, mockLoads(queues), maxDeskProvider)
@@ -110,7 +110,7 @@ class DeskFlexingSpec extends CrunchTestLike {
 
         val queues = List(FastTrack, NonEeaDesk, EeaDesk)
 
-        val maxDeskProvider = FlexedTerminalDeskLimits(totalDesks, Set(EeaDesk, NonEeaDesk, FastTrack), minDesks, maxDesks.view.mapValues(d => DeskCapacityProvider(d)).toMap)
+        val maxDeskProvider = FlexedTerminalDeskLimits(totalDesks, Set(EeaDesk, NonEeaDesk, FastTrack), _ => minDesks, maxDesks.view.mapValues(d => DeskCapacityProvider(d)).toMap)
 
         val eventualDesksAndWaits = services.crunch.deskrecs.TerminalDesksAndWaitsProvider(T1, (_: LocalDate, q: Queue) => Future.successful(ac.slaByQueue(q)), queuePriority, observer.mockDeskRecs, "test")
           .desksAndWaits(minuteMillis, mockLoads(queues), maxDeskProvider)
@@ -141,7 +141,7 @@ class DeskFlexingSpec extends CrunchTestLike {
 
         val queues = List(EGate, FastTrack, NonEeaDesk, EeaDesk)
 
-        val maxDeskProvider = FlexedTerminalDeskLimits(totalDesks, Set(EeaDesk, NonEeaDesk, FastTrack), minDesks, maxDesks.view.mapValues(d => DeskCapacityProvider(d)).toMap)
+        val maxDeskProvider = FlexedTerminalDeskLimits(totalDesks, Set(EeaDesk, NonEeaDesk, FastTrack), _ => minDesks, maxDesks.view.mapValues(d => DeskCapacityProvider(d)).toMap)
 
         val eventualDesksAndWaits = services.crunch.deskrecs.TerminalDesksAndWaitsProvider(T1, (_: LocalDate, q: Queue) => Future.successful(ac.slaByQueue(q)), queuePriority, observer.mockDeskRecs, "test")
           .desksAndWaits(minuteMillis, mockLoads(queues), maxDeskProvider)

--- a/server/src/test/scala/services/crunch/deskrecs/PortDesksAndWaitsProviderSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/PortDesksAndWaitsProviderSpec.scala
@@ -92,7 +92,7 @@ class PortDesksAndWaitsProviderSpec extends CrunchTestLike {
   }
 
   object MockTerminalDeskLimits extends TerminalDeskLimitsLike {
-    override val minDesksByQueue24Hrs: Map[Queue, IndexedSeq[Int]] = Map(
+    override val minDesksByQueue24Hrs: LocalDate => Map[Queue, IndexedSeq[Int]] = _ => Map(
       EeaDesk -> IndexedSeq.fill(24)(10),
       EGate -> IndexedSeq.fill(24)(10),
       NonEeaDesk -> IndexedSeq.fill(24)(10),

--- a/shared/src/main/scala/drt/shared/SimulationMinute.scala
+++ b/shared/src/main/scala/drt/shared/SimulationMinute.scala
@@ -13,6 +13,7 @@ object SimulationMinute {
     minute = crunchMinute.minute,
     desks = crunchMinute.deployedDesks.getOrElse(0),
     waitTime = crunchMinute.deployedWait.getOrElse(0),
+    maybePaxInQueue = crunchMinute.maybeDeployedPaxInQueue,
   )
 }
 
@@ -20,12 +21,14 @@ case class SimulationMinute(terminal: Terminal,
                             queue: Queue,
                             minute: MillisSinceEpoch,
                             desks: Int,
-                            waitTime: Int) extends SimulationMinuteLike with MinuteComparison[CrunchMinute] with MinuteLike[CrunchMinute, TQM] {
+                            waitTime: Int,
+                            maybePaxInQueue: Option[Int],
+                           ) extends SimulationMinuteLike with MinuteComparison[CrunchMinute] with MinuteLike[CrunchMinute, TQM] {
   lazy val key: TQM = MinuteHelper.key(terminal, queue, minute)
 
   override def maybeUpdated(existing: CrunchMinute, now: MillisSinceEpoch): Option[CrunchMinute] =
     if (existing.deployedDesks.isEmpty || existing.deployedDesks.get != desks || existing.deployedWait.isEmpty || existing.deployedWait.get != waitTime) Option(existing.copy(
-      deployedDesks = Option(desks), deployedWait = Option(waitTime), lastUpdated = Option(now)
+      deployedDesks = Option(desks), deployedWait = Option(waitTime), maybeDeployedPaxInQueue = maybePaxInQueue, lastUpdated = Option(now)
     ))
     else None
 
@@ -44,7 +47,7 @@ case class SimulationMinute(terminal: Terminal,
     maybePaxInQueue = None,
     deployedDesks = Option(desks),
     deployedWait = Option(waitTime),
-    maybeDeployedPaxInQueue = None,
+    maybeDeployedPaxInQueue = maybePaxInQueue,
     lastUpdated = None)
 
 }


### PR DESCRIPTION
Use date to determine queues with minimum desks
Record deployment specific pax in queues
Display deployment specific pax in queues in desks and queues charts