### PR TITLE
Drtii 1927 min staff whenever pax join queue 2

### DIFF
--- a/client/src/main/scala/drt/client/components/MainMenu.scala
+++ b/client/src/main/scala/drt/client/components/MainMenu.scala
@@ -19,8 +19,6 @@ import uk.gov.homeoffice.drt.auth.Roles._
 import uk.gov.homeoffice.drt.feeds._
 import uk.gov.homeoffice.drt.ports.{AirportConfig, PortCode, PortRegion}
 
-import scala.scalajs.js
-
 object MainMenu {
   case class Props(router: RouterCtl[Loc],
                    currentLoc: Loc,
@@ -54,9 +52,9 @@ object MainMenu {
         List((PortFeedUpload, forecastUploadFile))
       else List.empty
 
-    val terminals = airportConfig.terminals(SDate.now().toLocalDate)
+    val terminals = airportConfig.terminalsForDate(SDate.now().toLocalDate)
 
-    def terminalDepsMenuItem: List[(Role, Int => MenuItem)] = terminals.map { tn =>
+    def terminalDepsMenuItem: List[(Role, Int => MenuItem)] = terminals.toList.map { tn =>
       val terminalName = tn.toString
       val targetLoc = currentLoc match {
         case tptl: TerminalPageTabLoc if tptl.mode == Dashboard =>
@@ -70,7 +68,7 @@ object MainMenu {
       }
       (BorderForceStaff, (offset: Int) =>
         MenuItem(offset, terminalName, Icon.calculator, targetLoc, linkClasses = Seq(s"terminal-${terminalName.toLowerCase}")))
-    }.toList
+    }
 
     val restrictedMenuItems: List[(Role, Int => MenuItem)] = addFileUpload ++ terminalDepsMenuItem :+ ((ViewConfig, portConfigMenuItem))
 

--- a/client/src/main/scala/drt/client/components/PortConfigPage.scala
+++ b/client/src/main/scala/drt/client/components/PortConfigPage.scala
@@ -73,7 +73,7 @@ object PortConfigDetails {
   val component: Component[Props, Unit, Unit, CtorType.Props] = ScalaComponent.builder[Props]("ConfigDetails")
     .render_P { props =>
       <.div(
-        props.airportConfig.terminals(SDate.now().toLocalDate).map(tn => {
+        props.airportConfig.terminalsForDate(SDate.now().toLocalDate).map(tn => {
           val maybeUpdate = props.updatesByTerminal.get(tn).flatMap(_.updatesForDate(SDate.now().millisSinceEpoch))
           <.div(
             <.h2(tn.toString),

--- a/client/src/main/scala/drt/client/components/PortDashboardPage.scala
+++ b/client/src/main/scala/drt/client/components/PortDashboardPage.scala
@@ -80,7 +80,7 @@ object PortDashboardPage {
               val selectedPeriodLengthMinutes = Try(userPreferences.portDashboardIntervalMinutes.getOrElse(portName, 180)).getOrElse(180)
               val userHasTerminalPreference: Option[Set[String]] = userPreferences.portDashboardTerminals.get(portName)
               val paxTypeAndQueueOrder = portConfig.terminalPaxSplits
-              val terminals = portConfig.terminals(SDate.now().toLocalDate)
+              val terminals = portConfig.terminalsForDate(SDate.now().toLocalDate)
 
               val selectedTerminals: List[String] = if (userHasTerminalPreference.isEmpty) {
                 terminals.map(t => s"${t.toString}").toList

--- a/client/src/main/scala/drt/client/components/PortExportDashboardPage.scala
+++ b/client/src/main/scala/drt/client/components/PortExportDashboardPage.scala
@@ -17,7 +17,7 @@ object PortExportDashboardPage {
 
       airportConfigRCP(airportConfigMP => {
         <.div(^.className := "terminal-export-dashboard", airportConfigMP().renderReady(config => {
-          val terminals = config.terminals(SDate.now().toLocalDate)
+          val terminals = config.terminalsForDate(SDate.now().toLocalDate)
           <.div(terminals.map(tn => {
             <.div(
               <.h3(s"Terminal $tn"),

--- a/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalContentComponent.scala
@@ -123,7 +123,7 @@ object TerminalContentComponent {
       val staffingPanelActive = if (state.activeTab == "staffing") "active" else "fade"
       val viewModeStr = props.terminalPageTab.viewMode.getClass.getSimpleName.toLowerCase
       val terminalName = terminal.toString
-      val terminals = props.airportConfig.terminals(SDate.now().toLocalDate)
+      val terminals = props.airportConfig.terminalsForDate(SDate.now().toLocalDate)
       val arrivalsExportForPort = TerminalExportComponent.componentFactory(terminals, "Arrivals")
       val recommendationExportForPort = TerminalExportComponent.componentFactory(terminals, "Recommendations")
       val deploymentsExportForPort = TerminalExportComponent.componentFactory(terminals, "Deployments")

--- a/client/src/main/scala/drt/client/components/TerminalDesksAndQueuesRow.scala
+++ b/client/src/main/scala/drt/client/components/TerminalDesksAndQueuesRow.scala
@@ -166,7 +166,7 @@ object TerminalDesksAndQueuesRow {
 
   def adjustmentState(props: Props, action: String): StaffAdjustmentDialogueState =
     StaffAdjustmentDialogueState(
-      props.airportConfig.terminals(props.viewMode.localDate),
+      props.airportConfig.terminalsForDate(props.viewMode.localDate),
       Option(props.terminal),
       "Additional info",
       SDate(props.minuteMillis),

--- a/client/src/test/scala/drt/client/components/MonthlyShiftsUtilSpec.scala
+++ b/client/src/test/scala/drt/client/components/MonthlyShiftsUtilSpec.scala
@@ -6,6 +6,7 @@ import drt.shared._
 import uk.gov.homeoffice.drt.ports.Terminals.Terminal
 import uk.gov.homeoffice.drt.time.{LocalDate, SDateLike}
 import drt.client.services.JSDateConversions.SDate
+import uk.gov.homeoffice.drt.Shift
 
 object MonthlyShiftsUtilSpec extends TestSuite {
   val tests: Tests = Tests {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -27,7 +27,7 @@ object Settings {
   object versions {
     val scala = "2.13.16"
 
-    val drtLib = "v1260"
+    val drtLib = "v1271"
     val drtCirium = "v339"
     val bluebus = "v149"
 

--- a/server/src/main/scala/controllers/application/DebugController.scala
+++ b/server/src/main/scala/controllers/application/DebugController.scala
@@ -34,7 +34,7 @@ class DebugController @Inject()(cc: ControllerComponents, ctrl: DrtSystemInterfa
         "Port Live" -> PortLiveArrivalsActor.persistenceId,
         "Crunch State" -> "crunch-state",
         "Flight State" -> "flight-state",
-      ) ++ airportConfig.terminals(SDate.now().toLocalDate).map(t => {
+      ) ++ airportConfig.terminalsForDate(SDate.now().toLocalDate).map(t => {
         "Terminal Day Flight (for snapshot day)" -> f"terminal-flights-${t.toString.toLowerCase}-${pit.getFullYear}-${pit.getMonth}%02d-${pit.getDate}%02d"
       })
 

--- a/server/src/main/scala/controllers/application/ExportPortConfigController.scala
+++ b/server/src/main/scala/controllers/application/ExportPortConfigController.scala
@@ -160,7 +160,7 @@ class ExportPortConfigController @Inject()(cc: ControllerComponents, ctrl: DrtSy
 
   def exportConfig: Action[AnyContent] = Action.async { _ =>
     val aConfigAndDeskByTerminal = Future.sequence {
-      airportConfig.terminals(SDate.now().toLocalDate).map { tn =>
+      airportConfig.terminalsForDate(SDate.now().toLocalDate).map { tn =>
         val terminal = tn.toString
         val slaConfig: Future[String] = getSlaConfig(tn)
         val airportConfigString = getAirportConfig(tn)

--- a/server/src/main/scala/controllers/application/SimulationsController.scala
+++ b/server/src/main/scala/controllers/application/SimulationsController.scala
@@ -379,7 +379,7 @@ class SimulationsController @Inject()(cc: ControllerComponents, ctrl: DrtSystemI
         simulationParams.applyPassengerWeighting(fws, ctrl.paxFeedSourceOrder),
       ))
       val portStateActor = actorSystem.actorOf(props)
-      val deskLimits = PortDeskLimits.flexed(simulationConfig, terminalEgateBanksFromParams(simulationParams))
+      val deskLimits = PortDeskLimits.flexed(simulationConfig, terminalEgateBanksFromParams(simulationParams), ctrl.applicationService.paxForQueue)
       Scenarios.simulationResult(
         simulationParams = simulationParams,
         simulationAirportConfig = simulationConfig,

--- a/server/src/main/scala/controllers/application/exports/DesksExportController.scala
+++ b/server/src/main/scala/controllers/application/exports/DesksExportController.scala
@@ -116,7 +116,7 @@ class DesksExportController @Inject()(cc: ControllerComponents, ctrl: DrtSystemI
         val start = viewDay
         val end = viewDay.getLocalNextMidnight.addMinutes(-1)
         val stream = exportStreamFn(Option(pit.millisSinceEpoch), start, end, periodMinutes(request))
-        val terminals = ctrl.airportConfig.terminals(ld).toSeq
+        val terminals = ctrl.airportConfig.terminalsForDate(ld).toSeq
         streamExport(ctrl.airportConfig.portCode, terminals, ld, ld, stream, s"desks-and-queues-$exportName-at-${pit.toISOString}-for")
       case _ =>
         BadRequest(write(ErrorResponse("Invalid date format")))

--- a/server/src/main/scala/controllers/application/exports/FlightsExportController.scala
+++ b/server/src/main/scala/controllers/application/exports/FlightsExportController.scala
@@ -30,7 +30,7 @@ class FlightsExportController @Inject()(cc: ControllerComponents, ctrl: DrtSyste
 
   def exportFlightsWithSplitsTerminalsForDayAtPointInTimeCSV(localDateString: String,
                                                     pointInTime: MillisSinceEpoch): Action[AnyContent] = {
-    val terminals = ctrl.airportConfig.terminals(LocalDate.parse(localDateString).getOrElse(throw new Exception(s"Could not parse local date '$localDateString''")))
+    val terminals = ctrl.airportConfig.terminalsForDate(LocalDate.parse(localDateString).getOrElse(throw new Exception(s"Could not parse local date '$localDateString''")))
     doExportForPointInTime(localDateString, pointInTime, terminals.toSeq, exportForUser)
   }
 

--- a/server/src/main/scala/services/crunch/desklimits/TerminalDeskLimitsLike.scala
+++ b/server/src/main/scala/services/crunch/desklimits/TerminalDeskLimitsLike.scala
@@ -45,9 +45,9 @@ trait TerminalDeskLimitsLike {
         val minDesksByMinute = DeskRecs
           .desksForMillis(minuteMillis, minDesksByQueue24Hrs(date).getOrElse(queue, IndexedSeq.fill(24)(0)))
 
-        val minDesksByWorkload = DeskRecs.minDesksByWorkload(minDesksByMinute, paxByMinute)
+        val minDesksForWorkload = DeskRecs.minDesksForWorkload(minDesksByMinute, paxByMinute)
 
-        val minDesks = minDesksByWorkload
+        val minDesks = minDesksForWorkload
           .toList.zip(processorProvider.processorsByMinute)
           .map { case (min, max) =>
             Math.min(min, max.maxCapacity)

--- a/server/src/main/scala/services/crunch/desklimits/TerminalDeskLimitsLike.scala
+++ b/server/src/main/scala/services/crunch/desklimits/TerminalDeskLimitsLike.scala
@@ -1,7 +1,7 @@
 package services.crunch.desklimits
 
-import services.{WorkloadProcessors, WorkloadProcessorsProvider}
 import services.crunch.deskrecs.DeskRecs
+import services.{WorkloadProcessors, WorkloadProcessorsProvider}
 import uk.gov.homeoffice.drt.egates.{Desk, EgateBanksUpdates}
 import uk.gov.homeoffice.drt.ports.Queues.Queue
 import uk.gov.homeoffice.drt.time.{LocalDate, SDate}
@@ -34,19 +34,26 @@ case class EgatesCapacityProvider(egatesProvider: () => Future[EgateBanksUpdates
 
 trait TerminalDeskLimitsLike {
   val minDesksByQueue24Hrs: LocalDate => Map[Queue, IndexedSeq[Int]]
+  val paxForQueue: (NumericRange[Long], Queue) => Future[Seq[Int]]
 
   def deskLimitsForMinutes(minuteMillis: NumericRange[Long], queue: Queue, allocatedDesks: Map[Queue, List[Int]])
                           (implicit ec: ExecutionContext): Future[(Iterable[Int], WorkloadProcessorsProvider)] = {
     val date = SDate(minuteMillis.min).toLocalDate
 
-    maxDesksForMinutes(minuteMillis, queue, allocatedDesks).map { processorProvider =>
-      val minDesks = DeskRecs
-        .desksForMillis(minuteMillis, minDesksByQueue24Hrs(date).getOrElse(queue, IndexedSeq.fill(24)(0)))
-        .toList.zip(processorProvider.processorsByMinute)
-        .map { case (min, max) =>
-          Math.min(min, max.maxCapacity)
-        }
-      (minDesks, processorProvider)
+    maxDesksForMinutes(minuteMillis, queue, allocatedDesks).flatMap { processorProvider =>
+      paxForQueue(minuteMillis, queue).map { paxByMinute =>
+        val minDesksByMinute = DeskRecs
+          .desksForMillis(minuteMillis, minDesksByQueue24Hrs(date).getOrElse(queue, IndexedSeq.fill(24)(0)))
+
+        val minDesksByWorkload = DeskRecs.minDesksByWorkload(minDesksByMinute, paxByMinute)
+
+        val minDesks = minDesksByWorkload
+          .toList.zip(processorProvider.processorsByMinute)
+          .map { case (min, max) =>
+            Math.min(min, max.maxCapacity)
+          }
+        (minDesks, processorProvider)
+      }
     }
   }
 

--- a/server/src/main/scala/services/crunch/desklimits/fixed/FixedTerminalDeskLimits.scala
+++ b/server/src/main/scala/services/crunch/desklimits/fixed/FixedTerminalDeskLimits.scala
@@ -10,6 +10,7 @@ import scala.concurrent.Future
 
 case class FixedTerminalDeskLimits(minDesksByQueue24Hrs: LocalDate => Map[Queue, IndexedSeq[Int]],
                                    maxDesksByQueue24Hrs: Map[Queue, QueueCapacityProvider],
+                                   paxForQueue: (NumericRange[Long], Queue) => Future[Seq[Int]],
                                   ) extends TerminalDeskLimitsLike {
   override def maxDesksForMinutes(minuteMillis: NumericRange[Long],
                                   queue: Queue,

--- a/server/src/main/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimits.scala
+++ b/server/src/main/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimits.scala
@@ -45,7 +45,8 @@ trait FlexedTerminalDeskLimitsLike extends TerminalDeskLimitsLike {
 case class FlexedTerminalDeskLimits(terminalDesks: Int,
                                     flexedQueues: Set[Queue],
                                     minDesksByQueue24Hrs: LocalDate => Map[Queue, IndexedSeq[Int]],
-                                    capacityByQueue: Map[Queue, QueueCapacityProvider]
+                                    capacityByQueue: Map[Queue, QueueCapacityProvider],
+                                    paxForQueue: (NumericRange[Long], Queue) => Future[Seq[Int]],
                                    ) extends FlexedTerminalDeskLimitsLike {
   override def maxDesksForMinutes(minuteMillis: NumericRange[Long],
                                   queue: Queue,

--- a/server/src/main/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimitsFromAvailableStaff.scala
+++ b/server/src/main/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimitsFromAvailableStaff.scala
@@ -15,6 +15,7 @@ case class FlexedTerminalDeskLimitsFromAvailableStaff(totalStaffByMinute: List[I
                                                       flexedQueues: Set[Queue],
                                                       minDesksByQueue24Hrs: LocalDate => Map[Queue, IndexedSeq[Int]],
                                                       capacityByQueue: Map[Queue, QueueCapacityProvider],
+                                                      paxForQueue: (NumericRange[Long], Queue) => Future[Seq[Int]],
                                                      )
                                                      (implicit ec: ExecutionContext) extends FlexedTerminalDeskLimitsLike {
   override def maxDesksForMinutes(minuteMillis: NumericRange[Long], queue: Queue, allocatedDesks: Map[Queue, List[Int]]): Future[WorkloadProcessorsProvider] = {

--- a/server/src/main/scala/services/crunch/deskrecs/DeskRecs.scala
+++ b/server/src/main/scala/services/crunch/deskrecs/DeskRecs.scala
@@ -1,12 +1,17 @@
 package services.crunch.deskrecs
 
+import drt.shared.CrunchApi
 import drt.shared.CrunchApi.MillisSinceEpoch
 import org.joda.time.DateTime
 import org.slf4j.{Logger, LoggerFactory}
+import uk.gov.homeoffice.drt.models.TQM
 import uk.gov.homeoffice.drt.ports.Queues.Queue
+import uk.gov.homeoffice.drt.ports.Terminals.Terminal
+import uk.gov.homeoffice.drt.time.{SDate, SDateLike}
 import uk.gov.homeoffice.drt.time.TimeZoneHelper.europeLondonTimeZone
 
 import scala.collection.immutable.{Map, NumericRange}
+import scala.concurrent.{ExecutionContext, Future}
 
 object DeskRecs {
   val log: Logger = LoggerFactory.getLogger(getClass)
@@ -24,5 +29,24 @@ object DeskRecs {
 
   def desksForMillis(millisRange: NumericRange[Long], desks24Hrs: IndexedSeq[Int]): IndexedSeq[Int] = millisRange
     .map(m => DeskRecs.desksForHourOfDayInUKLocalTime(m, desks24Hrs))
+
+  def minDesksByWorkload(minDesks: Seq[Int], pax: Seq[Int]): Seq[Int] =
+    minDesks
+      .zip(pax)
+      .map {
+        case (minDesks, p) if p > 0 => Math.max(minDesks, 1)
+        case (minDesks, _) => minDesks
+      }
+      .grouped(15)
+      .flatMap(groupedMinDesks => Seq.fill(15)(groupedMinDesks.max))
+      .toSeq
+
+  def paxForQueue(paxProvider: (SDateLike, SDateLike, Terminal) => Future[Map[TQM, CrunchApi.PassengersMinute]])
+                 (implicit ec: ExecutionContext): Terminal => (NumericRange[Long], Queue) => Future[Seq[Int]] =
+    terminal => (millis, queue) => {
+      paxProvider(SDate(millis.start), SDate(millis.end), terminal)
+        .map(_.values.filter(_.key.queue == queue).toSeq.sortBy(_.minute).map(_.passengers.size))
+    }
+
 }
 

--- a/server/src/main/scala/services/graphstages/FlightFilter.scala
+++ b/server/src/main/scala/services/graphstages/FlightFilter.scala
@@ -38,7 +38,7 @@ object FlightFilter {
     validTerminalFilter(validTerminals.toList) + notDivertedFilter + notCancelledFilter + outsideCtaFilter
 
   def forPortConfig(config: AirportConfig): FlightFilter = {
-    val terminals = regular(config.terminals(SDate.now().toLocalDate))
+    val terminals = regular(config.terminalsForDate(SDate.now().toLocalDate))
     config.portCode match {
       case PortCode("LHR") => terminals + lhrRedListFilter
       case _ => terminals

--- a/server/src/main/scala/services/staffing/StaffMinutesChecker.scala
+++ b/server/src/main/scala/services/staffing/StaffMinutesChecker.scala
@@ -17,7 +17,7 @@ case class StaffMinutesChecker(now: () => SDateLike,
   def calculateForecastStaffMinutes(): Unit = {
     (forecastMaxDays - 2 until forecastMaxDays).foreach { daysInFuture =>
       val date = now().addDays(daysInFuture).toLocalDate
-      airportConfig.terminals(now().toLocalDate).foreach { terminal: Terminal =>
+      airportConfig.terminalsForDate(now().toLocalDate).foreach { terminal: Terminal =>
         log.info(s"Requesting staff minutes calculation for $terminal on $date")
         val request = TerminalUpdateRequest(terminal, date)
         staffingUpdateRequestQueue ! request

--- a/server/src/main/scala/uk/gov/homeoffice/drt/crunchsystem/ProdDrtSystem.scala
+++ b/server/src/main/scala/uk/gov/homeoffice/drt/crunchsystem/ProdDrtSystem.scala
@@ -49,7 +49,7 @@ case class ProdDrtSystem @Inject()(airportConfig: AirportConfig, params: DrtPara
 
   override val manifestLookupService: ManifestLookupLike = ManifestLookup(aggregatedDb)
 
-  override val manifestLookups: ManifestLookups = ManifestLookups(system, airportConfig.terminals)
+  override val manifestLookups: ManifestLookups = ManifestLookups(system, airportConfig.terminalsForDate)
 
   override val userService: UserTableLike = UserTable(aggregatedDb)
 
@@ -96,7 +96,7 @@ case class ProdDrtSystem @Inject()(airportConfig: AirportConfig, params: DrtPara
     system,
     now,
     manifestLookups,
-    airportConfig.terminals,
+    airportConfig.terminalsForDate,
   )
 
   override def run(): Unit = applicationService.run()

--- a/server/src/main/scala/uk/gov/homeoffice/drt/service/ApplicationService.scala
+++ b/server/src/main/scala/uk/gov/homeoffice/drt/service/ApplicationService.scala
@@ -267,7 +267,6 @@ case class ApplicationService(journalType: StreamingJournalLike,
     OptimisationProviders.passengersProvider(minuteLookups.queueLoadsMinutesActor)
 
   val paxForQueue: Terminal => (NumericRange[Long], Queue) => Future[Seq[Int]] = DeskRecs.paxForQueue(paxProvider)
-//    _ => (millis, _) => Future.successful(Seq.fill(millis.size)(0))
 
   val deskLimitsProviders: Map[Terminal, TerminalDeskLimitsLike] = if (config.get[Boolean]("crunch.flex-desks"))
     PortDeskLimits.flexed(airportConfig, terminalEgatesProvider, paxForQueue)

--- a/server/src/main/scala/uk/gov/homeoffice/drt/service/ApplicationService.scala
+++ b/server/src/main/scala/uk/gov/homeoffice/drt/service/ApplicationService.scala
@@ -10,6 +10,7 @@ import drt.server.feeds.Feed.FeedTick
 import drt.server.feeds.FeedPoller.{AdhocCheck, Enable}
 import drt.server.feeds._
 import drt.server.feeds.api.{ApiFeedImpl, DbManifestArrivalKeys, DbManifestProcessor}
+import drt.shared.CrunchApi
 import drt.shared.CrunchApi.{MillisSinceEpoch, StaffMinute}
 import manifests.ManifestLookupLike
 import manifests.queues.SplitsCalculator
@@ -49,7 +50,7 @@ import uk.gov.homeoffice.drt.crunchsystem.{ActorsServiceLike, PersistentStateAct
 import uk.gov.homeoffice.drt.db.AggregatedDbTables
 import uk.gov.homeoffice.drt.db.dao.{ApiManifestProvider, FlightDao}
 import uk.gov.homeoffice.drt.egates.{EgateBank, EgateBanksUpdate, EgateBanksUpdates, PortEgateBanksUpdates}
-import uk.gov.homeoffice.drt.models.{CrunchMinute, UniqueArrivalKey, VoyageManifest, VoyageManifests}
+import uk.gov.homeoffice.drt.models.{CrunchMinute, TQM, UniqueArrivalKey, VoyageManifest, VoyageManifests}
 import uk.gov.homeoffice.drt.ports.Queues.Queue
 import uk.gov.homeoffice.drt.ports.Terminals.Terminal
 import uk.gov.homeoffice.drt.ports._
@@ -62,7 +63,7 @@ import uk.gov.homeoffice.drt.time._
 
 import javax.inject.Singleton
 import scala.collection.SortedSet
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.{NumericRange, SortedMap}
 import scala.concurrent.duration.{DurationInt, DurationLong, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -100,7 +101,7 @@ case class ApplicationService(journalType: StreamingJournalLike,
   private val optimiserDeployments: TryCrunchWholePax = OptimiserWithFlexibleProcessors.crunchWholePax(useFairXmax = useFairXmaxForDeployment)
 
   private val crunchRequestsProvider: LocalDate => Iterable[TerminalUpdateRequest] =
-    (date: LocalDate) => airportConfig.terminals(date).map(TerminalUpdateRequest(_, date))
+    (date: LocalDate) => airportConfig.terminalsForDate(date).map(TerminalUpdateRequest(_, date))
 
   val slasActor: ActorRef = system.actorOf(Props(new ConfigActor[Map[Queue, Int], SlaConfigs]("slas", now, crunchRequestsProvider, maxDaysToConsider)(
     emptyProvider = new EmptyConfig[Map[Queue, Int], SlaConfigs] {
@@ -167,7 +168,7 @@ case class ApplicationService(journalType: StreamingJournalLike,
     (d: UtcDate) => aggregatedDb.run(getFlights(d))
   }
 
-  val aclArrivalsForDate: UtcDate => Future[ArrivalsState] = feedService.activeFeedActorsWithPrimary.find(_._1 == AclFeedSource) match {
+  private val aclArrivalsForDate: UtcDate => Future[ArrivalsState] = feedService.activeFeedActorsWithPrimary.find(_._1 == AclFeedSource) match {
     case Some((_, _, _, actor)) =>
       log.info(s"Using ACL feed actor: $actor")
       (date: UtcDate) =>
@@ -262,11 +263,16 @@ case class ApplicationService(journalType: StreamingJournalLike,
     ).addPredictions
 
   val terminalEgatesProvider: Terminal => Future[EgateBanksUpdates] = EgateBanksUpdatesActor.terminalEgatesProvider(egateBanksUpdatesActor)
+  val paxProvider: (SDateLike, SDateLike, Terminal) => Future[Map[TQM, CrunchApi.PassengersMinute]] =
+    OptimisationProviders.passengersProvider(minuteLookups.queueLoadsMinutesActor)
+
+  val paxForQueue: Terminal => (NumericRange[Long], Queue) => Future[Seq[Int]] = DeskRecs.paxForQueue(paxProvider)
+//    _ => (millis, _) => Future.successful(Seq.fill(millis.size)(0))
 
   val deskLimitsProviders: Map[Terminal, TerminalDeskLimitsLike] = if (config.get[Boolean]("crunch.flex-desks"))
-    PortDeskLimits.flexed(airportConfig, terminalEgatesProvider)
+    PortDeskLimits.flexed(airportConfig, terminalEgatesProvider, paxForQueue)
   else
-    PortDeskLimits.fixed(airportConfig, terminalEgatesProvider)
+    PortDeskLimits.fixed(airportConfig, terminalEgatesProvider, paxForQueue)
 
   val startUpdateGraphs: (
     PersistentStateActors,
@@ -277,7 +283,7 @@ case class ApplicationService(journalType: StreamingJournalLike,
       SortedSet[TerminalUpdateRequest],
     ) => () => (ActorRef, ActorRef, ActorRef, ActorRef, Iterable[UniqueKillSwitch]) =
     (actors, mergeArrivalsQueue, crunchQueue, deskRecsQueue, deploymentQueue, staffQueue) => () => {
-      val staffToDeskLimits = PortDeskLimits.flexedByAvailableStaff(airportConfig, terminalEgatesProvider) _
+      val staffToDeskLimits = PortDeskLimits.flexedByAvailableStaff(airportConfig, terminalEgatesProvider, paxForQueue) _
 
       implicit val timeout: Timeout = new Timeout(10.seconds)
 
@@ -343,7 +349,7 @@ case class ApplicationService(journalType: StreamingJournalLike,
       val (deskRecsRequestQueueActor: ActorRef, deskRecsKillSwitch: UniqueKillSwitch) = DynamicRunnableDeskRecs(
         deskRecsQueueActor = actors.deskRecsQueueActor,
         deskRecsQueue = deskRecsQueue,
-        paxProvider = OptimisationProviders.passengersProvider(minuteLookups.queueLoadsMinutesActor),
+        paxProvider = paxProvider,
         deskLimitsProvider = deskLimitsProviders,
         terminalLoadsToQueueMinutes = portDeskRecs.terminalLoadsToDesks,
         queueMinutesSinkActor = minuteLookups.queueMinutesRouterActor,
@@ -358,7 +364,7 @@ case class ApplicationService(journalType: StreamingJournalLike,
         deploymentQueueActor = actors.deploymentQueueActor,
         deploymentQueue = deploymentQueue,
         staffToDeskLimits = staffToDeskLimits,
-        paxProvider = OptimisationProviders.passengersProvider(minuteLookups.queueLoadsMinutesActor),
+        paxProvider = paxProvider,
         staffMinutesProvider = OptimisationProviders.staffMinutesProvider(minuteLookups.staffMinutesRouterActor),
         loadsToDeployments = portDeployments.loadsToSimulations,
         queueMinutesSinkActor = minuteLookups.queueMinutesRouterActor,

--- a/server/src/main/scala/uk/gov/homeoffice/drt/testsystem/TestDrtSystem.scala
+++ b/server/src/main/scala/uk/gov/homeoffice/drt/testsystem/TestDrtSystem.scala
@@ -80,7 +80,7 @@ case class TestDrtSystem @Inject()(airportConfig: AirportConfig,
     updateFlightsLiveView,
   )
   override val manifestLookupService: ManifestLookupLike = MockManifestLookupService()
-  override val manifestLookups: ManifestLookupsLike = ManifestLookups(system, airportConfig.terminals)
+  override val manifestLookups: ManifestLookupsLike = ManifestLookups(system, airportConfig.terminalsForDate)
   lazy override val actorService: ActorsServiceLike = TestActorService(journalType,
     airportConfig,
     now,
@@ -94,7 +94,7 @@ case class TestDrtSystem @Inject()(airportConfig: AirportConfig,
     airportConfig.minutesToCrunch,
     airportConfig.crunchOffsetMinutes,
     manifestLookups,
-    airportConfig.terminals,
+    airportConfig.terminalsForDate,
   )
 
   lazy val feedService: FeedService = TestFeedService(

--- a/server/src/test/scala/actors/routing/minutes/ManifestsRouterActorSpec.scala
+++ b/server/src/test/scala/actors/routing/minutes/ManifestsRouterActorSpec.scala
@@ -39,7 +39,7 @@ class ManifestsRouterActorSpec extends CrunchTestLike {
       requestAndTerminateActor ! ((date, maybePit))
       Future(VoyageManifests.empty)
     }
-    override val terminals: LocalDate => Iterable[Terminals.Terminal] = defaultAirportConfig.terminals
+    override val terminals: LocalDate => Iterable[Terminals.Terminal] = defaultAirportConfig.terminalsForDate
   }
 
   val noopUpdates: ManifestsUpdate = (_: UtcDate, _: VoyageManifests) => Future(Set.empty[TerminalUpdateRequest])
@@ -48,7 +48,7 @@ class ManifestsRouterActorSpec extends CrunchTestLike {
 
   "When sending an ApiFeedResponse" >> {
     "Given a Success response with 1 manifest" >> {
-      val mockLookup = MockManifestsLookup(probe.ref, defaultAirportConfig.terminals)
+      val mockLookup = MockManifestsLookup(probe.ref, defaultAirportConfig.terminalsForDate)
       val manifestRouterActor: ActorRef = manifestRouterActorWithMock(mockLookup)
       val creationDate = SDate("2020-11-20T12:00Z")
 
@@ -66,7 +66,7 @@ class ManifestsRouterActorSpec extends CrunchTestLike {
     }
 
     "Given a Success response with 1 manifest" >> {
-      val mockLookup = MockManifestsLookup(probe.ref, defaultAirportConfig.terminals)
+      val mockLookup = MockManifestsLookup(probe.ref, defaultAirportConfig.terminalsForDate)
       val manifestRouterActor: ActorRef = manifestRouterActorWithMock(mockLookup)
       val creationDate = SDate("2020-11-20T12:00Z")
 
@@ -102,7 +102,7 @@ class ManifestsRouterActorSpec extends CrunchTestLike {
     }
 
     "Given a Failure response" >> {
-      val mockLookup = MockManifestsLookup(probe.ref, defaultAirportConfig.terminals)
+      val mockLookup = MockManifestsLookup(probe.ref, defaultAirportConfig.terminalsForDate)
       val manifestRouterActor: ActorRef = manifestRouterActorWithMock(mockLookup)
 
       val creationDate = SDate("2020-11-20T12:00Z")
@@ -193,7 +193,7 @@ class ManifestsRouterActorSpec extends CrunchTestLike {
       val manifest1 = manifestForDate("2020-11-01")
       val manifest2 = manifestForDate("2020-11-02")
       val manifest3 = manifestForDate("2020-11-03")
-      val manifestsLookup = MockManifestsLookup(probe.ref, defaultAirportConfig.terminals)
+      val manifestsLookup = MockManifestsLookup(probe.ref, defaultAirportConfig.terminalsForDate)
       val testManifests = VoyageManifests(Set(manifest1, manifest2, manifest3))
       val manifestRouterActor = system.actorOf(
         Props(new ManifestRouterActor(manifestsLookup.lookup(testManifests), noopUpdates))

--- a/server/src/test/scala/scenarios/ArrivalsScenarioSpec.scala
+++ b/server/src/test/scala/scenarios/ArrivalsScenarioSpec.scala
@@ -11,6 +11,7 @@ import queueus.{ChildEGateAdjustments, PaxTypeQueueAllocation, TerminalQueueAllo
 import services.crunch.CrunchTestLike
 import services.crunch.TestDefaults.airportConfig
 import services.crunch.desklimits.PortDeskLimits
+import services.crunch.desklimits.fixed.FixedTerminalDeskLimitsSpec.dummyPaxForQueue
 import services.imports.ArrivalCrunchSimulationActor
 import services.scenarios.Scenarios
 import uk.gov.homeoffice.drt.actor.commands.TerminalUpdateRequest
@@ -75,7 +76,7 @@ class ArrivalsScenarioSpec extends CrunchTestLike {
       redListUpdatesProvider = () => Future.successful(RedListUpdates.empty),
       egateBanksProvider = egateBanksProvider,
       paxFeedSourceOrder = paxFeedSourceOrder,
-      deskLimitsProviders = PortDeskLimits.flexed(airportConfig, terminalEgatesProvider)
+      deskLimitsProviders = PortDeskLimits.flexed(airportConfig, terminalEgatesProvider, _ => dummyPaxForQueue)
     )
 
     val result = Await.result(futureResult, 1.second)

--- a/server/src/test/scala/services/crunch/CrunchMinuteSpec.scala
+++ b/server/src/test/scala/services/crunch/CrunchMinuteSpec.scala
@@ -18,7 +18,7 @@ class CrunchMinuteSpec extends CrunchTestLike {
       val daysInMinutes = 60 * 60 * 24 * days
       val daysInMillis = 1000 * 60 * daysInMinutes
       val tqms = for {
-        terminal <- airportConfig.terminals(date)
+        terminal <- airportConfig.terminalsForDate(date)
         queue <- airportConfig.queuesByTerminal.head._2.getOrElse(terminal, Seq())
         minute <- (dateMillis to (dateMillis + daysInMillis) by 60000).take(daysInMinutes)
       } yield (terminal, queue, minute)
@@ -40,7 +40,7 @@ class CrunchMinuteSpec extends CrunchTestLike {
       val daysInMinutes = 60 * 60 * 24 * days
       val daysInMillis = 1000 * 60 * daysInMinutes
       val tms = for {
-        terminal <- airportConfig.terminals(date)
+        terminal <- airportConfig.terminalsForDate(date)
         minute <- (dateMillis to (dateMillis + daysInMillis) by 60000).take(daysInMinutes)
       } yield (terminal, minute)
 

--- a/server/src/test/scala/services/crunch/desklimits/PortDeskLimitsSpec.scala
+++ b/server/src/test/scala/services/crunch/desklimits/PortDeskLimitsSpec.scala
@@ -2,10 +2,13 @@ package services.crunch.desklimits
 
 import services.{WorkloadProcessors, WorkloadProcessorsProvider}
 import services.crunch.CrunchTestLike
+import services.crunch.desklimits.fixed.FixedTerminalDeskLimitsSpec.dummyPaxForQueue
 import uk.gov.homeoffice.drt.egates.{EgateBank, EgateBanksUpdate, EgateBanksUpdates}
 import uk.gov.homeoffice.drt.ports.Queues
-import uk.gov.homeoffice.drt.ports.Terminals.T1
+import uk.gov.homeoffice.drt.ports.Queues.Queue
+import uk.gov.homeoffice.drt.ports.Terminals.{T1, Terminal}
 
+import scala.collection.immutable.NumericRange
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
 
@@ -16,7 +19,8 @@ class PortDeskLimitsSpec extends CrunchTestLike {
         val threeBanks = IndexedSeq(EgateBank(IndexedSeq(true)), EgateBank(IndexedSeq(true)), EgateBank(IndexedSeq(true)))
         val oneBankUpdate = IndexedSeq(EgateBank(IndexedSeq(true, true)))
         val eventualUpdates = Future.successful(EgateBanksUpdates(List(EgateBanksUpdate(0L, threeBanks), EgateBanksUpdate(10L, oneBankUpdate))))
-        val portDeskLimits = PortDeskLimits.flexed(defaultAirportConfig, _ => eventualUpdates)
+        val paxForMillis: Terminal => (NumericRange[Long], Queue) => Future[Seq[Int]] = _ => dummyPaxForQueue
+        val portDeskLimits = PortDeskLimits.flexed(defaultAirportConfig, _ => eventualUpdates, paxForMillis)
 
         val maxDesks = Await.result(portDeskLimits(T1).maxProcessors(9L to 10L, Queues.EGate, Map()), 1.second)
         maxDesks === WorkloadProcessorsProvider(IndexedSeq(WorkloadProcessors(threeBanks), WorkloadProcessors(oneBankUpdate)))

--- a/server/src/test/scala/services/crunch/desklimits/fixed/FixedTerminalDeskLimitsSpec.scala
+++ b/server/src/test/scala/services/crunch/desklimits/fixed/FixedTerminalDeskLimitsSpec.scala
@@ -3,17 +3,22 @@ package services.crunch.desklimits.fixed
 import drt.shared.CrunchApi.MillisSinceEpoch
 import services.crunch.CrunchTestLike
 import services.crunch.desklimits.DeskCapacityProvider
+import services.crunch.desklimits.fixed.FixedTerminalDeskLimitsSpec.dummyPaxForQueue
 import services.crunch.desklimits.flexed.WorkloadProcessorsHelper.uniformDesksForHours
 import services.{WorkloadProcessors, WorkloadProcessorsProvider}
 import uk.gov.homeoffice.drt.egates.Desk
-import uk.gov.homeoffice.drt.ports.Queues.EeaDesk
+import uk.gov.homeoffice.drt.ports.Queues.{EeaDesk, Queue}
 import uk.gov.homeoffice.drt.time.MilliTimes.oneHourMillis
 import uk.gov.homeoffice.drt.time.SDate
 import uk.gov.homeoffice.drt.time.TimeZoneHelper.europeLondonTimeZone
 
 import scala.collection.immutable.NumericRange
-import scala.concurrent.Await
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration.DurationInt
+
+object FixedTerminalDeskLimitsSpec {
+  val dummyPaxForQueue: (NumericRange[Long], Queue) => Future[Seq[Int]] = (millis, _) => Future.successful(Seq.fill(millis.size)(0))
+}
 
 class FixedTerminalDeskLimitsSpec extends CrunchTestLike {
   val minDesks: IndexedSeq[Int] = IndexedSeq.fill(24)(1)
@@ -27,11 +32,12 @@ class FixedTerminalDeskLimitsSpec extends CrunchTestLike {
   val nonBstMidnightToMidnightByHour: NumericRange[MillisSinceEpoch] = nonBst20200101 until nonBst20200202 by oneHourMillis
   val bstMidnightToMidnightByHour: NumericRange[MillisSinceEpoch] = bst20200601 until bst20200602 by oneHourMillis
 
+
   "Given a fixed desk limits provider with one queue with a max of 10 desks " +
     "When I ask for max desks at each hour from midnight to midnight outside BST " +
     "Then I should get 10 for every hour" >> {
     val maxDesks = IndexedSeq.fill(24)(10)
-    val limits = FixedTerminalDeskLimits(_ => Map(EeaDesk -> minDesks), Map(EeaDesk -> DeskCapacityProvider(maxDesks)))
+    val limits = FixedTerminalDeskLimits(_ => Map(EeaDesk -> minDesks), Map(EeaDesk -> DeskCapacityProvider(maxDesks)), dummyPaxForQueue)
     val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
     val expected = uniformDesksForHours(10, 24)
 
@@ -42,7 +48,7 @@ class FixedTerminalDeskLimitsSpec extends CrunchTestLike {
     "When I ask for max desks at each hour from midnight to midnight inside BST " +
     "Then I should get 0 through 23, ie not offset by an hour" >> {
     val maxDesks = 0 to 23
-    val limits = FixedTerminalDeskLimits(_ => Map(EeaDesk -> minDesks), Map(EeaDesk -> DeskCapacityProvider(maxDesks)))
+    val limits = FixedTerminalDeskLimits(_ => Map(EeaDesk -> minDesks), Map(EeaDesk -> DeskCapacityProvider(maxDesks)), dummyPaxForQueue)
     val result = limits.maxDesksForMinutes(nonBstMidnightToMidnightByHour, EeaDesk, Map())
     val expected = WorkloadProcessorsProvider((0 to 23).map(d => WorkloadProcessors(Seq.fill(d)(Desk))))
 

--- a/server/src/test/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimitsFromAvailableStaffSpec.scala
+++ b/server/src/test/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimitsFromAvailableStaffSpec.scala
@@ -3,6 +3,7 @@ package services.crunch.desklimits.flexed
 import drt.shared.CrunchApi.MillisSinceEpoch
 import services.crunch.CrunchTestLike
 import services.crunch.desklimits.EgatesCapacityProvider
+import services.crunch.desklimits.fixed.FixedTerminalDeskLimitsSpec.dummyPaxForQueue
 import services.crunch.desklimits.flexed.WorkloadProcessorsHelper.uniformDesksForHours
 import services.{WorkloadProcessors, WorkloadProcessorsProvider}
 import uk.gov.homeoffice.drt.egates.{Desk, EgateBank, EgateBanksUpdate, EgateBanksUpdates}
@@ -44,7 +45,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
       "Then I should get 5 for every hour - the available staff" >> {
         val terminalDesks = 10
         val availableStaff = List.fill(24)(5)
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), _ => Map(), Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), _ => Map(), Map(), dummyPaxForQueue)
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
         val expected = uniformDesksForHours(5, 24)
 
@@ -58,7 +59,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
       "Then I should get 10 for every hour - the terminal desks" >> {
         val terminalDesks = 10
         val availableStaff = List.fill(24)(20)
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), _ => Map(), Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), _ => Map(), Map(), dummyPaxForQueue)
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
         val expected = uniformDesksForHours(10, 24)
 
@@ -73,7 +74,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
         val terminalDesks = 10
         val availableStaff = List.fill(24)(5)
         val minDesksForEeaAndNonEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> minDesks)
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map(), dummyPaxForQueue)
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
         val expected = uniformDesksForHours(4, 24)
 
@@ -88,7 +89,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
         val terminalDesks = 10
         val availableStaff = List.fill(24)(15)
         val minDesksForEeaAndNonEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> minDesks)
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map(), dummyPaxForQueue)
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
         val expected = uniformDesksForHours(9, 24)
 
@@ -104,7 +105,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
         val availableStaff = List.fill(24)(15)
         val minDesksForEeaAndNonEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> minDesks)
         val existingNonEeaAllocation: Map[Queue, List[Int]] = Map(NonEeaDesk -> List.fill(24)(2))
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map(), dummyPaxForQueue)
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, existingNonEeaAllocation)
         val expected = uniformDesksForHours(8, 24)
 
@@ -120,7 +121,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
         val availableStaff = List.fill(24)(5)
         val minDesksForEeaAndNonEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> minDesks)
         val existingNonEeaAllocation: Map[Queue, List[Int]] = Map(NonEeaDesk -> List.fill(24)(2))
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map(), dummyPaxForQueue)
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, existingNonEeaAllocation)
         val expected = uniformDesksForHours(3, 24)
 
@@ -136,7 +137,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
         val availableStaff = List.fill(24)(5)
         val minDesksForEeaAndNonEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> minDesks, EGate -> minDesks)
         val existingNonEeaAllocation: Map[Queue, List[Int]] = Map(NonEeaDesk -> List.fill(24)(2))
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map(), dummyPaxForQueue)
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, existingNonEeaAllocation)
         val expected = uniformDesksForHours(2, 24)
 
@@ -152,7 +153,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
         val availableStaff = List.fill(24)(15)
         val minDesksForEeaAndNonEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> minDesks, EGate -> minDesks)
         val existingNonEeaAllocation: Map[Queue, List[Int]] = Map(NonEeaDesk -> List.fill(24)(2))
-        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map())
+        val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksForEeaAndNonEea, Map(), dummyPaxForQueue)
         val result = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, existingNonEeaAllocation)
         val expected = uniformDesksForHours(8, 24)
 
@@ -168,7 +169,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
           val terminalDesks = 10
           val availableStaff = List.fill(24)(0)
           val minDesksForEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks)
-          val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), _ => minDesksForEea, Map())
+          val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), _ => minDesksForEea, Map(), dummyPaxForQueue)
           val result: Future[(Iterable[Int], WorkloadProcessorsProvider)] = limits.deskLimitsForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
           val expected = (List.fill(24)(0), uniformDesksForHours(0, 24))
 
@@ -183,7 +184,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
           val terminalDesks = 10
           val availableStaff = List.fill(24)(1)
           val minDesksForEea: Map[Queue, IndexedSeq[Int]] = Map(EeaDesk -> minDesks, NonEeaDesk -> IndexedSeq.fill(24)(4))
-          val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), _ => minDesksForEea, Map())
+          val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(EeaDesk), _ => minDesksForEea, Map(), dummyPaxForQueue)
           val result = limits.deskLimitsForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
           val expected = (List.fill(24)(0), uniformDesksForHours(0, 24))
 
@@ -199,7 +200,7 @@ class FlexedTerminalDeskLimitsFromAvailableStaffSpec extends CrunchTestLike {
           val availableStaff = List.fill(24)(2)
           val minDesksForEea: Map[Queue, IndexedSeq[Int]] = Map(EGate -> minDesks)
           val egatesCapProvider = EgatesCapacityProvider(() => Future.successful(EgateBanksUpdates(List(EgateBanksUpdate(0L, IndexedSeq.fill(3)(EgateBank(IndexedSeq())))))))
-          val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(), _ => minDesksForEea, Map(EGate -> egatesCapProvider))
+          val limits = FlexedTerminalDeskLimitsFromAvailableStaff(availableStaff, terminalDesks, Set(), _ => minDesksForEea, Map(EGate -> egatesCapProvider), dummyPaxForQueue)
           val result = limits.deskLimitsForMinutes(bstMidnightToMidnightByHour, EGate, Map())
           val expected = (List.fill(24)(0), WorkloadProcessorsProvider(IndexedSeq.fill(24)(WorkloadProcessors(Seq.fill(2)(EgateBank(IndexedSeq()))))))
 

--- a/server/src/test/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimitsSpec.scala
+++ b/server/src/test/scala/services/crunch/desklimits/flexed/FlexedTerminalDeskLimitsSpec.scala
@@ -4,6 +4,7 @@ import drt.shared.CrunchApi.MillisSinceEpoch
 import services.WorkloadProcessorsProvider
 import services.crunch.CrunchTestLike
 import services.crunch.desklimits.DeskCapacityProvider
+import services.crunch.desklimits.fixed.FixedTerminalDeskLimitsSpec.dummyPaxForQueue
 import services.crunch.desklimits.flexed.WorkloadProcessorsHelper.uniformDesksForHours
 import uk.gov.homeoffice.drt.ports.Queues.{EGate, EeaDesk, NonEeaDesk, Queue}
 import uk.gov.homeoffice.drt.time.MilliTimes.oneHourMillis
@@ -36,7 +37,7 @@ class FlexedTerminalDeskLimitsSpec extends CrunchTestLike {
     "When I ask for max desks at each hour from midnight to midnight outside BST " >> {
       "Then I should get 10 for every hour" >> {
         val terminalDesks = 10
-        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk), _ => minDesksByQueue, Map())
+        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk), _ => minDesksByQueue, Map(), dummyPaxForQueue)
         val result: Future[WorkloadProcessorsProvider] = limits.maxDesksForMinutes(bstMidnightToMidnightByHour, EeaDesk, Map())
         val expected = uniformDesksForHours(10, 24)
 
@@ -49,7 +50,7 @@ class FlexedTerminalDeskLimitsSpec extends CrunchTestLike {
     "When I ask for max desks for Eee for 24 hours, with no existing allocations for Non-EEA " >> {
       "Then I should get 9 for every hour (10 minus 1 minimum Non-EEA desk)" >> {
         val terminalDesks = 10
-        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksByQueue, Map())
+        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksByQueue, Map(), dummyPaxForQueue)
         val noExistingAllocations = Map[Queue, List[Int]]()
         val result = limits.maxDesksForMinutes(nonBstMidnightToMidnightByHour, EeaDesk, noExistingAllocations)
         val expected = uniformDesksForHours(9, 24)
@@ -63,7 +64,7 @@ class FlexedTerminalDeskLimitsSpec extends CrunchTestLike {
     "When I ask for max desks for Eee for 24 hours, with existing allocations for Non-EEA of 4 desks " >> {
       "Then I should get 6 for every hour (10 minus 4 allocated Non-EEA desks)" >> {
         val terminalDesks = 10
-        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksByQueue, Map())
+        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksByQueue, Map(), dummyPaxForQueue)
         val existingNonEeaAllocations = Map[Queue, List[Int]](NonEeaDesk -> List.fill(24)(4))
         val result = limits.maxDesksForMinutes(nonBstMidnightToMidnightByHour, EeaDesk, existingNonEeaAllocations)
         val expected = uniformDesksForHours(6, 24)
@@ -77,7 +78,7 @@ class FlexedTerminalDeskLimitsSpec extends CrunchTestLike {
     "When I ask for max desks for EGates for 24 hours, with existing allocations for the flexed desks " >> {
       "Then I should get 3 for every hour - the max for EGates regardless of the existing allocations" >> {
         val terminalDesks = 10
-        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksByQueue, Map(EGate -> DeskCapacityProvider(IndexedSeq.fill(24)(3))))
+        val limits = FlexedTerminalDeskLimits(terminalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesksByQueue, Map(EGate -> DeskCapacityProvider(IndexedSeq.fill(24)(3))), dummyPaxForQueue)
         val existingFlexedAllocations = Map[Queue, List[Int]](
           EeaDesk -> List.fill(24)(5),
           NonEeaDesk -> List.fill(24)(5)

--- a/server/src/test/scala/services/crunch/deskrecs/DeskFlexingSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/DeskFlexingSpec.scala
@@ -3,6 +3,7 @@ package services.crunch.deskrecs
 import drt.shared.CrunchApi.MillisSinceEpoch
 import services.crunch.CrunchTestLike
 import services.crunch.desklimits.DeskCapacityProvider
+import services.crunch.desklimits.fixed.FixedTerminalDeskLimitsSpec.dummyPaxForQueue
 import services.crunch.desklimits.flexed.FlexedTerminalDeskLimits
 import services.{OptimiserConfig, OptimizerCrunchResult}
 import uk.gov.homeoffice.drt.ports.AirportConfig
@@ -83,7 +84,7 @@ class DeskFlexingSpec extends CrunchTestLike {
 
         val queues = List(EeaDesk, NonEeaDesk)
 
-        val maxDeskProvider = FlexedTerminalDeskLimits(totalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesks, maxDesks.view.mapValues(d => DeskCapacityProvider(d)).toMap)
+        val maxDeskProvider = FlexedTerminalDeskLimits(totalDesks, Set(EeaDesk, NonEeaDesk), _ => minDesks, maxDesks.view.mapValues(d => DeskCapacityProvider(d)).toMap, dummyPaxForQueue)
 
         val eventualDesksAndWaits = services.crunch.deskrecs.TerminalDesksAndWaitsProvider(T1, (_: LocalDate, q: Queue) => Future.successful(ac.slaByQueue(q)), queuePriority, observer.mockDeskRecs, "test")
           .desksAndWaits(minuteMillis, mockLoads(queues), maxDeskProvider)
@@ -110,7 +111,7 @@ class DeskFlexingSpec extends CrunchTestLike {
 
         val queues = List(FastTrack, NonEeaDesk, EeaDesk)
 
-        val maxDeskProvider = FlexedTerminalDeskLimits(totalDesks, Set(EeaDesk, NonEeaDesk, FastTrack), _ => minDesks, maxDesks.view.mapValues(d => DeskCapacityProvider(d)).toMap)
+        val maxDeskProvider = FlexedTerminalDeskLimits(totalDesks, Set(EeaDesk, NonEeaDesk, FastTrack), _ => minDesks, maxDesks.view.mapValues(d => DeskCapacityProvider(d)).toMap, dummyPaxForQueue)
 
         val eventualDesksAndWaits = services.crunch.deskrecs.TerminalDesksAndWaitsProvider(T1, (_: LocalDate, q: Queue) => Future.successful(ac.slaByQueue(q)), queuePriority, observer.mockDeskRecs, "test")
           .desksAndWaits(minuteMillis, mockLoads(queues), maxDeskProvider)
@@ -141,7 +142,7 @@ class DeskFlexingSpec extends CrunchTestLike {
 
         val queues = List(EGate, FastTrack, NonEeaDesk, EeaDesk)
 
-        val maxDeskProvider = FlexedTerminalDeskLimits(totalDesks, Set(EeaDesk, NonEeaDesk, FastTrack), _ => minDesks, maxDesks.view.mapValues(d => DeskCapacityProvider(d)).toMap)
+        val maxDeskProvider = FlexedTerminalDeskLimits(totalDesks, Set(EeaDesk, NonEeaDesk, FastTrack), _ => minDesks, maxDesks.view.mapValues(d => DeskCapacityProvider(d)).toMap, dummyPaxForQueue)
 
         val eventualDesksAndWaits = services.crunch.deskrecs.TerminalDesksAndWaitsProvider(T1, (_: LocalDate, q: Queue) => Future.successful(ac.slaByQueue(q)), queuePriority, observer.mockDeskRecs, "test")
           .desksAndWaits(minuteMillis, mockLoads(queues), maxDeskProvider)

--- a/server/src/test/scala/services/crunch/deskrecs/DeskRecsTest.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/DeskRecsTest.scala
@@ -1,0 +1,59 @@
+package services.crunch.deskrecs
+
+import drt.shared.CrunchApi
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.homeoffice.drt.models.TQM
+import uk.gov.homeoffice.drt.ports.Queues.{EGate, EeaDesk}
+import uk.gov.homeoffice.drt.ports.Terminals.{T1, Terminal}
+import uk.gov.homeoffice.drt.time.SDateLike
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.DurationInt
+import scala.concurrent.{Await, Future}
+
+class DeskRecsTest extends AnyWordSpec with Matchers {
+  "minDesksByWorkload" should {
+    "give all zeros when there are no passengers and zero min desks" in {
+      val mins = DeskRecs.minDesksByWorkload(
+        minDesks = Seq.fill(60)(0),
+        pax = Seq.fill(60)(0)
+      )
+      mins.forall(_ == 0) shouldBe true
+    }
+
+    "give ones for 15 minute periods where there are any passengers and zero min desks" in {
+      val mins = DeskRecs.minDesksByWorkload(
+        minDesks = Seq.fill(60)(0),
+        pax = Seq.fill(15)(0) ++ Seq.fill(7)(0) ++ Seq(1) ++ Seq.fill(7)(0) ++ Seq.fill(15)(0) ++ Seq.fill(15)(1)
+      )
+      mins shouldBe Seq.fill(15)(0) ++ Seq.fill(15)(1) ++ Seq.fill(15)(0) ++ Seq.fill(15)(1)
+    }
+
+    "give max of min desks for 15 minute periods where there are passengers and min desks greater than 1" in {
+      val mins = DeskRecs.minDesksByWorkload(
+        minDesks = Seq.fill(60)(3),
+        pax = Seq.fill(15)(0) ++ Seq.fill(7)(0) ++ Seq(1) ++ Seq.fill(7)(0) ++ Seq.fill(15)(0) ++ Seq.fill(15)(1)
+      )
+      mins shouldBe Seq.fill(15)(3) ++ Seq.fill(15)(3) ++ Seq.fill(15)(3) ++ Seq.fill(15)(3)
+    }
+  }
+
+  "paxForQueue" should {
+    "return pax numbers for the correct queue given a passengersminute provider" in {
+      val provider: (SDateLike, SDateLike, Terminal) => Future[Map[TQM, CrunchApi.PassengersMinute]] =
+        (_, _, _) => Future.successful(Map(
+          TQM(T1, EeaDesk, 120000l) -> CrunchApi.PassengersMinute(T1, EeaDesk, 120000l, Seq.fill(5)(5), None),
+          TQM(T1, EeaDesk, 60000l) -> CrunchApi.PassengersMinute(T1, EeaDesk, 60000l, Seq.fill(6)(5), None),
+          TQM(T1, EeaDesk, 0l) -> CrunchApi.PassengersMinute(T1, EeaDesk, 0l, Seq.fill(7)(5), None),
+          TQM(T1, EGate, 120000l) -> CrunchApi.PassengersMinute(T1, EGate, 120000l, Seq.fill(15)(5), None),
+          TQM(T1, EGate, 60000l) -> CrunchApi.PassengersMinute(T1, EGate, 60000l, Seq.fill(15)(5), None),
+          TQM(T1, EGate, 0l) -> CrunchApi.PassengersMinute(T1, EGate, 0l, Seq.fill(15)(5), None),
+        ))
+      val paxForT1 = DeskRecs.paxForQueue(provider)
+      val paxForEeaDesk = Await.result(paxForT1(T1)(0l to 120000 by 60000, EeaDesk), 1.second)
+
+      paxForEeaDesk shouldBe Seq(7, 6, 5)
+    }
+  }
+}

--- a/server/src/test/scala/services/crunch/deskrecs/DeskRecsTest.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/DeskRecsTest.scala
@@ -15,7 +15,7 @@ import scala.concurrent.{Await, Future}
 class DeskRecsTest extends AnyWordSpec with Matchers {
   "minDesksByWorkload" should {
     "give all zeros when there are no passengers and zero min desks" in {
-      val mins = DeskRecs.minDesksByWorkload(
+      val mins = DeskRecs.minDesksForWorkload(
         minDesks = Seq.fill(60)(0),
         pax = Seq.fill(60)(0)
       )
@@ -23,7 +23,7 @@ class DeskRecsTest extends AnyWordSpec with Matchers {
     }
 
     "give ones for 15 minute periods where there are any passengers and zero min desks" in {
-      val mins = DeskRecs.minDesksByWorkload(
+      val mins = DeskRecs.minDesksForWorkload(
         minDesks = Seq.fill(60)(0),
         pax = Seq.fill(15)(0) ++ Seq.fill(7)(0) ++ Seq(1) ++ Seq.fill(7)(0) ++ Seq.fill(15)(0) ++ Seq.fill(15)(1)
       )
@@ -31,7 +31,7 @@ class DeskRecsTest extends AnyWordSpec with Matchers {
     }
 
     "give max of min desks for 15 minute periods where there are passengers and min desks greater than 1" in {
-      val mins = DeskRecs.minDesksByWorkload(
+      val mins = DeskRecs.minDesksForWorkload(
         minDesks = Seq.fill(60)(3),
         pax = Seq.fill(15)(0) ++ Seq.fill(7)(0) ++ Seq(1) ++ Seq.fill(7)(0) ++ Seq.fill(15)(0) ++ Seq.fill(15)(1)
       )

--- a/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeploymentsSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeploymentsSpec.scala
@@ -7,6 +7,7 @@ import org.apache.pekko.actor.{Actor, Props}
 import org.apache.pekko.testkit.TestProbe
 import drt.shared.CrunchApi.{MinutesContainer, PassengersMinute}
 import services.TryCrunchWholePax
+import services.crunch.desklimits.fixed.FixedTerminalDeskLimitsSpec.dummyPaxForQueue
 import services.crunch.desklimits.flexed.FlexedTerminalDeskLimitsFromAvailableStaff
 import services.crunch.desklimits.{PortDeskLimits, TerminalDeskLimitsLike}
 import services.crunch.deskrecs.OptimiserMocks.MockSinkActor
@@ -36,10 +37,10 @@ class DynamicRunnableDeploymentsSpec extends CrunchTestLike {
 
   val egatesProvider: Terminal => Future[EgateBanksUpdates] = MockEgatesProvider.terminalProvider(airportConfig)
 
-  val maxDesksProvider: Map[Terminal, TerminalDeskLimitsLike] = PortDeskLimits.flexed(airportConfig, egatesProvider)
+  val maxDesksProvider: Map[Terminal, TerminalDeskLimitsLike] = PortDeskLimits.flexed(airportConfig, egatesProvider, _ => dummyPaxForQueue)
   val mockCrunch: TryCrunchWholePax = CrunchMocks.mockCrunchWholePax
 
-  val staffToDeskLimits: (Terminal, List[Int]) => FlexedTerminalDeskLimitsFromAvailableStaff = PortDeskLimits.flexedByAvailableStaff(airportConfig, egatesProvider)
+  val staffToDeskLimits: (Terminal, List[Int]) => FlexedTerminalDeskLimitsFromAvailableStaff = PortDeskLimits.flexedByAvailableStaff(airportConfig, egatesProvider, _ => dummyPaxForQueue)
   val desksAndWaitsProvider: PortDesksAndWaitsProvider = PortDesksAndWaitsProvider(airportConfig, mockCrunch, FlightFilter.forPortConfig(airportConfig), paxFeedSourceOrder, (_: LocalDate, q: Queue) => Future.successful(airportConfig.slaByQueue(q)))
 
   def setupGraphAndCheckQueuePax(minutes: MinutesContainer[PassengersMinute, TQM],

--- a/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeskRecsSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/DynamicRunnableDeskRecsSpec.scala
@@ -14,6 +14,7 @@ import manifests.ManifestLookupLike
 import queueus._
 import services.TryCrunchWholePax
 import services.crunch.desklimits.PortDeskLimits
+import services.crunch.desklimits.fixed.FixedTerminalDeskLimitsSpec.dummyPaxForQueue
 import services.crunch.deskrecs.OptimiserMocks._
 import services.crunch.{CrunchTestLike, MockEgatesProvider, TestDefaults}
 import services.graphstages.{CrunchMocks, FlightFilter}
@@ -89,7 +90,7 @@ class RunnableDynamicDeskRecsSpec extends CrunchTestLike {
     val sink = system.actorOf(Props(new MockSinkActor(probe.ref)))
 
     val minute = SDate(flight.apiFlight.Scheduled).millisSinceEpoch
-    val maxDeskProviders = PortDeskLimits.flexed(airportConfig, MockEgatesProvider.terminalProvider(airportConfig))
+    val maxDeskProviders = PortDeskLimits.flexed(airportConfig, MockEgatesProvider.terminalProvider(airportConfig), _ => dummyPaxForQueue)
     val queueMinutesProducer = DynamicRunnableDeskRecs.crunchRequestsToDeskRecs(
       loadsProvider = (_, _, _) => {
         Future.successful(Map(TQM(T1, EeaDesk, minute) -> PassengersMinute(T1, EeaDesk, minute, Seq(50, 50, 50), None)))

--- a/server/src/test/scala/services/crunch/deskrecs/PortDesksAndWaitsProviderSpec.scala
+++ b/server/src/test/scala/services/crunch/deskrecs/PortDesksAndWaitsProviderSpec.scala
@@ -4,6 +4,7 @@ import drt.shared.CrunchApi.{DeskRecMinute, MillisSinceEpoch, PassengersMinute}
 import drt.shared.{ArrivalGenerator, CrunchApi}
 import services.crunch.CrunchTestLike
 import services.crunch.desklimits.TerminalDeskLimitsLike
+import services.crunch.desklimits.fixed.FixedTerminalDeskLimitsSpec.dummyPaxForQueue
 import services.graphstages.{DynamicWorkloadCalculator, FlightFilter}
 import services.{OptimiserWithFlexibleProcessors, WorkloadProcessors, WorkloadProcessorsProvider}
 import uk.gov.homeoffice.drt.arrivals.{ApiFlightWithSplits, FlightsWithSplits, Splits}
@@ -97,6 +98,8 @@ class PortDesksAndWaitsProviderSpec extends CrunchTestLike {
       EGate -> IndexedSeq.fill(24)(10),
       NonEeaDesk -> IndexedSeq.fill(24)(10),
     )
+
+    override val paxForQueue: (NumericRange[MillisSinceEpoch], Queue) => Future[Seq[Int]] = dummyPaxForQueue
 
     override def maxDesksForMinutes(minuteMillis: NumericRange[MillisSinceEpoch], queue: Queue, existingAllocations: Map[Queue, List[Int]]): Future[WorkloadProcessorsProvider] =
       Future.successful(WorkloadProcessorsProvider(DeskRecs.desksForMillis(minuteMillis, IndexedSeq.fill(24)(10)).map(x => WorkloadProcessors(Seq.fill(x)(Desk)))))

--- a/server/src/test/scala/services/staffing/StaffMinutesCheckerSpec.scala
+++ b/server/src/test/scala/services/staffing/StaffMinutesCheckerSpec.scala
@@ -20,7 +20,7 @@ class StaffMinutesCheckerSpec extends Specification {
 
       val expected = for {
         date <- Seq(LocalDate(2023, 1, 9), LocalDate(2023, 1, 10))
-        terminal <- Lhr.config.terminals(date)
+        terminal <- Lhr.config.terminalsForDate(date)
       } yield {
         TerminalUpdateRequest(terminal, date)
       }


### PR DESCRIPTION
Introduce `minDesksByWorkload`
Use the maximum between predefined min-desks and the min desks by workload to determine how many desks should be reserved per queue
Update calls for `airportConfig.terminals` to `airportConfig.terminalsForDate`