### PR TITLE
DRTII-679 make tables clear to screen readers

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,7 +8,7 @@
       "name": "drt-client",
       "version": "0.0.0",
       "dependencies": {
-        "@drt/drt-react": "github:UKHomeOffice/drt-react#v2.3.0",
+        "@drt/drt-react": "github:UKHomeOffice/drt-react#v2.4.0",
         "@handsontable/react": "3.1.2",
         "@mui/icons-material": "5.16.5",
         "@mui/lab": "5.0.0-alpha.173",
@@ -1871,8 +1871,8 @@
       }
     },
     "node_modules/@drt/drt-react": {
-      "version": "2.3.0",
-      "resolved": "git+ssh://git@github.com/UKHomeOffice/drt-react.git#259949aeea043d99b82e313b4263d56f2ddc4ab0",
+      "version": "2.4.0",
+      "resolved": "git+ssh://git@github.com/UKHomeOffice/drt-react.git#434c83f715db393b3e8aa12ead3e93e9641f50dc",
       "license": "MIT",
       "dependencies": {
         "-": "^0.0.1",

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "build": "esbuild ./target/scala-2.13/client-opt/main.js --bundle --outdir=../server/src/main/assets/ --minify"
   },
   "dependencies": {
-    "@drt/drt-react": "github:UKHomeOffice/drt-react#v2.3.0",
+    "@drt/drt-react": "github:UKHomeOffice/drt-react#v2.4.0",
     "@handsontable/react": "3.1.2",
     "@mui/icons-material": "5.16.5",
     "@mui/lab": "5.0.0-alpha.173",

--- a/client/src/main/scala/drt/client/components/FlightTable.scala
+++ b/client/src/main/scala/drt/client/components/FlightTable.scala
@@ -6,8 +6,8 @@ import drt.client.SPAMain.TerminalPageTabLoc
 import drt.client.actions.Actions.{RemoveArrivalSources, UpdateFlightHighlight}
 import drt.client.components.styles.DrtReactTheme
 import drt.client.modules.GoogleEventTracker
-import drt.client.services.JSDateConversions.SDate
 import drt.client.services._
+import drt.client.services.JSDateConversions.SDate
 import drt.shared._
 import drt.shared.api.WalkTimes
 import io.kinoplan.scalajs.react.material.ui.core.MuiTypography
@@ -31,6 +31,7 @@ import scala.collection.immutable.HashSet
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
 import scala.util.Try
+import drt.client.util.DateUtil
 
 object FlightTable {
   private val egateAgeEligibilityDateChange = "2026-07-08"
@@ -99,6 +100,7 @@ object FlightTable {
           )
         )
       }
+
 
       val submitCallback: js.Function1[js.Object, Unit] = (data: js.Object) => {
         val sfp = data.asInstanceOf[SearchFilterPayload]
@@ -208,8 +210,8 @@ object FlightTable {
             )
           } else EmptyVdom
         ),
-        <.div {
-
+        <.div (
+          ^.aria.label := s"Arrivals, ${DateUtil.displayArrivalSearchDate(SDate(props.terminalPageTab.viewMode.localDate), props.terminalPageTab)}",
           FlightTableContent(
             FlightTableContent.Props(
               flights = props.flights,
@@ -234,7 +236,7 @@ object FlightTable {
               codeShares = props.codeShares
             )
           )
-        },
+        ),
         excludedPaxNote
       )
     }

--- a/client/src/main/scala/drt/client/components/FlightTableContent.scala
+++ b/client/src/main/scala/drt/client/components/FlightTableContent.scala
@@ -30,6 +30,7 @@ import uk.gov.homeoffice.drt.time.SDateLike
 
 import scala.collection.immutable.{ HashSet, Seq }
 import scala.scalajs.js
+import drt.client.util.DateUtil
 
 object FlightTableContent {
   case class Props(
@@ -65,19 +66,6 @@ object FlightTableContent {
           !e.target.checked
         )))
       }
-
-    private def displayArrivalSearchDate(selectedDate: SDateLike, terminalPageTab: TerminalPageTabLoc): String = {
-      val searchFormForDate = searchForm(selectedDate, terminalPageTab)
-
-      val fromSDate = SDate(searchFormForDate.fromTime.valueOf().toLong)
-      val toSDate = SDate(searchFormForDate.toTime.valueOf().toLong)
-      val from = fromSDate.toHoursAndMinutes
-      val to = toSDate.toHoursAndMinutes
-      if (fromSDate.toLocalDate != toSDate.toLocalDate)
-        s"${searchFormForDate.displayText} ($from ${fromSDate.toLocalDate.ddmmyyyy} to $to ${toSDate.toLocalDate.ddmmyyyy})"
-      else
-        s"${searchFormForDate.displayText} ($from to $to)"
-    }
 
     def render(props: Props): VdomElement = {
       val flightDisplayFilter = props.airportConfig.portCode match {
@@ -119,7 +107,7 @@ object FlightTableContent {
               <.div(
                 ^.style := js.Dictionary("paddingTop" -> "10px"),
                 MuiTypography(sx = SxProps(Map("fontSize" -> "18px", "fontWeight" -> "bold")))(
-                  s"Arrivals, ${displayArrivalSearchDate(SDate(props.terminalPageTab.viewMode.localDate), props.terminalPageTab)}"
+                  s"Arrivals, ${DateUtil.displayArrivalSearchDate(SDate(props.terminalPageTab.viewMode.localDate), props.terminalPageTab)}"
                 )
               ),
               <.div(^.style :=

--- a/client/src/main/scala/drt/client/components/PcpPaxSummariesComponent.scala
+++ b/client/src/main/scala/drt/client/components/PcpPaxSummariesComponent.scala
@@ -60,6 +60,7 @@ object PcpPaxSummariesComponent {
           props.crunchMinutesPot.render(cms =>
             <.div(
               ^.className := "pcp-pax-summaries",
+              ^.aria.label := "Estimated pax over timeframes",
               boxes.zipWithIndex.map {
                 case (label, box) =>
                   val start = now.addMinutes(box * 5)

--- a/client/src/main/scala/drt/client/components/PortConfigPage.scala
+++ b/client/src/main/scala/drt/client/components/PortConfigPage.scala
@@ -154,6 +154,7 @@ object PortConfigDetails {
       val sortedMap = WalkTimes.sortGateStandMap(gateWalktimes)
       <.table(
         ^.className := "table table-bordered table-hover",
+        ^.aria.label := "Gate/Stand Walktime",
         <.tbody(
           <.tr(
             <.th(^.className := "col", "Gate"),
@@ -180,6 +181,7 @@ object PortConfigDetails {
 
       <.table(
         ^.className := "table table-bordered table-hover",
+        ^.aria.label := "Gate/Stand Walktime",
         <.tbody(
           <.tr(
             <.th(^.className := "col", "Stand"),

--- a/client/src/main/scala/drt/client/components/PortConfigPage.scala
+++ b/client/src/main/scala/drt/client/components/PortConfigPage.scala
@@ -203,6 +203,7 @@ object PortConfigDetails {
     ^.className := "config-block float-left",
     <.table(
       ^.className := "table table-bordered table-hover",
+      ^.aria.label := "Walktimes",
       <.tbody(
         <.tr(
           <.th(^.className := "col", "Gate"),

--- a/client/src/main/scala/drt/client/components/PortConfigPage.scala
+++ b/client/src/main/scala/drt/client/components/PortConfigPage.scala
@@ -220,6 +220,7 @@ object PortConfigDetails {
     ^.className := "config-block float-left",
     <.table(
       ^.className := "table table-bordered table-hover",
+       ^.aria.label := "Passenger Queue Allocation",
       <.tbody(
         <.tr(
           <.th(^.className := "col", "Passenger Type"),

--- a/client/src/main/scala/drt/client/components/PortConfigPage.scala
+++ b/client/src/main/scala/drt/client/components/PortConfigPage.scala
@@ -126,6 +126,7 @@ object PortConfigDetails {
     ^.className := "config-block float-left",
     <.table(
       ^.className := "table table-bordered table-hover",
+      ^.aria.label := "Processing Times",
       <.tbody(
         <.tr(
           <.th(^.className := "col", "Passenger Type & Queue"),

--- a/client/src/main/scala/drt/client/components/TerminalDesksAndQueues.scala
+++ b/client/src/main/scala/drt/client/components/TerminalDesksAndQueues.scala
@@ -9,6 +9,7 @@ import drt.client.logger.{ Logger, LoggerFactory }
 import drt.client.modules.GoogleEventTracker
 import drt.client.services.handlers.UpdateUserPreferences
 import drt.client.services.{ SPACircuit, StaffMovementMinute, ViewMode }
+import drt.client.util.AirportName.getAirportByCode
 import drt.shared.CrunchApi.StaffMinute
 import drt.shared._
 import io.kinoplan.scalajs.react.material.ui.core.MuiButton._
@@ -334,6 +335,8 @@ object TerminalDesksAndQueues {
           dayCrunchMinutes <- props.dayCrunchSummaries
           slaConfigs <- props.slaConfigs
         } yield {
+          val portName = getAirportByCode(props.airportConfig.portCode.toString()).getOrElse(props.airportConfig.portCode.toString())
+          val desksAndQueuesTableLabel = s"Desks and queues at $portName, ${props.terminal.toString}"
           val slas =
             slaConfigs.configForDate(props.viewStart.millisSinceEpoch).getOrElse(props.airportConfig.slaByQueue)
           val interval = if (state.timeInterval == Hourly) 60 else 15
@@ -389,7 +392,8 @@ object TerminalDesksAndQueues {
               }.toTagMod
             } else {
               <.table(
-                ^.aria.labelledBy := "desk-queues-description",
+                ^.aria.label := desksAndQueuesTableLabel,
+                ^.aria.describedBy := "desk-queues-description",
                 ^.className := s"user-desk-recs table-striped",
                 <.thead(
                   ^.className := "sticky-top",

--- a/client/src/main/scala/drt/client/components/TerminalPlanningComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalPlanningComponent.scala
@@ -170,6 +170,7 @@ object TerminalPlanningComponent {
               ),
               <.table(
                 ^.className := "headlines",
+                ^.aria.label := "Daily pax breakdown",
                 <.thead(
                   <.tr(
                     <.th(^.className := "queue-heading"),

--- a/client/src/main/scala/drt/client/components/TerminalPlanningComponent.scala
+++ b/client/src/main/scala/drt/client/components/TerminalPlanningComponent.scala
@@ -262,6 +262,7 @@ object TerminalPlanningComponent {
               ),
               <.table(
                 ^.className := "forecast",
+                ^.aria.label := "Daily staff breakdown",
                 <.thead(
                   ^.className := "sticky-top",
                   <.tr(

--- a/client/src/main/scala/drt/client/components/TerminalStaffing.scala
+++ b/client/src/main/scala/drt/client/components/TerminalStaffing.scala
@@ -191,6 +191,7 @@ object TerminalStaffing {
         staffWithShiftsAndMovements: (Terminal, SDateLike, MillisSinceEpoch => SDateLike) => Int
     ): VdomTagOf[Table] =
       <.table(
+        ^.aria.label := "Staff over the day",
         ^.className := "table table-striped table-xcondensed table-sm",
         <.tbody(
           daysWorthOf15Minutes.grouped(16).flatMap {

--- a/client/src/main/scala/drt/client/util/DateUtil.scala
+++ b/client/src/main/scala/drt/client/util/DateUtil.scala
@@ -1,6 +1,10 @@
 package drt.client.util
 
 import uk.gov.homeoffice.drt.time.LocalDate
+import drt.client.components.DaySelectorComponent.searchForm
+import uk.gov.homeoffice.drt.time.SDateLike
+import drt.client.services.JSDateConversions.SDate
+import drt.client.SPAMain.TerminalPageTabLoc
 
 object DateUtil {
   def isNotValidDate(dateString: String): Boolean = {
@@ -11,4 +15,17 @@ object DateUtil {
       case _ => true
     }
   }
+
+  def displayArrivalSearchDate(selectedDate: SDateLike, terminalPageTab: TerminalPageTabLoc): String = {
+      val searchFormForDate = searchForm(selectedDate, terminalPageTab)
+
+      val fromSDate = SDate(searchFormForDate.fromTime.valueOf().toLong)
+      val toSDate = SDate(searchFormForDate.toTime.valueOf().toLong)
+      val from = fromSDate.toHoursAndMinutes
+      val to = toSDate.toHoursAndMinutes
+      if (fromSDate.toLocalDate != toSDate.toLocalDate)
+        s"${searchFormForDate.displayText} ($from ${fromSDate.toLocalDate.ddmmyyyy} to $to ${toSDate.toLocalDate.ddmmyyyy})"
+      else
+        s"${searchFormForDate.displayText} ($from to $to)"
+    }
 }


### PR DESCRIPTION
Added aria label for all of the assigned tables defined in ticket 679. Aligns with WCAG standards for screen readers and user accessibility.

Please also see the related PR in the drt-react repo which is where the aria label was created specifically for the react table 

Related PR - https://github.com/UKHomeOffice/drt-react/pull/122